### PR TITLE
Rename exposed classes

### DIFF
--- a/src/careamics/__init__.py
+++ b/src/careamics/__init__.py
@@ -9,16 +9,16 @@ except PackageNotFoundError:
 
 __all__ = [
     "CAREamist",
-    "CAREamicsModule",
+    "CAREamicsModuleWrapper",
     "Configuration",
     "load_configuration",
     "save_configuration",
-    "CAREamicsTrainDataModule",
-    "CAREamicsPredictDataModule",
+    "TrainingDataWrapper",
+    "PredictDataWrapper",
 ]
 
 from .careamist import CAREamist
 from .config import Configuration, load_configuration, save_configuration
-from .lightning_datamodule import CAREamicsTrainDataModule
-from .lightning_module import CAREamicsModule
-from .lightning_prediction_datamodule import CAREamicsPredictDataModule
+from .lightning_datamodule import TrainingDataWrapper
+from .lightning_module import CAREamicsModuleWrapper
+from .lightning_prediction_datamodule import PredictDataWrapper

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -20,9 +20,9 @@ from careamics.config import (
 )
 from careamics.config.inference_model import TRANSFORMS_UNION
 from careamics.config.support import SupportedAlgorithm, SupportedData, SupportedLogger
-from careamics.lightning_datamodule import CAREamicsWood
-from careamics.lightning_module import CAREamicsKiln
-from careamics.lightning_prediction_datamodule import CAREamicsClay
+from careamics.lightning_datamodule import CAREamicsTrainData
+from careamics.lightning_module import CAREamicsModule
+from careamics.lightning_prediction_datamodule import CAREamicsPredictData
 from careamics.lightning_prediction_loop import CAREamicsPredictionLoop
 from careamics.model_io import export_to_bmz, load_pretrained
 from careamics.utils import check_path_exists, get_logger
@@ -140,7 +140,7 @@ class CAREamist:
             self.cfg = source
 
             # instantiate model
-            self.model = CAREamicsKiln(
+            self.model = CAREamicsModule(
                 algorithm_config=self.cfg.algorithm_config,
             )
 
@@ -156,7 +156,7 @@ class CAREamist:
                 self.cfg = load_configuration(source)
 
                 # instantiate model
-                self.model = CAREamicsKiln(
+                self.model = CAREamicsModule(
                     algorithm_config=self.cfg.algorithm_config,
                 )
 
@@ -193,8 +193,8 @@ class CAREamist:
         self.trainer.predict_loop = CAREamicsPredictionLoop(self.trainer)
 
         # place holder for the datamodules
-        self.train_datamodule: Optional[CAREamicsWood] = None
-        self.pred_datamodule: Optional[CAREamicsClay] = None
+        self.train_datamodule: Optional[CAREamicsTrainData] = None
+        self.pred_datamodule: Optional[CAREamicsPredictData] = None
 
     def _define_callbacks(self) -> List[Callback]:
         """
@@ -227,7 +227,7 @@ class CAREamist:
     def train(
         self,
         *,
-        datamodule: Optional[CAREamicsWood] = None,
+        datamodule: Optional[CAREamicsTrainData] = None,
         train_source: Optional[Union[Path, str, np.ndarray]] = None,
         val_source: Optional[Union[Path, str, np.ndarray]] = None,
         train_target: Optional[Union[Path, str, np.ndarray]] = None,
@@ -360,7 +360,7 @@ class CAREamist:
                     f"instance (got {type(train_source)})."
                 )
 
-    def _train_on_datamodule(self, datamodule: CAREamicsWood) -> None:
+    def _train_on_datamodule(self, datamodule: CAREamicsTrainData) -> None:
         """
         Train the model on the provided datamodule.
 
@@ -402,7 +402,7 @@ class CAREamist:
             Minimum number of patches to use for validation, by default 5.
         """
         # create datamodule
-        datamodule = CAREamicsWood(
+        datamodule = CAREamicsTrainData(
             data_config=self.cfg.data_config,
             train_data=train_data,
             val_data=val_data,
@@ -458,7 +458,7 @@ class CAREamist:
             path_to_val_target = check_path_exists(path_to_val_target)
 
         # create datamodule
-        datamodule = CAREamicsWood(
+        datamodule = CAREamicsTrainData(
             data_config=self.cfg.data_config,
             train_data=path_to_train_data,
             val_data=path_to_val_data,
@@ -475,7 +475,7 @@ class CAREamist:
     @overload
     def predict(  # numpydoc ignore=GL08
         self,
-        source: CAREamicsClay,
+        source: CAREamicsPredictData,
         *,
         checkpoint: Optional[Literal["best", "last"]] = None,
     ) -> Union[list, np.ndarray]:
@@ -519,7 +519,7 @@ class CAREamist:
 
     def predict(
         self,
-        source: Union[CAREamicsClay, Path, str, np.ndarray],
+        source: Union[CAREamicsPredictData, Path, str, np.ndarray],
         *,
         batch_size: int = 1,
         tile_size: Optional[Tuple[int, ...]] = None,
@@ -587,7 +587,7 @@ class CAREamist:
         ValueError
             If the input is not a CAREamicsClay instance, a path or a numpy array.
         """
-        if isinstance(source, CAREamicsClay):
+        if isinstance(source, CAREamicsPredictData):
             # record datamodule
             self.pred_datamodule = source
 
@@ -623,7 +623,7 @@ class CAREamist:
                 source_path = check_path_exists(source)
 
                 # create datamodule
-                datamodule = CAREamicsClay(
+                datamodule = CAREamicsPredictData(
                     prediction_config=prediction_config,
                     pred_data=source_path,
                     read_source_func=read_source_func,
@@ -640,7 +640,7 @@ class CAREamist:
 
             elif isinstance(source, np.ndarray):
                 # create datamodule
-                datamodule = CAREamicsClay(
+                datamodule = CAREamicsPredictData(
                     prediction_config=prediction_config,
                     pred_data=source,
                     dataloader_params=dataloader_params,

--- a/src/careamics/lightning_datamodule.py
+++ b/src/careamics/lightning_datamodule.py
@@ -28,9 +28,9 @@ DatasetType = Union[InMemoryDataset, PathIterableDataset]
 logger = get_logger(__name__)
 
 
-class CAREamicsWood(L.LightningDataModule):
+class CAREamicsTrainData(L.LightningDataModule):
     """
-    LightningDataModule for training and validation datasets.
+    CAREamics Ligthning training and validation data module.
 
     The data module can be used with Path, str or numpy arrays. In the case of
     numpy arrays, it loads and computes all the patches in memory. For Path and str
@@ -353,9 +353,12 @@ class CAREamicsWood(L.LightningDataModule):
         )
 
 
-class CAREamicsTrainDataModule(CAREamicsWood):
+class TrainingDataWrapper(CAREamicsTrainData):
     """
-    LightningDataModule wrapper for training and validation datasets.
+    Wrapper around the CAREamics Lightning training data module.
+
+    This class is used to explicitely pass the parameters usually contained in a
+    `data_model` configuration.
 
     Since the lightning datamodule has no access to the model, make sure that the
     parameters passed to the datamodule are consistent with the model's requirements and

--- a/src/careamics/lightning_module.py
+++ b/src/careamics/lightning_module.py
@@ -17,7 +17,7 @@ from careamics.transforms import Denormalize, ImageRestorationTTA
 from careamics.utils.torch_utils import get_optimizer, get_scheduler
 
 
-class CAREamicsKiln(L.LightningModule):
+class CAREamicsModule(L.LightningModule):
     """
     CAREamics Lightning module.
 
@@ -192,7 +192,7 @@ class CAREamicsKiln(L.LightningModule):
         }
 
 
-class CAREamicsModule(CAREamicsKiln):
+class CAREamicsModuleWrapper(CAREamicsModule):
     """Class defining the API for CAREamics Lightning layer.
 
     This class exposes parameters used to create an AlgorithmModel instance, triggering

--- a/src/careamics/lightning_prediction_datamodule.py
+++ b/src/careamics/lightning_prediction_datamodule.py
@@ -62,9 +62,9 @@ def _collate_tiles(batch: List[Tuple[np.ndarray, TileInformation]]) -> Any:
         return default_collate(new_batch)
 
 
-class CAREamicsClay(L.LightningDataModule):
+class CAREamicsPredictData(L.LightningDataModule):
     """
-    LightningDataModule for prediction dataset.
+    CAREamics Lightning prediction data module.
 
     The data module can be used with Path, str or numpy arrays. The data can be either
     a folder containing images or a single file.
@@ -238,9 +238,12 @@ class CAREamicsClay(L.LightningDataModule):
         )  # TODO check workers are used
 
 
-class CAREamicsPredictDataModule(CAREamicsClay):
+class PredictDataWrapper(CAREamicsPredictData):
     """
-    LightningDataModule wrapper of an inference dataset.
+    Wrapper around the CAREamics inference Lightning data module.
+
+    This class is used to explicitely pass the parameters usually contained in a
+    `inference_model` configuration.
 
     Since the lightning datamodule has no access to the model, make sure that the
     parameters passed to the datamodule are consistent with the model's requirements

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -11,7 +11,7 @@ from torch import __version__, load, save
 
 from careamics.config import Configuration, load_configuration, save_configuration
 from careamics.config.support import SupportedArchitecture
-from careamics.lightning_module import CAREamicsKiln
+from careamics.lightning_module import CAREamicsModule
 
 from .bioimage import (
     create_env_text,
@@ -21,7 +21,7 @@ from .bioimage import (
 )
 
 
-def _export_state_dict(model: CAREamicsKiln, path: Union[Path, str]) -> Path:
+def _export_state_dict(model: CAREamicsModule, path: Union[Path, str]) -> Path:
     """
     Export the model state dictionary to a file.
 
@@ -51,7 +51,7 @@ def _export_state_dict(model: CAREamicsKiln, path: Union[Path, str]) -> Path:
     return path
 
 
-def _load_state_dict(model: CAREamicsKiln, path: Union[Path, str]) -> None:
+def _load_state_dict(model: CAREamicsModule, path: Union[Path, str]) -> None:
     """
     Load a model from a state dictionary.
 
@@ -73,7 +73,7 @@ def _load_state_dict(model: CAREamicsKiln, path: Union[Path, str]) -> None:
 
 # TODO break down in subfunctions
 def export_to_bmz(
-    model: CAREamicsKiln,
+    model: CAREamicsModule,
     config: Configuration,
     path: Union[Path, str],
     name: str,
@@ -185,7 +185,7 @@ def export_to_bmz(
         save_bioimageio_package(model_description, output_path=path)
 
 
-def load_from_bmz(path: Union[Path, str]) -> Tuple[CAREamicsKiln, Configuration]:
+def load_from_bmz(path: Union[Path, str]) -> Tuple[CAREamicsModule, Configuration]:
     """Load a model from a BioImage Model Zoo archive.
 
     Parameters
@@ -223,7 +223,7 @@ def load_from_bmz(path: Union[Path, str]) -> Tuple[CAREamicsKiln, Configuration]
     config = load_configuration(config_path)
 
     # create careamics lightning module
-    model = CAREamicsKiln(algorithm_config=config.algorithm_config)
+    model = CAREamicsModule(algorithm_config=config.algorithm_config)
 
     # load model state dictionary
     _load_state_dict(model, weights_path)

--- a/src/careamics/model_io/model_io_utils.py
+++ b/src/careamics/model_io/model_io_utils.py
@@ -6,12 +6,12 @@ from typing import Tuple, Union
 from torch import load
 
 from careamics.config import Configuration
-from careamics.lightning_module import CAREamicsKiln
+from careamics.lightning_module import CAREamicsModule
 from careamics.model_io.bmz_io import load_from_bmz
 from careamics.utils import check_path_exists
 
 
-def load_pretrained(path: Union[Path, str]) -> Tuple[CAREamicsKiln, Configuration]:
+def load_pretrained(path: Union[Path, str]) -> Tuple[CAREamicsModule, Configuration]:
     """
     Load a pretrained model from a checkpoint or a BioImage Model Zoo model.
 
@@ -44,7 +44,7 @@ def load_pretrained(path: Union[Path, str]) -> Tuple[CAREamicsKiln, Configuratio
         )
 
 
-def _load_checkpoint(path: Union[Path, str]) -> Tuple[CAREamicsKiln, Configuration]:
+def _load_checkpoint(path: Union[Path, str]) -> Tuple[CAREamicsModule, Configuration]:
     """
     Load a model from a checkpoint and return both model and configuration.
 
@@ -75,6 +75,6 @@ def _load_checkpoint(path: Union[Path, str]) -> Tuple[CAREamicsKiln, Configurati
             f"checkpoint: {checkpoint.keys()}"
         ) from e
 
-    model = CAREamicsKiln.load_from_checkpoint(path)
+    model = CAREamicsModule.load_from_checkpoint(path)
 
     return model, Configuration(**cfg_dict)

--- a/tests/test_lightning_datamodule.py
+++ b/tests/test_lightning_datamodule.py
@@ -1,6 +1,6 @@
 import pytest
 
-from careamics import CAREamicsPredictDataModule, CAREamicsTrainDataModule
+from careamics import PredictDataWrapper, TrainingDataWrapper
 from careamics.config.support import SupportedPixelManipulation, SupportedStructAxis
 
 
@@ -12,7 +12,7 @@ def simple_array(ordered_array):
 def test_lightning_train_datamodule_wrong_type(simple_array):
     """Test that an error is raised if the data type is not supported."""
     with pytest.raises(ValueError):
-        CAREamicsTrainDataModule(
+        TrainingDataWrapper(
             train_data=simple_array,
             data_type="wrong_type",
             patch_size=(10, 10),
@@ -24,7 +24,7 @@ def test_lightning_train_datamodule_wrong_type(simple_array):
 def test_lightning_train_datamodule_array(simple_array):
     """Test that the data module is created correctly with an array."""
     # create data module
-    data_module = CAREamicsTrainDataModule(
+    data_module = TrainingDataWrapper(
         train_data=simple_array,
         data_type="array",
         patch_size=(8, 8),
@@ -42,7 +42,7 @@ def test_lightning_train_datamodule_supervised_n2v_throws_error(simple_array):
     """Test that an error is raised if target data is passed but the transformations
     (default ones) contain N2V manipulate."""
     with pytest.raises(ValueError):
-        CAREamicsTrainDataModule(
+        TrainingDataWrapper(
             train_data=simple_array,
             data_type="array",
             patch_size=(10, 10),
@@ -62,7 +62,7 @@ def test_lightning_train_datamodule_supervised_n2v_throws_error(simple_array):
 )
 def test_lightning_train_datamodule_n2v2(simple_array, use_n2v2, strategy):
     """Test that n2v2 parameter is correctly passed."""
-    data_module = CAREamicsTrainDataModule(
+    data_module = TrainingDataWrapper(
         train_data=simple_array,
         data_type="array",
         patch_size=(16, 16),
@@ -78,7 +78,7 @@ def test_lightning_train_datamodule_structn2v(simple_array):
     struct_axis = SupportedStructAxis.HORIZONTAL.value
     struct_span = 11
 
-    data_module = CAREamicsTrainDataModule(
+    data_module = TrainingDataWrapper(
         train_data=simple_array,
         data_type="array",
         patch_size=(16, 16),
@@ -94,7 +94,7 @@ def test_lightning_train_datamodule_structn2v(simple_array):
 def test_lightning_predict_datamodule_wrong_type(simple_array):
     """Test that an error is raised if the data type is not supported."""
     with pytest.raises(ValueError):
-        CAREamicsPredictDataModule(
+        PredictDataWrapper(
             pred_data=simple_array,
             data_type="wrong_type",
             mean=0.5,
@@ -107,7 +107,7 @@ def test_lightning_predict_datamodule_wrong_type(simple_array):
 def test_lightning_pred_datamodule_tiling(simple_array):
     """Test that the data module is created correctly with an array."""
     # create data module
-    data_module = CAREamicsPredictDataModule(
+    data_module = PredictDataWrapper(
         pred_data=simple_array,
         data_type="array",
         mean=0.5,
@@ -126,7 +126,7 @@ def test_lightning_pred_datamodule_tiling(simple_array):
 def test_lightning_pred_datamodule_no_tiling(simple_array):
     """Test that the data module is created correctly with an array."""
     # create data module
-    data_module = CAREamicsPredictDataModule(
+    data_module = PredictDataWrapper(
         pred_data=simple_array,
         data_type="array",
         mean=0.5,

--- a/tests/test_lightning_module.py
+++ b/tests/test_lightning_module.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from careamics.config import AlgorithmModel
-from careamics.lightning_module import CAREamicsKiln, CAREamicsModule
+from careamics.lightning_module import CAREamicsModule, CAREamicsModuleWrapper
 
 
 def test_careamics_module(minimum_algorithm_n2v):
@@ -14,7 +14,7 @@ def test_careamics_module(minimum_algorithm_n2v):
     model_parameters = algo_config.model.model_dump(exclude_none=True)
 
     # instantiate CAREamicsModule
-    CAREamicsModule(
+    CAREamicsModuleWrapper(
         algorithm=algo_config.algorithm,
         loss=algo_config.loss,
         architecture=algo_config.model.architecture,
@@ -31,7 +31,7 @@ def test_careamics_kiln(minimum_algorithm_n2v):
     algo_config = AlgorithmModel(**minimum_algorithm_n2v)
 
     # instantiate CAREamicsKiln
-    CAREamicsKiln(algo_config)
+    CAREamicsModule(algo_config)
 
 
 @pytest.mark.parametrize(
@@ -57,7 +57,7 @@ def test_careamics_kiln_unet_2D_depth_2_shape(shape):
     algo_config = AlgorithmModel(**algo_dict)
 
     # instantiate CAREamicsKiln
-    model = CAREamicsKiln(algo_config)
+    model = CAREamicsModule(algo_config)
     # set model to evaluation mode to avoid batch dimension error
     model.model.eval()
     # test forward pass
@@ -92,7 +92,7 @@ def test_careamics_kiln_unet_2D_depth_3_shape(shape):
     algo_config = AlgorithmModel(**algo_dict)
 
     # instantiate CAREamicsKiln
-    model = CAREamicsKiln(algo_config)
+    model = CAREamicsModule(algo_config)
     # set model to evaluation mode to avoid batch dimension error
     model.model.eval()
     # test forward pass
@@ -125,7 +125,7 @@ def test_careamics_kiln_unet_depth_2_3D(shape):
     algo_config = AlgorithmModel(**algo_dict)
 
     # instantiate CAREamicsKiln
-    model = CAREamicsKiln(algo_config)
+    model = CAREamicsModule(algo_config)
     # set model to evaluation mode to avoid batch dimension error
     model.model.eval()
     # test forward pass
@@ -158,7 +158,7 @@ def test_careamics_kiln_unet_depth_3_3D(shape):
     algo_config = AlgorithmModel(**algo_dict)
 
     # instantiate CAREamicsKiln
-    model = CAREamicsKiln(algo_config)
+    model = CAREamicsModule(algo_config)
     # set model to evaluation mode to avoid batch dimension error
     model.model.eval()
     # test forward pass
@@ -183,13 +183,14 @@ def test_careamics_kiln_unet_depth_2_channels_2D(n_channels):
     algo_config = AlgorithmModel(**algo_dict)
 
     # instantiate CAREamicsKiln
-    model = CAREamicsKiln(algo_config)
+    model = CAREamicsModule(algo_config)
     # set model to evaluation mode to avoid batch dimension error
     model.model.eval()
     # test forward pass
     x = torch.rand((1, n_channels, 32, 32))
     y: torch.Tensor = model.forward(x)
     assert y.shape == x.shape
+
 
 @pytest.mark.parametrize("n_channels", [1, 3, 4])
 def test_careamics_kiln_unet_depth_3_channels_2D(n_channels):
@@ -207,7 +208,7 @@ def test_careamics_kiln_unet_depth_3_channels_2D(n_channels):
     algo_config = AlgorithmModel(**algo_dict)
 
     # instantiate CAREamicsKiln
-    model = CAREamicsKiln(algo_config)
+    model = CAREamicsModule(algo_config)
     # set model to evaluation mode to avoid batch dimension error
     model.model.eval()
     # test forward pass
@@ -232,7 +233,7 @@ def test_careamics_kiln_unet_depth_2_channels_3D(n_channels):
     algo_config = AlgorithmModel(**algo_dict)
 
     # instantiate CAREamicsKiln
-    model = CAREamicsKiln(algo_config)
+    model = CAREamicsModule(algo_config)
     # set model to evaluation mode to avoid batch dimension error
     model.model.eval()
     # test forward pass
@@ -257,7 +258,7 @@ def test_careamics_kiln_unet_depth_3_channels_3D(n_channels):
     algo_config = AlgorithmModel(**algo_dict)
 
     # instantiate CAREamicsKiln
-    model = CAREamicsKiln(algo_config)
+    model = CAREamicsModule(algo_config)
     # set model to evaluation mode to avoid batch dimension error
     model.model.eval()
     # test forward pass


### PR DESCRIPTION
The so-called `Wood` and `Clay` classes are exposed to the users via the `CAREamist` API, and although these are fun names it will be confusing for users and developers wanting to contribute.

Here is a proposal for the renaming. In solidarity, the `Kiln` is also gone.

`Wood` -> `CAREamicsTrainData`
`CAREamicsTrainDataModule` -> `TrainingDataWrapper`

`Clay` -> `CAREamicsPredictData`
`CAREamicsPredictDataModule` -> `PredictDataWrapper`

`CAREamicsKiln` -> `CAREamicsModule`
`CAREamicsModule` -> `CAREamicsModuleWrapper` (lightning API)

Let's have a bit of a brainstorm to potentially find better names.