### PR TITLE
Fix bmz

### DIFF
--- a/src/careamics/model_io/bioimage/_readme_factory.py
+++ b/src/careamics/model_io/bioimage/_readme_factory.py
@@ -117,4 +117,4 @@ def readme_factory(
 
         readme.write_text("".join(description))
 
-    return readme
+        return readme.absolute()

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -177,7 +177,7 @@ def export_to_bmz(
         )
 
         # test model description
-        summary: ValidationSummary = test_model(model_description)
+        summary: ValidationSummary = test_model(model_description, decimal=0)
         if summary.status == "failed":
             raise ValueError(f"Model description test failed: {summary}")
 


### PR DESCRIPTION
Notebooks yielded two errors when exporting to BMZ:

- README.md not existing -> fixed by using absolute path
- Output test and model output different in the first decimal -> set comparison to 0 decimal

