### PR TITLE
Feature: Add independent channel option in UNet – Conv group implementation

### DIFF
--- a/src/careamics/config/architectures/unet_model.py
+++ b/src/careamics/config/architectures/unet_model.py
@@ -39,6 +39,7 @@ class UNetModel(ArchitectureModel):
         "None", "Sigmoid", "Softmax", "Tanh", "ReLU", "LeakyReLU"
     ] = Field(default="None", validate_default=True)
     n2v2: bool = Field(default=False, validate_default=True)
+    independent_channels: bool = Field(default=True, validate_default=True)
 
     @field_validator("num_channels_init")
     @classmethod

--- a/src/careamics/config/configuration_factory.py
+++ b/src/careamics/config/configuration_factory.py
@@ -288,6 +288,8 @@ def create_n2n_configuration(
         Number of epochs.
     use_augmentations : bool, optional
         Whether to use augmentations, by default True.
+    independent_channels : bool, optional
+        Whether to train all channels independently, by default False.
     loss : Literal["mae", "mse"], optional
         Loss function to use, by default "mae".
     n_channels : int, optional
@@ -449,7 +451,7 @@ def create_n2v_configuration(
     ...     struct_n2v_span=7
     ... )
 
-    If you are training multiple channels independently, then you need to specify the 
+    If you are training multiple channels independently, then you need to specify the
     number of channels:
     >>> config = create_n2v_configuration(
     ...     experiment_name="n2v_experiment",

--- a/src/careamics/models/unet.py
+++ b/src/careamics/models/unet.py
@@ -46,7 +46,7 @@ class UnetEncoder(nn.Module):
         dropout: float = 0.0,
         pool_kernel: int = 2,
         n2v2: bool = False,
-        independent_channels: bool = True
+        groups: int = 1
     ) -> None:
         """
         Constructor.
@@ -69,7 +69,6 @@ class UnetEncoder(nn.Module):
             Kernel size for the max pooling layers, by default 2.
         """
         super().__init__()
-        groups = in_channels if independent_channels else 1
 
         self.pooling = (
             getattr(nn, f"MaxPool{conv_dim}d")(kernel_size=pool_kernel)
@@ -364,7 +363,7 @@ class UNet(nn.Module):
             dropout=dropout,
             pool_kernel=pool_kernel,
             n2v2=n2v2,
-            independent_channels=independent_channels
+            groups=groups
         )
 
         self.decoder = UnetDecoder(

--- a/src/careamics/models/unet.py
+++ b/src/careamics/models/unet.py
@@ -4,7 +4,7 @@ UNet model.
 A UNet encoder, decoder and complete model.
 """
 
-from typing import Any, List, Union, Tuple
+from typing import Any, List, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -46,7 +46,7 @@ class UnetEncoder(nn.Module):
         dropout: float = 0.0,
         pool_kernel: int = 2,
         n2v2: bool = False,
-        groups: int = 1
+        groups: int = 1,
     ) -> None:
         """
         Constructor.
@@ -88,7 +88,7 @@ class UnetEncoder(nn.Module):
                     out_channels=out_channels,
                     dropout_perc=dropout,
                     use_batch_norm=use_batch_norm,
-                    groups=groups
+                    groups=groups,
                 )
             )
             encoder_blocks.append(self.pooling)
@@ -179,7 +179,7 @@ class UnetDecoder(nn.Module):
             intermediate_channel_multiplier=2,
             use_batch_norm=use_batch_norm,
             dropout_perc=dropout,
-            groups=self.groups
+            groups=self.groups,
         )
 
         decoder_blocks: List[nn.Module] = []
@@ -198,7 +198,7 @@ class UnetDecoder(nn.Module):
                     dropout_perc=dropout,
                     activation="ReLU",
                     use_batch_norm=use_batch_norm,
-                    groups=groups
+                    groups=groups,
                 )
             )
 
@@ -230,19 +230,17 @@ class UnetDecoder(nn.Module):
                 # divide index by 2 because of upsampling layers
                 skip_connection: torch.Tensor = skip_connections[i // 2]
                 if self.n2v2:
-                    if x.shape != skip_connections[-1].shape: 
+                    if x.shape != skip_connections[-1].shape:
                         x = self._interleave(x, skip_connection, self.groups)
                 else:
                     x = self._interleave(x, skip_connection, self.groups)
         return x
-    
+
     @staticmethod
-    def _interleave(
-        A: torch.Tensor, B: torch.Tensor, groups: int
-    ) -> torch.Tensor:
+    def _interleave(A: torch.Tensor, B: torch.Tensor, groups: int) -> torch.Tensor:
         """
-        Splits the tensors `A` and `B` into equally sized groups along the 
-        channel axis (axis=1); then concatenates the groups in alternating 
+        Splits the tensors `A` and `B` into equally sized groups along the
+        channel axis (axis=1); then concatenates the groups in alternating
         order along the channel axis, starting with the first group from tensor
         A.
 
@@ -263,21 +261,26 @@ class UnetDecoder(nn.Module):
             If either of `A` or `B`'s channel axis is not divisible by `groups`.
         """
         if (A.shape[1] % groups != 0) or (B.shape[1] % groups != 0):
-            raise ValueError(
-                f"Number of channels not divisible by {groups} groups."
-            )
-        
+            raise ValueError(f"Number of channels not divisible by {groups} groups.")
+
         m = A.shape[1] // groups
         n = B.shape[1] // groups
 
-        A_groups: List[torch.Tensor] = [A[:, i*m:(i+1)*m] for i in range(groups)]
-        B_groups: List[torch.Tensor] = [B[:, i*n:(i+1)*n] for i in range(groups)]
+        A_groups: List[torch.Tensor] = [
+            A[:, i * m : (i + 1) * m] for i in range(groups)
+        ]
+        B_groups: List[torch.Tensor] = [
+            B[:, i * n : (i + 1) * n] for i in range(groups)
+        ]
 
-        interleaved = torch.cat([
-            tensor_list[i] 
-            for i in range(groups) 
-            for tensor_list in [A_groups, B_groups] 
-        ], dim=1)
+        interleaved = torch.cat(
+            [
+                tensor_list[i]
+                for i in range(groups)
+                for tensor_list in [A_groups, B_groups]
+            ],
+            dim=1,
+        )
 
         return interleaved
 
@@ -363,7 +366,7 @@ class UNet(nn.Module):
             dropout=dropout,
             pool_kernel=pool_kernel,
             n2v2=n2v2,
-            groups=groups
+            groups=groups,
         )
 
         self.decoder = UnetDecoder(
@@ -373,13 +376,13 @@ class UNet(nn.Module):
             use_batch_norm=use_batch_norm,
             dropout=dropout,
             n2v2=n2v2,
-            groups=groups
+            groups=groups,
         )
         self.final_conv = getattr(nn, f"Conv{conv_dims}d")(
             in_channels=num_channels_init * groups,
             out_channels=num_classes,
             kernel_size=1,
-            groups=groups
+            groups=groups,
         )
         self.final_activation = get_activation(final_activation)
 

--- a/src/careamics/models/unet.py
+++ b/src/careamics/models/unet.py
@@ -380,6 +380,7 @@ class UNet(nn.Module):
             in_channels=num_channels_init * groups,
             out_channels=num_classes,
             kernel_size=1,
+            groups=groups
         )
         self.final_activation = get_activation(final_activation)
 

--- a/src/careamics/models/unet.py
+++ b/src/careamics/models/unet.py
@@ -35,7 +35,7 @@ class UnetEncoder(nn.Module):
     pool_kernel : int, optional
         Kernel size for the max pooling layers, by default 2.
     groups: int, optional
-        Number of blocked connections from input channels to output 
+        Number of blocked connections from input channels to output
         channels, by default 1.
     """
 
@@ -71,7 +71,7 @@ class UnetEncoder(nn.Module):
         pool_kernel : int, optional
             Kernel size for the max pooling layers, by default 2.
         groups: int, optional
-            Number of blocked connections from input channels to output 
+            Number of blocked connections from input channels to output
             channels, by default 1.
         """
         super().__init__()
@@ -141,7 +141,7 @@ class UnetDecoder(nn.Module):
     dropout : float, optional
         Dropout probability, by default 0.0.
     groups: int, optional
-        Number of blocked connections from input channels to output 
+        Number of blocked connections from input channels to output
         channels, by default 1.
     """
 
@@ -171,7 +171,7 @@ class UnetDecoder(nn.Module):
         dropout : float, optional
             Dropout probability, by default 0.0.
         groups: int, optional
-            Number of blocked connections from input channels to output 
+            Number of blocked connections from input channels to output
             channels, by default 1.
         """
         super().__init__()

--- a/src/careamics/models/unet.py
+++ b/src/careamics/models/unet.py
@@ -34,6 +34,9 @@ class UnetEncoder(nn.Module):
         Dropout probability, by default 0.0.
     pool_kernel : int, optional
         Kernel size for the max pooling layers, by default 2.
+    groups: int, optional
+        Number of blocked connections from input channels to output 
+        channels, by default 1.
     """
 
     def __init__(
@@ -67,6 +70,9 @@ class UnetEncoder(nn.Module):
             Dropout probability, by default 0.0.
         pool_kernel : int, optional
             Kernel size for the max pooling layers, by default 2.
+        groups: int, optional
+            Number of blocked connections from input channels to output 
+            channels, by default 1.
         """
         super().__init__()
 
@@ -134,6 +140,9 @@ class UnetDecoder(nn.Module):
         Whether to use batch normalization, by default True.
     dropout : float, optional
         Dropout probability, by default 0.0.
+    groups: int, optional
+        Number of blocked connections from input channels to output 
+        channels, by default 1.
     """
 
     def __init__(
@@ -161,6 +170,9 @@ class UnetDecoder(nn.Module):
             Whether to use batch normalization, by default True.
         dropout : float, optional
             Dropout probability, by default 0.0.
+        groups: int, optional
+            Number of blocked connections from input channels to output 
+            channels, by default 1.
         """
         super().__init__()
 
@@ -349,6 +361,9 @@ class UNet(nn.Module):
             Kernel size of the pooling layers, by default 2.
         last_activation : Optional[Callable], optional
             Activation function to use for the last layer, by default None.
+        independent_channels : bool
+            Whether to train parallel independent networks for each channel, by
+            default True.
         """
         super().__init__()
 

--- a/tests/config/test_configuration_factory.py
+++ b/tests/config/test_configuration_factory.py
@@ -1,11 +1,292 @@
 import pytest
 
-from careamics.config import create_n2v_configuration
+from careamics.config import (
+    create_n2v_configuration,
+    create_n2n_configuration,
+    create_care_configuration
+)
 from careamics.config.support import (
     SupportedPixelManipulation,
     SupportedStructAxis,
     SupportedTransform,
 )
+
+
+def test_n2n_configuration():
+    """Test that N2N configuration can be created."""
+    config = create_n2n_configuration(
+        experiment_name="test",
+        data_type="tiff",
+        axes="YX",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+    )
+    
+    assert config.data_config.transforms[0].name == SupportedTransform.NORMALIZE.value
+    assert config.data_config.transforms[1].name == SupportedTransform.NDFLIP.value
+    assert (
+        config.data_config.transforms[2].name 
+        == SupportedTransform.XY_RANDOM_ROTATE90.value
+    )
+    assert not config.data_config.transforms[-1].is_3D  # XY_RANDOM_ROTATE90
+    assert not config.data_config.transforms[-2].is_3D  # NDFLIP
+    assert not config.algorithm_config.model.is_3D()
+
+
+def test_cn2n_3d_configuration():
+    """Test that a 3D N2N configurationc an be created."""
+    config = create_care_configuration(
+        experiment_name="test",
+        data_type="tiff",
+        axes="ZYX",
+        patch_size=[64, 64, 64],
+        batch_size=8,
+        num_epochs=100,
+    )
+    assert config.data_config.transforms[0].name == SupportedTransform.NORMALIZE.value
+    assert config.data_config.transforms[-1].is_3D  # XY_RANDOM_ROTATE90
+    assert config.data_config.transforms[-2].is_3D  # NDFLIP
+    assert config.algorithm_config.model.is_3D()
+
+
+def test_n2n_3d_errors():
+    """Test that errors are raised if the axes are incompatible with the patches."""
+    with pytest.raises(ValueError):
+        create_n2n_configuration(
+            experiment_name="test",
+            data_type="tiff",
+            axes="ZYX",
+            patch_size=[64, 64],
+            batch_size=8,
+            num_epochs=100,
+        )
+
+    with pytest.raises(ValueError):
+        create_n2n_configuration(
+            experiment_name="test",
+            data_type="tiff",
+            axes="YX",
+            patch_size=[64, 64, 64],
+            batch_size=8,
+            num_epochs=100,
+        )
+
+
+def test_n2n_channels_errors():
+    """Test that error are raised if the number of input channel and the axes are not
+    compatible."""
+    with pytest.raises(ValueError):
+        create_n2n_configuration(
+            experiment_name="test",
+            data_type="tiff",
+            axes="YXC",
+            patch_size=[64, 64],
+            batch_size=8,
+            num_epochs=100,
+        )
+
+    with pytest.raises(ValueError):
+        create_n2n_configuration(
+            experiment_name="test",
+            data_type="tiff",
+            axes="YX",
+            patch_size=[64, 64],
+            batch_size=8,
+            num_epochs=100,
+            n_channels=5,
+        )
+
+def test_n2n_aug_off():
+    """Test that the augmentations are correctly disabled."""
+    config = create_n2n_configuration(
+        experiment_name="test",
+        data_type="tiff",
+        axes="YX",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+        use_augmentations=False,
+    )
+    assert len(config.data_config.transforms) == 1
+    assert config.data_config.transforms[-1].name == SupportedTransform.NORMALIZE.value
+
+
+
+@pytest.mark.parametrize("ind_channels", [True, False])
+def test_n2n_independent_channels(ind_channels):
+    """Test that independent channels are correctly passed."""
+    config = create_n2n_configuration(
+        experiment_name="test",
+        data_type="tiff",
+        axes="YXC",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+        n_channels=4,
+        independent_channels=ind_channels,
+    )
+    assert config.algorithm_config.model.independent_channels == ind_channels
+
+
+def test_n2n_chanels_equal():
+    """Test that channels in and out are equal."""
+    config = create_n2n_configuration(
+        experiment_name="test",
+        data_type="tiff",
+        axes="YXC",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+        n_channels=4,
+    )
+    assert config.algorithm_config.model.in_channels == 4
+    assert config.algorithm_config.model.num_classes == 4
+    
+
+def test_care_configuration():
+    """Test that CARE configuration can be created."""
+    config = create_care_configuration(
+        experiment_name="test",
+        data_type="tiff",
+        axes="YX",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+    )
+    
+    assert config.data_config.transforms[0].name == SupportedTransform.NORMALIZE.value
+    assert config.data_config.transforms[1].name == SupportedTransform.NDFLIP.value
+    assert (
+        config.data_config.transforms[2].name 
+        == SupportedTransform.XY_RANDOM_ROTATE90.value
+    )
+    assert not config.data_config.transforms[-1].is_3D  # XY_RANDOM_ROTATE90
+    assert not config.data_config.transforms[-2].is_3D  # NDFLIP
+    assert not config.algorithm_config.model.is_3D()
+
+
+def test_care_3d_configuration():
+    """Test that a 3D care configurationc an be created."""
+    config = create_care_configuration(
+        experiment_name="test",
+        data_type="tiff",
+        axes="ZYX",
+        patch_size=[64, 64, 64],
+        batch_size=8,
+        num_epochs=100,
+    )
+    assert config.data_config.transforms[0].name == SupportedTransform.NORMALIZE.value
+    assert config.data_config.transforms[-1].is_3D  # XY_RANDOM_ROTATE90
+    assert config.data_config.transforms[-2].is_3D  # NDFLIP
+    assert config.algorithm_config.model.is_3D()
+
+
+def test_care_3d_errors():
+    """Test that errors are raised if the axes are incompatible with the patches."""
+    with pytest.raises(ValueError):
+        create_care_configuration(
+            experiment_name="test",
+            data_type="tiff",
+            axes="ZYX",
+            patch_size=[64, 64],
+            batch_size=8,
+            num_epochs=100,
+        )
+
+    with pytest.raises(ValueError):
+        create_care_configuration(
+            experiment_name="test",
+            data_type="tiff",
+            axes="YX",
+            patch_size=[64, 64, 64],
+            batch_size=8,
+            num_epochs=100,
+        )
+
+
+def test_care_channels_errors():
+    """Test that error are raised if the number of input channel and the axes are not
+    compatible."""
+    with pytest.raises(ValueError):
+        create_care_configuration(
+            experiment_name="test",
+            data_type="tiff",
+            axes="YXC",
+            patch_size=[64, 64],
+            batch_size=8,
+            num_epochs=100,
+        )
+
+    with pytest.raises(ValueError):
+        create_care_configuration(
+            experiment_name="test",
+            data_type="tiff",
+            axes="YX",
+            patch_size=[64, 64],
+            batch_size=8,
+            num_epochs=100,
+            n_channels_in=5,
+        )
+
+def test_care_aug_off():
+    """Test that the augmentations are correctly disabled."""
+    config = create_care_configuration(
+        experiment_name="test",
+        data_type="tiff",
+        axes="YX",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+        use_augmentations=False,
+    )
+    assert len(config.data_config.transforms) == 1
+    assert config.data_config.transforms[-1].name == SupportedTransform.NORMALIZE.value
+
+
+
+@pytest.mark.parametrize("ind_channels", [True, False])
+def test_care_independent_channels(ind_channels):
+    """Test that independent channels are correctly passed."""
+    config = create_care_configuration(
+        experiment_name="test",
+        data_type="tiff",
+        axes="YXC",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+        n_channels_in=4,
+        independent_channels=ind_channels,
+    )
+    assert config.algorithm_config.model.independent_channels == ind_channels
+
+
+def test_care_chanels_out():
+    """Test that channels out are set to channels in if not speicifed."""
+    config = create_care_configuration(
+        experiment_name="test",
+        data_type="tiff",
+        axes="YXC",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+        n_channels_in=4,
+    )
+    assert config.algorithm_config.model.num_classes == 4
+
+    # otherwise set independently    
+    config = create_care_configuration(
+        experiment_name="test",
+        data_type="tiff",
+        axes="YXC",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+        n_channels_in=4,
+        n_channels_out=5
+    )
+    assert config.algorithm_config.model.num_classes == 5
+
 
 
 def test_n2v_configuration():
@@ -88,16 +369,19 @@ def test_n2v_model_parameters():
         patch_size=[64, 64],
         batch_size=8,
         num_epochs=100,
+        independent_channels=False,
         use_n2v2=False,
         model_kwargs={
             "depth": 4,
             "n2v2": True,
             "in_channels": 2,
             "num_classes": 5,
+            "independent_channels": True,
         },
     )
     assert config.algorithm_config.model.depth == 4
     assert not config.algorithm_config.model.n2v2
+    assert not config.algorithm_config.model.independent_channels
 
     # set to 1 because no C specified
     assert config.algorithm_config.model.in_channels == 1
@@ -124,6 +408,22 @@ def test_n2v_model_parameters_channels():
     )
     assert config.algorithm_config.model.in_channels == 4
     assert config.algorithm_config.model.num_classes == 4
+
+
+@pytest.mark.parametrize("ind_channels", [True, False])
+def test_n2v_independent_channels(ind_channels):
+    """Test that the idnependent channels parameter is passed correctly."""
+    config = create_n2v_configuration(
+        experiment_name="test",
+        data_type="tiff",
+        axes="YXC",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+        n_channels=4,
+        independent_channels=ind_channels,
+    )
+    assert config.algorithm_config.model.independent_channels == ind_channels
 
 
 def test_n2v_model_parameters_channels_error():

--- a/tests/config/test_configuration_factory.py
+++ b/tests/config/test_configuration_factory.py
@@ -1,9 +1,9 @@
 import pytest
 
 from careamics.config import (
-    create_n2v_configuration,
+    create_care_configuration,
     create_n2n_configuration,
-    create_care_configuration
+    create_n2v_configuration,
 )
 from careamics.config.support import (
     SupportedPixelManipulation,
@@ -22,11 +22,11 @@ def test_n2n_configuration():
         batch_size=8,
         num_epochs=100,
     )
-    
+
     assert config.data_config.transforms[0].name == SupportedTransform.NORMALIZE.value
     assert config.data_config.transforms[1].name == SupportedTransform.NDFLIP.value
     assert (
-        config.data_config.transforms[2].name 
+        config.data_config.transforms[2].name
         == SupportedTransform.XY_RANDOM_ROTATE90.value
     )
     assert not config.data_config.transforms[-1].is_3D  # XY_RANDOM_ROTATE90
@@ -97,6 +97,7 @@ def test_n2n_channels_errors():
             n_channels=5,
         )
 
+
 def test_n2n_aug_off():
     """Test that the augmentations are correctly disabled."""
     config = create_n2n_configuration(
@@ -110,7 +111,6 @@ def test_n2n_aug_off():
     )
     assert len(config.data_config.transforms) == 1
     assert config.data_config.transforms[-1].name == SupportedTransform.NORMALIZE.value
-
 
 
 @pytest.mark.parametrize("ind_channels", [True, False])
@@ -142,7 +142,7 @@ def test_n2n_chanels_equal():
     )
     assert config.algorithm_config.model.in_channels == 4
     assert config.algorithm_config.model.num_classes == 4
-    
+
 
 def test_care_configuration():
     """Test that CARE configuration can be created."""
@@ -154,11 +154,11 @@ def test_care_configuration():
         batch_size=8,
         num_epochs=100,
     )
-    
+
     assert config.data_config.transforms[0].name == SupportedTransform.NORMALIZE.value
     assert config.data_config.transforms[1].name == SupportedTransform.NDFLIP.value
     assert (
-        config.data_config.transforms[2].name 
+        config.data_config.transforms[2].name
         == SupportedTransform.XY_RANDOM_ROTATE90.value
     )
     assert not config.data_config.transforms[-1].is_3D  # XY_RANDOM_ROTATE90
@@ -229,6 +229,7 @@ def test_care_channels_errors():
             n_channels_in=5,
         )
 
+
 def test_care_aug_off():
     """Test that the augmentations are correctly disabled."""
     config = create_care_configuration(
@@ -242,7 +243,6 @@ def test_care_aug_off():
     )
     assert len(config.data_config.transforms) == 1
     assert config.data_config.transforms[-1].name == SupportedTransform.NORMALIZE.value
-
 
 
 @pytest.mark.parametrize("ind_channels", [True, False])
@@ -274,7 +274,7 @@ def test_care_chanels_out():
     )
     assert config.algorithm_config.model.num_classes == 4
 
-    # otherwise set independently    
+    # otherwise set independently
     config = create_care_configuration(
         experiment_name="test",
         data_type="tiff",
@@ -283,10 +283,9 @@ def test_care_chanels_out():
         batch_size=8,
         num_epochs=100,
         n_channels_in=4,
-        n_channels_out=5
+        n_channels_out=5,
     )
     assert config.algorithm_config.model.num_classes == 5
-
 
 
 def test_n2v_configuration():

--- a/tests/models/test_unet.py
+++ b/tests/models/test_unet.py
@@ -69,6 +69,7 @@ def test_blurpool3d(input_shape):
         [1, 1] + [i // 2 for i in input_shape[2:]]
     )
 
+
 @pytest.mark.parametrize("independent_channels", [True, False])
 def test_independent_channels(independent_channels):
     """
@@ -80,16 +81,16 @@ def test_independent_channels(independent_channels):
     input_shape = (1, n_channels, 8, 8)
 
     # input 1
-    x1 = torch.randn((input_shape))
+    x1 = torch.randn(input_shape)
     # input 2: channel 1 same as input 1, channel 2 all zeros
     x2 = x1.clone()
     x2[:, 1] = 0
 
     model = UNet(
-        conv_dims=2, 
-        in_channels=n_channels, 
+        conv_dims=2,
+        in_channels=n_channels,
         num_classes=n_channels,
-        independent_channels=independent_channels
+        independent_channels=independent_channels,
     )
     model.eval()
 
@@ -105,6 +106,5 @@ def test_independent_channels(independent_channels):
         assert (y1[:, 0] == y2[:, 0]).all()
     else:
         # when not independent
-        # channel 2 different between inputs => all channels different between outputs 
+        # channel 2 different between inputs => all channels different between outputs
         assert (y1[:, 0] != y2[:, 0]).any()
-

--- a/tests/models/test_unet.py
+++ b/tests/models/test_unet.py
@@ -68,3 +68,43 @@ def test_blurpool3d(input_shape):
     assert layer(torch.randn(input_shape)).shape == tuple(
         [1, 1] + [i // 2 for i in input_shape[2:]]
     )
+
+@pytest.mark.parametrize("independent_channels", [True, False])
+def test_independent_channels(independent_channels):
+    """
+    Test that with independent channels there is no connections between the
+    parallel networks.
+    """
+
+    n_channels = 2
+    input_shape = (1, n_channels, 8, 8)
+
+    # input 1
+    x1 = torch.randn((input_shape))
+    # input 2: channel 1 same as input 1, channel 2 all zeros
+    x2 = x1.clone()
+    x2[:, 1] = 0
+
+    model = UNet(
+        conv_dims=2, 
+        in_channels=n_channels, 
+        num_classes=n_channels,
+        independent_channels=independent_channels
+    )
+    model.eval()
+
+    y1 = model(x1)
+    y2 = model(x2)
+
+    # channel 2 different between inputs => channel 2 different between outputs
+    assert (y1[:, 1] != y2[:, 1]).any()
+
+    if independent_channels:
+        # when channel independent
+        # channel 1 same between inputs => channel 1 same between outputs
+        assert (y1[:, 0] == y2[:, 0]).all()
+    else:
+        # when not independent
+        # channel 2 different between inputs => all channels different between outputs 
+        assert (y1[:, 0] != y2[:, 0]).any()
+

--- a/tests/test_careamist.py
+++ b/tests/test_careamist.py
@@ -135,6 +135,7 @@ def test_train_array(tmp_path: Path, minimum_configuration: dict):
     )
     assert (tmp_path / "model.zip").exists()
 
+
 @pytest.mark.parametrize("independent_channels", [False, True])
 def test_train_array_channel(
     tmp_path: Path, minimum_configuration: dict, independent_channels: bool
@@ -154,7 +155,6 @@ def test_train_array_channel(
     config.data_config.batch_size = 2
     config.data_config.data_type = SupportedData.ARRAY.value
     config.data_config.patch_size = (8, 8)
-    
 
     # instantiate CAREamist
     careamist = CAREamist(source=config, work_dir=tmp_path)

--- a/tests/test_careamist.py
+++ b/tests/test_careamist.py
@@ -135,8 +135,10 @@ def test_train_array(tmp_path: Path, minimum_configuration: dict):
     )
     assert (tmp_path / "model.zip").exists()
 
-
-def test_train_array_channel(tmp_path: Path, minimum_configuration: dict):
+@pytest.mark.parametrize("independent_channels", [False, True])
+def test_train_array_channel(
+    tmp_path: Path, minimum_configuration: dict, independent_channels: bool
+):
     """Test that CAREamics can be trained on arrays with channels."""
     # training data
     train_array = np.random.rand(32, 32, 3)
@@ -148,9 +150,11 @@ def test_train_array_channel(tmp_path: Path, minimum_configuration: dict):
     config.data_config.axes = "YXC"
     config.algorithm_config.model.in_channels = 3
     config.algorithm_config.model.num_classes = 3
+    config.algorithm_config.model.independent_channels = independent_channels
     config.data_config.batch_size = 2
     config.data_config.data_type = SupportedData.ARRAY.value
     config.data_config.patch_size = (8, 8)
+    
 
     # instantiate CAREamist
     careamist = CAREamist(source=config, work_dir=tmp_path)

--- a/tests/test_lightning_module.py
+++ b/tests/test_lightning_module.py
@@ -227,18 +227,10 @@ def test_careamics_kiln_unet_depth_2_channels_2D(n_channels):
 
 
 @pytest.mark.parametrize(
-        "n_channels,independent_channels", [
-            (1, False), 
-            (1, True),
-            (3, False),
-            (3, True), 
-            (4, False),
-            (4, True)
-        ]
-    )
-def test_careamics_kiln_unet_depth_3_channels_2D(
-    n_channels, independent_channels
-):
+    "n_channels,independent_channels",
+    [(1, False), (1, True), (3, False), (3, True), (4, False), (4, True)],
+)
+def test_careamics_kiln_unet_depth_3_channels_2D(n_channels, independent_channels):
     algo_dict = {
         "algorithm": "n2n",
         "model": {
@@ -247,7 +239,7 @@ def test_careamics_kiln_unet_depth_3_channels_2D(
             "in_channels": n_channels,
             "num_classes": n_channels,
             "depth": 3,
-            "independent_channels": independent_channels
+            "independent_channels": independent_channels,
         },
         "loss": "mae",
     }

--- a/tests/test_lightning_module.py
+++ b/tests/test_lightning_module.py
@@ -226,8 +226,19 @@ def test_careamics_kiln_unet_depth_2_channels_2D(n_channels):
     assert y.shape == x.shape
 
 
-@pytest.mark.parametrize("n_channels", [1, 3, 4])
-def test_careamics_kiln_unet_depth_3_channels_2D(n_channels):
+@pytest.mark.parametrize(
+        "n_channels,independent_channels", [
+            (1, False), 
+            (1, True),
+            (3, False),
+            (3, True), 
+            (4, False),
+            (4, True)
+        ]
+    )
+def test_careamics_kiln_unet_depth_3_channels_2D(
+    n_channels, independent_channels
+):
     algo_dict = {
         "algorithm": "n2n",
         "model": {
@@ -236,6 +247,7 @@ def test_careamics_kiln_unet_depth_3_channels_2D(n_channels):
             "in_channels": n_channels,
             "num_classes": n_channels,
             "depth": 3,
+            "independent_channels": independent_channels
         },
         "loss": "mae",
     }


### PR DESCRIPTION
### Feature

Option to conveniently train independent UNets for each channel in parallel. This is useful for noise2void, most cases will have channel independent noise.

### Implementation

PyTorch has the option to pass the parameter `groups` to `Conv2d` & `Conv3d`. `groups=n` creates _n_ parallel convolutions with no shared connections; in this case we have `groups==in_channels` and `out_channels==K*in_channels` – which is also known as a "depthwise convolution". Using depthwise convolutions throughout the network creates essentially _n_=`in_channels` parallel networks.

When concatenating the skip connections in the decoder we have to interleave the input and the encoder features to ensure no connections between the parallel networks.

No change has to be made to batch normalisation because it is channel-wise.

### Change details

- add `independent_channels` option to `UNet` class and `UNetModel`
- add `groups` parameter to `UnetEncoder` and `UnetDecoder`; which will be passed to each of their `ConvBlock` layers.
- if `independent_channels=True` set `groups==in_channels` in the encoder and decoder. set `groups=1` otherwise.
- add `_interleave` static method in decoder for interleaving input and skip connections.
- update tests to cover independent channels at different depths
- add test to validate channels are indeed independent throughout network
- !possible breaking change! `independent_channels` default is set to `True`