### PR TITLE
Fix: sort files before loading

### DIFF
--- a/src/careamics/dataset/iterable_dataset.py
+++ b/src/careamics/dataset/iterable_dataset.py
@@ -55,8 +55,17 @@ def _iterate_over_files(
     worker_id = worker_info.id if worker_info is not None else 0
     num_workers = worker_info.num_workers if worker_info is not None else 1
 
+    sorted_files = data_files.copy()
+    sorted_files.sort()
+
+    if target_files is not None:
+        sorted_target_files = target_files.copy()
+        sorted_target_files.sort()
+    else:
+        sorted_target_files = []
+
     # iterate over the files
-    for i, filename in enumerate(data_files):
+    for i, filename in enumerate(sorted_files):
         # retrieve file corresponding to the worker id
         if i % num_workers == worker_id:
             try:
@@ -65,15 +74,15 @@ def _iterate_over_files(
 
                 # read target, if available
                 if target_files is not None:
-                    if filename.name != target_files[i].name:
+                    if filename.name != sorted_target_files[i].name:
                         raise ValueError(
                             f"File {filename} does not match target file "
-                            f"{target_files[i]}. Have you passed sorted "
+                            f"{sorted_target_files[i]}. Have you passed sorted "
                             f"arrays?"
                         )
 
                     # read target
-                    target = read_source_func(target_files[i], data_config.axes)
+                    target = read_source_func(sorted_target_files[i], data_config.axes)
 
                     yield sample, target
                 else:

--- a/src/careamics/dataset/patching/patching.py
+++ b/src/careamics/dataset/patching/patching.py
@@ -126,7 +126,11 @@ def prepare_patches_unsupervised(
     """
     means, stds, num_samples = 0, 0, 0
     all_patches = []
-    for filename in train_files:
+
+    sorted_train_files = train_files.copy()
+    sorted_train_files.sort()
+
+    for filename in sorted_train_files:
         try:
             sample: np.ndarray = read_source_func(filename, axes)
             means += sample.mean()


### PR DESCRIPTION
### Description

`IterableDataset` was not sorting path lists, which can lead to the data not being returned in the expected order during prediction, or the source and target not being paired (raising an error).

- **What**: Sort `Path` list.
- **Why**: Ensure that source and target file lists are in the same order, and that prediction are returned in a sorted order.
- **How**: `list.sort()` used in the relevant places.

### Changes Made

- **Modified**: `IterableDataset` and `InMemoryDataset`


---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [x] PR to the documentation exists (for bug fixes / features)