### PR TITLE
Inputs to BMZ should not be normalized

### DIFF
--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -19,11 +19,13 @@ from careamics.config import (
     load_configuration,
 )
 from careamics.config.support import SupportedAlgorithm, SupportedData, SupportedLogger
+from careamics.dataset.dataset_utils import reshape_array
 from careamics.lightning_datamodule import CAREamicsTrainData
 from careamics.lightning_module import CAREamicsModule
 from careamics.lightning_prediction_datamodule import CAREamicsPredictData
 from careamics.lightning_prediction_loop import CAREamicsPredictionLoop
 from careamics.model_io import export_to_bmz, load_pretrained
+from careamics.transforms import Denormalize
 from careamics.utils import check_path_exists, get_logger
 
 from .callbacks import HyperParametersCallback
@@ -651,6 +653,83 @@ class CAREamist:
                     f"np.ndarray (got {type(source)})."
                 )
 
+    def _create_data_for_bmz(
+        self,
+        input_array: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
+        """Create data for BMZ export.
+
+        If no `input_array` is provided, this method checks if there is a prediction
+        datamodule, or a training data module, to extract a patch. If none exists,
+        then a random aray is created.
+
+        If there is a non-singleton batch dimension, this method returns only the first
+        element.
+
+        Parameters
+        ----------
+        input_array : Optional[np.ndarray], optional
+            Input array, by default None.
+
+        Returns
+        -------
+        np.ndarray
+            Input data for BMZ export.
+
+        Raises
+        ------
+        ValueError
+            If mean and std are not provided in the configuration.
+        """
+        if input_array is None:
+            if self.cfg.data_config.mean is None or self.cfg.data_config.std is None:
+                raise ValueError(
+                    "Mean and std cannot be None in the configuration in order to"
+                    "export to the BMZ format. Was the model trained?"
+                )
+
+            # generate images, priority is given to the prediction data module
+            if self.pred_datamodule is not None:
+                # unpack a batch, ignore masks or targets
+                input_patch, *_ = next(iter(self.pred_datamodule.predict_dataloader()))
+
+                # convert torch.Tensor to numpy
+                input_patch = input_patch.numpy()
+
+                # denormalize
+                denormalize = Denormalize(
+                    mean=self.cfg.data_config.mean, std=self.cfg.data_config.std
+                )
+                input_patch, _ = denormalize(input_patch)
+
+            elif self.train_datamodule is not None:
+                input_patch, *_ = next(iter(self.train_datamodule.train_dataloader()))
+                input_patch = input_patch.numpy()
+
+                # denormalize
+                denormalize = Denormalize(
+                    mean=self.cfg.data_config.mean, std=self.cfg.data_config.std
+                )
+                input_patch, _ = denormalize(input_patch)
+            else:
+                # create a random input array
+                input_patch = np.random.normal(
+                    loc=self.cfg.data_config.mean,
+                    scale=self.cfg.data_config.std,
+                    size=self.cfg.data_config.patch_size,
+                ).astype(np.float32)[
+                    np.newaxis, np.newaxis, ...
+                ]  # add S & C dimensions
+        else:
+            # potentially correct shape
+            input_patch = reshape_array(input_array, self.cfg.data_config.axes)
+
+        # if this a batch
+        if input_patch.shape[0] > 1:
+            input_patch = input_patch[[0], ...]  # keep singleton dim
+
+        return input_patch
+
     def export_to_bmz(
         self,
         path: Union[Path, str],
@@ -682,41 +761,7 @@ class CAREamist:
         data_description : Optional[str], optional
             Description of the data, by default None.
         """
-        if input_array is None:
-            # generate images, priority is given to the prediction data module
-            if self.pred_datamodule is not None:
-                # unpack a batch, ignore masks or targets
-                input_patch, *_ = next(iter(self.pred_datamodule.predict_dataloader()))
-
-                # convert torch.Tensor to numpy
-                input_patch = input_patch.numpy()
-            elif self.train_datamodule is not None:
-                input_patch, *_ = next(iter(self.train_datamodule.train_dataloader()))
-                input_patch = input_patch.numpy()
-            else:
-                if (
-                    self.cfg.data_config.mean is None
-                    or self.cfg.data_config.std is None
-                ):
-                    raise ValueError(
-                        "Mean and std cannot be None in the configuration in order to"
-                        "export to the BMZ format. Was the model trained?"
-                    )
-
-                # create a random input array
-                input_patch = np.random.normal(
-                    loc=self.cfg.data_config.mean,
-                    scale=self.cfg.data_config.std,
-                    size=self.cfg.data_config.patch_size,
-                ).astype(np.float32)[
-                    np.newaxis, np.newaxis, ...
-                ]  # add S & C dimensions
-        else:
-            input_patch = input_array
-
-        # if there is a batch dimension
-        if input_patch.shape[0] > 1:
-            input_patch = input_patch[0:1, ...]  # keep singleton dim
+        input_patch = self._create_data_for_bmz(input_array)
 
         # axes need to be reformated for the export because reshaping was done in the
         # datamodule

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -104,9 +104,9 @@ def export_to_bmz(
     authors : List[dict]
         Authors of the model.
     input_array : np.ndarray
-        Input array.
+        Input array, should not have been normalized.
     output_array : np.ndarray
-        Output array.
+        Output array, should have been denormalized.
     channel_names : Optional[List[str]], optional
         Channel names, by default None.
     data_description : Optional[str], optional

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -178,7 +178,7 @@ def export_to_bmz(
         )
 
         # test model description
-        summary: ValidationSummary = test_model(model_description, decimal=0)
+        summary: ValidationSummary = test_model(model_description, decimal=2)
         if summary.status == "failed":
             raise ValueError(f"Model description test failed: {summary}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -247,7 +247,7 @@ def overlaps() -> Tuple[int, int]:
 def pre_trained(tmp_path, minimum_configuration):
     """Fixture to create a pre-trained CAREamics model."""
     # training data
-    train_array = np.arange(32 * 32).reshape((32, 32))
+    train_array = np.arange(32 * 32).reshape((32, 32)).astype(float)
 
     # create configuration
     config = Configuration(**minimum_configuration)

--- a/tests/test_careamist.py
+++ b/tests/test_careamist.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Tuple
 
 import numpy as np
 import pytest
@@ -7,7 +8,10 @@ import tifffile
 from careamics import CAREamist, Configuration, save_configuration
 from careamics.config.support import SupportedAlgorithm, SupportedData
 
-# TODO test 3D and channels
+
+def random_array(shape: Tuple[int, ...]):
+    """Return a random array with values between 0 and 255."""
+    return (255 * (1 + np.random.rand(*shape)) / 2).astype(np.float32)
 
 
 def test_no_parameters():
@@ -74,7 +78,7 @@ def test_train_error_target_unsupervised_algorithm(
 def test_train_single_array_no_val(tmp_path: Path, minimum_configuration: dict):
     """Test that CAREamics can be trained with arrays."""
     # training data
-    train_array = np.random.rand(32, 32)
+    train_array = random_array((32, 32))
 
     # create configuration
     config = Configuration(**minimum_configuration)
@@ -106,8 +110,8 @@ def test_train_single_array_no_val(tmp_path: Path, minimum_configuration: dict):
 def test_train_array(tmp_path: Path, minimum_configuration: dict):
     """Test that CAREamics can be trained on arrays."""
     # training data
-    train_array = np.random.rand(32, 32)
-    val_array = np.random.rand(32, 32)
+    train_array = random_array((32, 32))
+    val_array = random_array((32, 32))
 
     # create configuration
     config = Configuration(**minimum_configuration)
@@ -142,8 +146,8 @@ def test_train_array_channel(
 ):
     """Test that CAREamics can be trained on arrays with channels."""
     # training data
-    train_array = np.random.rand(32, 32, 3)
-    val_array = np.random.rand(32, 32, 3)
+    train_array = random_array((32, 32, 3))
+    val_array = random_array((32, 32, 3))
 
     # create configuration
     config = Configuration(**minimum_configuration)
@@ -179,8 +183,8 @@ def test_train_array_channel(
 def test_train_array_3d(tmp_path: Path, minimum_configuration: dict):
     """Test that CAREamics can be trained on 3D arrays."""
     # training data
-    train_array = np.random.rand(8, 32, 32)
-    val_array = np.random.rand(8, 32, 32)
+    train_array = random_array((8, 32, 32))
+    val_array = random_array((8, 32, 32))
 
     # create configuration
     minimum_configuration["data_config"]["axes"] = "ZYX"
@@ -212,7 +216,7 @@ def test_train_array_3d(tmp_path: Path, minimum_configuration: dict):
 def test_train_tiff_files_in_memory_no_val(tmp_path: Path, minimum_configuration: dict):
     """Test that CAREamics can be trained with tiff files in memory."""
     # training data
-    train_array = np.random.rand(32, 32)
+    train_array = random_array((32, 32))
 
     # save files
     train_file = tmp_path / "train.tiff"
@@ -248,8 +252,8 @@ def test_train_tiff_files_in_memory_no_val(tmp_path: Path, minimum_configuration
 def test_train_tiff_files_in_memory(tmp_path: Path, minimum_configuration: dict):
     """Test that CAREamics can be trained with tiff files in memory."""
     # training data
-    train_array = np.random.rand(32, 32)
-    val_array = np.random.rand(32, 32)
+    train_array = random_array((32, 32))
+    val_array = random_array((32, 32))
 
     # save files
     train_file = tmp_path / "train.tiff"
@@ -290,8 +294,8 @@ def test_train_tiff_files(tmp_path: Path, minimum_configuration: dict):
     the in memory dataset.
     """
     # training data
-    train_array = np.random.rand(32, 32)
-    val_array = np.random.rand(32, 32)
+    train_array = random_array((32, 32))
+    val_array = random_array((32, 32))
 
     # save files
     train_file = tmp_path / "train.tiff"
@@ -330,10 +334,10 @@ def test_train_tiff_files(tmp_path: Path, minimum_configuration: dict):
 def test_train_array_supervised(tmp_path: Path, supervised_configuration: dict):
     """Test that CAREamics can be trained with arrays."""
     # training data
-    train_array = np.random.rand(32, 32)
-    val_array = np.random.rand(32, 32)
-    train_target = np.random.rand(32, 32)
-    val_target = np.random.rand(32, 32)
+    train_array = random_array((32, 32))
+    val_array = random_array((32, 32))
+    train_target = random_array((32, 32))
+    val_target = random_array((32, 32))
 
     # create configuration
     config = Configuration(**supervised_configuration)
@@ -372,10 +376,10 @@ def test_train_tiff_files_in_memory_supervised(
 ):
     """Test that CAREamics can be trained with tiff files in memory."""
     # training data
-    train_array = np.random.rand(32, 32)
-    val_array = np.random.rand(32, 32)
-    train_target = np.random.rand(32, 32)
-    val_target = np.random.rand(32, 32)
+    train_array = random_array((32, 32))
+    val_array = random_array((32, 32))
+    train_target = random_array((32, 32))
+    val_target = random_array((32, 32))
 
     # save files
     images = tmp_path / "images"
@@ -431,10 +435,10 @@ def test_train_tiff_files_supervised(tmp_path: Path, supervised_configuration: d
     the in memory dataset.
     """
     # training data
-    train_array = np.random.rand(32, 32)
-    val_array = np.random.rand(32, 32)
-    train_target = np.random.rand(32, 32)
-    val_target = np.random.rand(32, 32)
+    train_array = random_array((32, 32))
+    val_array = random_array((32, 32))
+    train_target = random_array((32, 32))
+    val_target = random_array((32, 32))
 
     # save files
     images = tmp_path / "images"
@@ -492,7 +496,7 @@ def test_predict_on_array_tiled(
 ):
     """Test that CAREamics can predict on arrays."""
     # training data
-    train_array = np.random.rand(32, 32)
+    train_array = random_array((32, 32))
 
     # create configuration
     config = Configuration(**minimum_configuration)
@@ -528,7 +532,7 @@ def test_predict_on_array_tiled(
 def test_predict_arrays_no_tiling(tmp_path: Path, minimum_configuration: dict):
     """Test that CAREamics can predict on arrays without tiling."""
     # training data
-    train_array = np.random.rand(4, 32, 32)
+    train_array = random_array((4, 32, 32))
 
     # create configuration
     config = Configuration(**minimum_configuration)
@@ -563,7 +567,7 @@ def test_predict_arrays_no_tiling(tmp_path: Path, minimum_configuration: dict):
 def test_predict_path(tmp_path: Path, minimum_configuration: dict, batch_size):
     """Test that CAREamics can predict with tiff files."""
     # training data
-    train_array = np.random.rand(32, 32)
+    train_array = random_array((32, 32))
 
     # save files
     train_file = tmp_path / "train.tiff"
@@ -603,7 +607,7 @@ def test_predict_pretrained_checkpoint(tmp_path: Path, pre_trained: Path):
     """Test that CAREamics can be instantiated with a pre-trained network and predict
     on an array."""
     # prediction data
-    source_array = np.random.rand(32, 32)
+    source_array = random_array((32, 32))
 
     # instantiate CAREamist
     careamist = CAREamist(source=pre_trained, work_dir=tmp_path)
@@ -620,7 +624,7 @@ def test_predict_pretrained_checkpoint(tmp_path: Path, pre_trained: Path):
 def test_predict_pretrained_bmz(tmp_path: Path, pre_trained_bmz: Path):
     """Test that CAREamics can be instantiated with a BMZ archive and predict."""
     # prediction data
-    source_array = np.random.rand(32, 32)
+    source_array = random_array((32, 32))
 
     # instantiate CAREamist
     careamist = CAREamist(source=pre_trained_bmz, work_dir=tmp_path)
@@ -630,6 +634,144 @@ def test_predict_pretrained_bmz(tmp_path: Path, pre_trained_bmz: Path):
 
     # check that it predicted
     assert predicted.squeeze().shape == source_array.shape
+
+
+def test_data_for_bmz_random(tmp_path, minimum_configuration):
+    """Test the BMZ example data creation when the careamist has a training
+    datamodule."""
+    seed = 24
+    rng = np.random.default_rng(seed)
+
+    # example data
+    example_data = 255 * (1 + rng.random((32, 32), dtype=float)) / 2
+
+    # create configuration
+    config = Configuration(**minimum_configuration)
+    config.training_config.num_epochs = 1
+    config.data_config.axes = "YX"
+    config.data_config.batch_size = 2
+    config.data_config.data_type = SupportedData.ARRAY.value
+    config.data_config.patch_size = (8, 8)
+    config.data_config.set_mean_and_std(
+        mean=example_data.mean(), std=example_data.std()
+    )
+
+    # instantiate CAREamist
+    careamist = CAREamist(source=config, work_dir=tmp_path)
+
+    # get data for BMZ
+    patch = careamist._create_data_for_bmz()
+    assert patch.shape == (1, 1) + tuple(config.data_config.patch_size)
+
+    # check that it is not normalised
+    assert np.abs(patch.mean() - example_data.mean()) < 0.1 * example_data.mean()
+
+
+def test_data_for_bmz_with_array(tmp_path, minimum_configuration):
+    """Test the BMZ example data creation when the careamist has a training
+    datamodule."""
+    seed = 24
+    rng = np.random.default_rng(seed)
+
+    # example data
+    example_data = 255 * (1 + rng.random((32, 32), dtype=float)) / 2
+
+    # create configuration
+    config = Configuration(**minimum_configuration)
+    config.training_config.num_epochs = 1
+    config.data_config.axes = "YX"
+    config.data_config.batch_size = 2
+    config.data_config.data_type = SupportedData.ARRAY.value
+    config.data_config.patch_size = (8, 8)
+    config.data_config.set_mean_and_std(
+        mean=example_data.mean(), std=example_data.std()
+    )
+
+    # instantiate CAREamist
+    careamist = CAREamist(source=config, work_dir=tmp_path)
+
+    # get data for BMZ
+    patch = careamist._create_data_for_bmz(example_data)
+    assert patch.shape == (1, 1) + example_data.shape
+
+    # check that it is not normalised
+    assert np.allclose(patch.squeeze(), example_data)
+
+
+def test_data_for_bmz_after_training(tmp_path, minimum_configuration):
+    """Test the BMZ example data creation when the careamist has a training
+    datamodule."""
+    seed = 24
+    rng = np.random.default_rng(seed)
+
+    # training data
+    train_array = 255 * (1 + rng.random((32, 32), dtype=float)) / 2
+    val_array = 255 * (1 + rng.random((32, 32), dtype=float)) / 2
+
+    # create configuration
+    config = Configuration(**minimum_configuration)
+    config.training_config.num_epochs = 1
+    config.data_config.axes = "YX"
+    config.data_config.batch_size = 2
+    config.data_config.data_type = SupportedData.ARRAY.value
+    config.data_config.patch_size = (8, 8)
+
+    # instantiate CAREamist
+    careamist = CAREamist(source=config, work_dir=tmp_path)
+
+    # train CAREamist
+    careamist.train(train_source=train_array, val_source=val_array)
+
+    # check that mean and std make sense
+    assert config.data_config.mean > 100
+    assert config.data_config.std > 20
+
+    # get data for BMZ
+    patch = careamist._create_data_for_bmz()
+    assert patch.shape == (1, 1) + tuple(config.data_config.patch_size)
+
+    # check that it is not normalised (data should be [0, 255])
+    assert patch.max() > config.data_config.mean
+
+
+def test_data_for_bmz_after_prediction(tmp_path, minimum_configuration):
+    """Test the BMZ example data creation when the careamist has a prediction
+    datamodule."""
+    seed = 24
+    rng = np.random.default_rng(seed)
+
+    # training data
+    train_array = 255 * (1 + rng.random((32, 32), dtype=float)) / 2
+    val_array = 255 * (1 + rng.random((32, 32), dtype=float)) / 2
+
+    # create configuration
+    config = Configuration(**minimum_configuration)
+    config.training_config.num_epochs = 1
+    config.data_config.axes = "YX"
+    config.data_config.batch_size = 2
+    config.data_config.data_type = SupportedData.ARRAY.value
+    config.data_config.patch_size = (8, 8)
+
+    # instantiate CAREamist
+    careamist = CAREamist(source=config, work_dir=tmp_path)
+
+    # train CAREamist
+    careamist.train(train_source=train_array, val_source=val_array)
+
+    # check that mean and std make sense
+    assert config.data_config.mean > 100
+    assert config.data_config.std > 20
+
+    # predict without tiling
+    test_array = 1_000 * (1 + rng.random((32, 32), dtype=float)) / 2
+    _ = careamist.predict(test_array)
+
+    # get data for BMZ
+    patch = careamist._create_data_for_bmz()
+    assert patch.shape == (1, 1) + test_array.shape
+
+    # check that it is not normalised
+    assert np.allclose(patch.squeeze(), test_array)
 
 
 def test_export_bmz_pretrained_prediction(tmp_path: Path, pre_trained: Path):
@@ -643,7 +785,7 @@ def test_export_bmz_pretrained_prediction(tmp_path: Path, pre_trained: Path):
     careamist = CAREamist(source=pre_trained, work_dir=tmp_path)
 
     # prediction data
-    source_array = np.random.rand(32, 32)
+    source_array = random_array((32, 32))
     _ = careamist.predict(source_array)
     assert len(careamist.pred_datamodule.predict_dataloader()) > 0
 
@@ -686,11 +828,11 @@ def test_export_bmz_pretrained_with_array(tmp_path: Path, pre_trained: Path):
     careamist = CAREamist(source=pre_trained, work_dir=tmp_path)
 
     # alternatively we can pass an array
-    array = np.random.rand(32, 32).astype(np.float32)
+    array = random_array((32, 32))
     careamist.export_to_bmz(
         path=tmp_path / "model2.zip",
         name="TopModel",
-        input_array=array[np.newaxis, np.newaxis, ...],
+        input_array=array,
         general_description="A model that just walked in.",
         authors=[{"name": "Amod", "affiliation": "El"}],
     )


### PR DESCRIPTION
### Description

The inputs to the BMZ model should not be normalized, as the BMZ core applies the normalization itself. Since all our tests were using tensors with values [-1, 1], this went unnoticed.

This PR uses a quick fix by applying denormalization to the patches extracted from the datamodules. This part of the code was refactored into a tested member function of `CAREamist`. I also scaled all tensors in `CAREamit` tests to [0, 255] to be more realistic.

- **What**: Add denormalization to BMZ export input data.
- **Why**: The current code export normalized tensors, which leads to failing validation of the BMZ archive
- **How**: `Denormalize` is now called in a the (refactored) `_create_data_for_bmz` method in `CAREamist`.

### Changes Made

- **Added**: `_create_data_for_bmz` method in `CAREamist`, specific tests.
- **Modified**: Existing `CAREamist` tests.

### Related Issues

Issues reported by users.

### Additional Notes and Examples

The choice here is **quick fix** one. The current way example inputs are generated prior to exporting to the BMZ format is by pulling patches from the existing dataloaders (either prediction, or training one):
https://github.com/CAREamics/careamics/blob/f613d724fd7e9f8f6ea102ee108701bb44dfae44/src/careamics/careamist.py#L694

This fix here is to simply call `Denormalize` on the array:
```python
# unpack a batch, ignore masks or targets
input_patch, *_ = next(iter(self.pred_datamodule.predict_dataloader()))

# convert torch.Tensor to numpy
input_patch = input_patch.numpy()

# denormalize
denormalize = Denormalize(
    mean=self.cfg.data_config.mean, std=self.cfg.data_config.std
)
input_patch, _ = denormalize(input_patch)
```

An alternative would be to find a way to create a new Dataloader with the data and remove normalization, but this seems possible only after training because the `CAREamist` remembers the source data (unless it is a DataLoader). However, we want to be able to export after loading a checkpoint for instance (choosing best model, loading it, exporting to BMZ).

So I think this is the best pragmatic choice.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [x] No change to the documentation needed