### PR TITLE
Refactor: Rename image means and stds with plural

### DIFF
--- a/src/careamics/config/configuration_factory.py
+++ b/src/careamics/config/configuration_factory.py
@@ -605,8 +605,8 @@ def create_inference_configuration(
         Configuration used to configure CAREamicsPredictData.
     """
     if (
-        configuration.data_config.image_mean is None
-        or configuration.data_config.image_std is None
+        configuration.data_config.image_means is None
+        or configuration.data_config.image_stds is None
     ):
         raise ValueError("Mean and std must be provided in the configuration.")
 
@@ -637,8 +637,8 @@ def create_inference_configuration(
         tile_size=tile_size,
         tile_overlap=tile_overlap,
         axes=axes or configuration.data_config.axes,
-        image_mean=configuration.data_config.image_mean,
-        image_std=configuration.data_config.image_std,
+        image_means=configuration.data_config.image_means,
+        image_stds=configuration.data_config.image_stds,
         tta_transforms=tta_transforms,
         batch_size=batch_size,
     )

--- a/src/careamics/config/data_model.py
+++ b/src/careamics/config/data_model.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pprint import pformat
 from typing import Any, Literal, Optional, Union
 
-import numpy as np
+from numpy.typing import NDArray
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -56,7 +56,7 @@ class DataConfig(BaseModel):
     ... )
 
     To change the mean and std of the data:
-    >>> data.set_mean_and_std(image_mean=[214.3], image_std=[84.5])
+    >>> data.set_mean_and_std(image_means=[214.3], image_stds=[84.5])
 
     One can pass also a list of transformations, by keyword, using the
     SupportedTransform value:
@@ -86,12 +86,16 @@ class DataConfig(BaseModel):
     axes: str
 
     # Optional fields
-    image_mean: Optional[list[float]] = Field(default=None, min_length=0, max_length=32)
-    image_std: Optional[list[float]] = Field(default=None, min_length=0, max_length=32)
-    target_mean: Optional[list[float]] = Field(
+    image_means: Optional[list[float]] = Field(
         default=None, min_length=0, max_length=32
     )
-    target_std: Optional[list[float]] = Field(default=None, min_length=0, max_length=32)
+    image_stds: Optional[list[float]] = Field(default=None, min_length=0, max_length=32)
+    target_means: Optional[list[float]] = Field(
+        default=None, min_length=0, max_length=32
+    )
+    target_stds: Optional[list[float]] = Field(
+        default=None, min_length=0, max_length=32
+    )
 
     transforms: list[TRANSFORMS_UNION] = Field(
         default=[
@@ -232,29 +236,29 @@ class DataConfig(BaseModel):
             If std is not None and mean is None.
         """
         # check that mean and std are either both None, or both specified
-        if (self.image_mean and not self.image_std) or (
-            self.image_std and not self.image_mean
+        if (self.image_means and not self.image_stds) or (
+            self.image_stds and not self.image_means
         ):
             raise ValueError(
                 "Mean and std must be either both None, or both specified."
             )
 
-        elif (self.image_mean is not None and self.image_std is not None) and (
-            len(self.image_mean) != len(self.image_std)
+        elif (self.image_means is not None and self.image_stds is not None) and (
+            len(self.image_means) != len(self.image_stds)
         ):
             raise ValueError(
                 "Mean and std must be specified for each " "input channel."
             )
 
-        if (self.target_mean and not self.target_std) or (
-            self.target_std and not self.target_mean
+        if (self.target_means and not self.target_stds) or (
+            self.target_stds and not self.target_means
         ):
             raise ValueError(
                 "Mean and std must be either both None, or both specified "
             )
 
-        elif self.target_mean is not None and self.target_std is not None:
-            if len(self.target_mean) != len(self.target_std):
+        elif self.target_means is not None and self.target_stds is not None:
+            if len(self.target_means) != len(self.target_stds):
                 raise ValueError(
                     "Mean and std must be either both None, or both specified for each "
                     "target channel."
@@ -344,10 +348,10 @@ class DataConfig(BaseModel):
 
     def set_mean_and_std(
         self,
-        image_mean: Union[np.ndarray, tuple, list, None],
-        image_std: Union[np.ndarray, tuple, list, None],
-        target_mean: Optional[Union[np.ndarray, tuple, list, None]] = None,
-        target_std: Optional[Union[np.ndarray, tuple, list, None]] = None,
+        image_means: Union[NDArray, tuple, list, None],
+        image_stds: Union[NDArray, tuple, list, None],
+        target_means: Optional[Union[NDArray, tuple, list, None]] = None,
+        target_stds: Optional[Union[NDArray, tuple, list, None]] = None,
     ) -> None:
         """
         Set mean and standard deviation of the data.
@@ -357,30 +361,30 @@ class DataConfig(BaseModel):
 
         Parameters
         ----------
-        image_mean : np.ndarray or tuple or list
-            Mean value for normalization.
-        image_std : np.ndarray or tuple or list
-            Standard deviation value for normalization.
-        target_mean : np.ndarray or tuple or list, optional
-            Target mean value for normalization, by default ().
-        target_std : np.ndarray or tuple or list, optional
-            Target standard deviation value for normalization, by default ().
+        image_means : NDArray or tuple or list
+            Mean values for normalization.
+        image_stds : NDArray or tuple or list
+            Standard deviation values for normalization.
+        target_means : NDArray or tuple or list, optional
+            Target mean values for normalization, by default ().
+        target_stds : NDArray or tuple or list, optional
+            Target standard deviation values for normalization, by default ().
         """
         # make sure we pass a list
-        if image_mean is not None:
-            image_mean = list(image_mean)
-        if image_std is not None:
-            image_std = list(image_std)
-        if target_mean is not None:
-            target_mean = list(target_mean)
-        if target_std is not None:
-            target_std = list(target_std)
+        if image_means is not None:
+            image_means = list(image_means)
+        if image_stds is not None:
+            image_stds = list(image_stds)
+        if target_means is not None:
+            target_means = list(target_means)
+        if target_stds is not None:
+            target_stds = list(target_stds)
 
         self._update(
-            image_mean=image_mean,
-            image_std=image_std,
-            target_mean=target_mean,
-            target_std=target_std,
+            image_means=image_means,
+            image_stds=image_stds,
+            target_means=target_means,
+            target_stds=target_stds,
         )
 
     def set_3D(self, axes: str, patch_size: list[int]) -> None:

--- a/src/careamics/config/inference_model.py
+++ b/src/careamics/config/inference_model.py
@@ -26,8 +26,8 @@ class InferenceConfig(BaseModel):
 
     axes: str
 
-    image_mean: list = Field(..., min_length=0, max_length=32)
-    image_std: list = Field(..., min_length=0, max_length=32)
+    image_means: list = Field(..., min_length=0, max_length=32)
+    image_stds: list = Field(..., min_length=0, max_length=32)
 
     # only default TTAs are supported for now
     tta_transforms: bool = Field(default=True)
@@ -182,18 +182,18 @@ class InferenceConfig(BaseModel):
             If std is not None and mean is None.
         """
         # check that mean and std are either both None, or both specified
-        if not self.image_mean and not self.image_std:
+        if not self.image_means and not self.image_stds:
             raise ValueError("Mean and std must be specified during inference.")
 
-        if (self.image_mean and not self.image_std) or (
-            self.image_std and not self.image_mean
+        if (self.image_means and not self.image_stds) or (
+            self.image_stds and not self.image_means
         ):
             raise ValueError(
                 "Mean and std must be either both None, or both specified."
             )
 
-        elif (self.image_mean is not None and self.image_std is not None) and (
-            len(self.image_mean) != len(self.image_std)
+        elif (self.image_means is not None and self.image_stds is not None) and (
+            len(self.image_means) != len(self.image_stds)
         ):
             raise ValueError(
                 "Mean and std must be specified for each " "input channel."

--- a/src/careamics/dataset/in_memory_dataset.py
+++ b/src/careamics/dataset/in_memory_dataset.py
@@ -85,30 +85,30 @@ class InMemoryDataset(Dataset):
         self.data = patches_data.patches
         self.data_targets = patches_data.targets
 
-        if self.data_config.image_mean is None:
+        if self.data_config.image_means is None:
             self.image_means = patches_data.image_stats.means
             self.image_stds = patches_data.image_stats.stds
             logger.info(
                 f"Computed dataset mean: {self.image_means}, std: {self.image_stds}"
             )
         else:
-            self.image_means = self.data_config.image_mean
-            self.image_stds = self.data_config.image_std
+            self.image_means = self.data_config.image_means
+            self.image_stds = self.data_config.image_stds
 
-        if self.data_config.target_mean is None:
+        if self.data_config.target_means is None:
             self.target_means = patches_data.target_stats.means
             self.target_stds = patches_data.target_stats.stds
         else:
-            self.target_means = self.data_config.target_mean
-            self.target_stds = self.data_config.target_std
+            self.target_means = self.data_config.target_means
+            self.target_stds = self.data_config.target_stds
 
         # update mean and std in configuration
         # the object is mutable and should then be recorded in the CAREamist obj
         self.data_config.set_mean_and_std(
-            image_mean=self.image_means,
-            image_std=self.image_stds,
-            target_mean=self.target_means,
-            target_std=self.target_stds,
+            image_means=self.image_means,
+            image_stds=self.image_stds,
+            target_means=self.target_means,
+            target_stds=self.target_stds,
         )
         # get transforms
         self.patch_transform = Compose(

--- a/src/careamics/dataset/in_memory_pred_dataset.py
+++ b/src/careamics/dataset/in_memory_pred_dataset.py
@@ -45,8 +45,8 @@ class InMemoryPredDataset(Dataset):
         self.pred_config = prediction_config
         self.input_array = inputs
         self.axes = self.pred_config.axes
-        self.image_means = self.pred_config.image_mean
-        self.image_stds = self.pred_config.image_std
+        self.image_means = self.pred_config.image_means
+        self.image_stds = self.pred_config.image_stds
 
         # Reshape data
         self.data = reshape_array(self.input_array, self.axes)

--- a/src/careamics/dataset/in_memory_tiled_pred_dataset.py
+++ b/src/careamics/dataset/in_memory_tiled_pred_dataset.py
@@ -58,8 +58,8 @@ class InMemoryTiledPredDataset(Dataset):
         self.axes = self.pred_config.axes
         self.tile_size = prediction_config.tile_size
         self.tile_overlap = prediction_config.tile_overlap
-        self.image_means = self.pred_config.image_mean
-        self.image_stds = self.pred_config.image_std
+        self.image_means = self.pred_config.image_means
+        self.image_stds = self.pred_config.image_stds
 
         # Generate patches
         self.data = self._prepare_tiles()

--- a/src/careamics/dataset/iterable_dataset.py
+++ b/src/careamics/dataset/iterable_dataset.py
@@ -73,7 +73,7 @@ class PathIterableDataset(IterableDataset):
         # compute mean and std over the dataset
         # only checking the image_mean because the DataConfig class ensures that
         # if image_mean is provided, image_std is also provided
-        if not self.data_config.image_mean:
+        if not self.data_config.image_means:
             self.data_stats = self._calculate_mean_and_std()
             logger.info(
                 f"Computed dataset mean: {self.data_stats.image_stats.means},"
@@ -82,14 +82,14 @@ class PathIterableDataset(IterableDataset):
 
             # update the mean in the config
             self.data_config.set_mean_and_std(
-                image_mean=self.data_stats.image_stats.means,
-                image_std=self.data_stats.image_stats.stds,
-                target_mean=(
+                image_means=self.data_stats.image_stats.means,
+                image_stds=self.data_stats.image_stats.stds,
+                target_means=(
                     list(self.data_stats.target_stats.means)
                     if self.data_stats.target_stats.means is not None
                     else None
                 ),
-                target_std=(
+                target_stds=(
                     list(self.data_stats.target_stats.stds)
                     if self.data_stats.target_stats.stds is not None
                     else None
@@ -99,8 +99,8 @@ class PathIterableDataset(IterableDataset):
         else:
             # if mean and std are provided in the config, use them
             self.data_stats = StatsOutput(
-                Stats(self.data_config.image_mean, self.data_config.image_std),
-                Stats(self.data_config.target_mean, self.data_config.target_std),
+                Stats(self.data_config.image_means, self.data_config.image_stds),
+                Stats(self.data_config.target_means, self.data_config.target_stds),
             )
 
         # create transform composed of normalization and other transforms

--- a/src/careamics/dataset/iterable_pred_dataset.py
+++ b/src/careamics/dataset/iterable_pred_dataset.py
@@ -75,13 +75,13 @@ class IterablePredDataset(IterableDataset):
 
         # check mean and std and create normalize transform
         if (
-            self.prediction_config.image_mean is None
-            or self.prediction_config.image_std is None
+            self.prediction_config.image_means is None
+            or self.prediction_config.image_stds is None
         ):
             raise ValueError("Mean and std must be provided for prediction.")
         else:
-            self.image_means = self.prediction_config.image_mean
-            self.image_stds = self.prediction_config.image_std
+            self.image_means = self.prediction_config.image_means
+            self.image_stds = self.prediction_config.image_stds
 
         # instantiate normalize transform
         self.patch_transform = Compose(

--- a/src/careamics/dataset/iterable_tiled_pred_dataset.py
+++ b/src/careamics/dataset/iterable_tiled_pred_dataset.py
@@ -87,13 +87,13 @@ class IterableTiledPredDataset(IterableDataset):
 
         # check mean and std and create normalize transform
         if (
-            self.prediction_config.image_mean is None
-            or self.prediction_config.image_std is None
+            self.prediction_config.image_means is None
+            or self.prediction_config.image_stds is None
         ):
             raise ValueError("Mean and std must be provided for prediction.")
         else:
-            self.image_means = self.prediction_config.image_mean
-            self.image_stds = self.prediction_config.image_std
+            self.image_means = self.prediction_config.image_means
+            self.image_stds = self.prediction_config.image_stds
 
             # instantiate normalize transform
             self.patch_transform = Compose(

--- a/src/careamics/lightning_prediction_datamodule.py
+++ b/src/careamics/lightning_prediction_datamodule.py
@@ -1,7 +1,7 @@
 """Prediction Lightning data modules."""
 
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Literal, Optional, Tuple, Union
 
 import numpy as np
 import pytorch_lightning as L
@@ -271,10 +271,10 @@ class PredictDataWrapper(CAREamicsPredictData):
         Prediction data.
     data_type : Union[Literal["array", "tiff", "custom"], SupportedData]
         Data type, see `SupportedData` for available options.
-    image_mean : float
-        Mean value for normalization, only used if Normalization is defined.
-    image_std : float
-        Std value for normalization, only used if Normalization is defined.
+    image_means : list of float
+        Mean values for normalization, only used if Normalization is defined.
+    image_stds : list of float
+        Std values for normalization, only used if Normalization is defined.
     tile_size : Tuple[int, ...]
         Tile size, 2D or 3D tile size.
     tile_overlap : Tuple[int, ...]
@@ -298,8 +298,8 @@ class PredictDataWrapper(CAREamicsPredictData):
         self,
         pred_data: Union[str, Path, np.ndarray],
         data_type: Union[Literal["array", "tiff", "custom"], SupportedData],
-        image_mean=List,
-        image_std=List,
+        image_means=list[float],
+        image_stds=list[float],
         tile_size: Optional[Tuple[int, ...]] = None,
         tile_overlap: Optional[Tuple[int, ...]] = None,
         axes: str = "YX",
@@ -318,10 +318,10 @@ class PredictDataWrapper(CAREamicsPredictData):
             Prediction data.
         data_type : Union[Literal["array", "tiff", "custom"], SupportedData]
             Data type, see `SupportedData` for available options.
-        image_mean : float
-            Mean value for normalization, only used if Normalization is defined.
-        image_std : float
-            Std value for normalization, only used if Normalization is defined.
+        image_means : list of float
+            Mean values for normalization, only used if Normalization is defined.
+        image_stds : list of float
+            Std values for normalization, only used if Normalization is defined.
         tile_size : List[int]
             Tile size, 2D or 3D tile size.
         tile_overlap : List[int]
@@ -347,8 +347,8 @@ class PredictDataWrapper(CAREamicsPredictData):
             "tile_size": tile_size,
             "tile_overlap": tile_overlap,
             "axes": axes,
-            "image_mean": image_mean,
-            "image_std": image_std,
+            "image_means": image_means,
+            "image_stds": image_stds,
             "tta": tta_transforms,
             "batch_size": batch_size,
             "transforms": [],

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -134,10 +134,10 @@ def _create_inputs_ouputs(
     output_axes = _create_axes(output_array, data_config, channel_names, False)
 
     # mean and std
-    assert data_config.image_mean is not None, "Mean cannot be None."
-    assert data_config.image_mean is not None, "Std cannot be None."
-    means = data_config.image_mean
-    stds = data_config.image_std
+    assert data_config.image_means is not None, "Mean cannot be None."
+    assert data_config.image_means is not None, "Std cannot be None."
+    means = data_config.image_means
+    stds = data_config.image_stds
 
     # and the mean and std required to invert the normalization
     # CAREamics denormalization: x = y * (std + eps) + mean

--- a/tests/config/test_data_model.py
+++ b/tests/config/test_data_model.py
@@ -28,16 +28,16 @@ def test_wrong_extensions(minimum_data: dict, ext: str):
 @pytest.mark.parametrize("mean, std", [(0, 124.5), (12.6, 0.1)])
 def test_mean_std_non_negative(minimum_data: dict, mean, std):
     """Test that non negative mean and std are accepted."""
-    minimum_data["image_mean"] = [mean]
-    minimum_data["image_std"] = [std]
-    minimum_data["target_mean"] = [mean]
-    minimum_data["target_std"] = [std]
+    minimum_data["image_means"] = [mean]
+    minimum_data["image_stds"] = [std]
+    minimum_data["target_means"] = [mean]
+    minimum_data["target_stds"] = [std]
 
     data_model = DataConfig(**minimum_data)
-    assert data_model.image_mean == [mean]
-    assert data_model.image_std == [std]
-    assert data_model.target_mean == [mean]
-    assert data_model.target_std == [std]
+    assert data_model.image_means == [mean]
+    assert data_model.image_stds == [std]
+    assert data_model.target_means == [mean]
+    assert data_model.target_stds == [std]
 
 
 def test_mean_std_both_specified_or_none(minimum_data: dict):
@@ -46,23 +46,23 @@ def test_mean_std_both_specified_or_none(minimum_data: dict):
     DataConfig(**minimum_data)
 
     # Error if only mean is defined
-    minimum_data["image_mean"] = [10.4]
+    minimum_data["image_means"] = [10.4]
     with pytest.raises(ValueError):
         DataConfig(**minimum_data)
 
     # Error if only std is defined
-    minimum_data.pop("image_mean")
-    minimum_data["image_std"] = [10.4]
+    minimum_data.pop("image_means")
+    minimum_data["image_stds"] = [10.4]
     with pytest.raises(ValueError):
         DataConfig(**minimum_data)
 
     # No error if both are specified
-    minimum_data["image_mean"] = [10.4]
-    minimum_data["image_std"] = [10.4]
+    minimum_data["image_means"] = [10.4]
+    minimum_data["image_stds"] = [10.4]
     DataConfig(**minimum_data)
 
     # Error if target mean is defined but target std is None
-    minimum_data["target_std"] = [10.4, 11]
+    minimum_data["target_stds"] = [10.4, 11]
     with pytest.raises(ValueError):
         DataConfig(**minimum_data)
 
@@ -74,13 +74,13 @@ def test_set_mean_and_std(minimum_data: dict):
     std = [14.07]
     data = DataConfig(**minimum_data)
     data.set_mean_and_std(mean, std)
-    assert data.image_mean == mean
-    assert data.image_std == std
+    assert data.image_means == mean
+    assert data.image_stds == std
 
     # Set also target mean and std
     data.set_mean_and_std(mean, std, mean, std)
-    assert data.target_mean == mean
-    assert data.target_std == std
+    assert data.target_means == mean
+    assert data.target_stds == std
 
 
 def test_normalize_not_accepted(minimum_data: dict):

--- a/tests/config/test_inference_model.py
+++ b/tests/config/test_inference_model.py
@@ -16,25 +16,25 @@ def test_wrong_extensions(minimum_inference: dict, ext: str):
 def test_mean_std_both_specified_or_none(minimum_inference: dict):
     """Test error raising when setting mean and std."""
     # Errors if both are None
-    minimum_inference["image_mean"] = []
-    minimum_inference["image_std"] = []
+    minimum_inference["image_means"] = []
+    minimum_inference["image_stds"] = []
     with pytest.raises(ValueError):
         InferenceConfig(**minimum_inference)
 
     # Error if only mean is defined
-    minimum_inference["image_mean"] = [10.4]
+    minimum_inference["image_means"] = [10.4]
     with pytest.raises(ValueError):
         InferenceConfig(**minimum_inference)
 
     # Error if only std is defined
-    minimum_inference.pop("image_mean")
-    minimum_inference["image_std"] = [10.4]
+    minimum_inference.pop("image_means")
+    minimum_inference["image_stds"] = [10.4]
     with pytest.raises(ValueError):
         InferenceConfig(**minimum_inference)
 
     # No error if both are specified
-    minimum_inference["image_mean"] = [10.4]
-    minimum_inference["image_std"] = [10.4]
+    minimum_inference["image_means"] = [10.4]
+    minimum_inference["image_stds"] = [10.4]
     InferenceConfig(**minimum_inference)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,8 +116,8 @@ def minimum_inference() -> dict:
     predic = {
         "data_type": SupportedData.ARRAY.value,
         "axes": "YX",
-        "image_mean": [2.0],
-        "image_std": [1.0],
+        "image_means": [2.0],
+        "image_stds": [1.0],
     }
 
     return predic

--- a/tests/dataset/test_in_memory_pred_dataset.py
+++ b/tests/dataset/test_in_memory_pred_dataset.py
@@ -45,8 +45,8 @@ def test_correct_normalized_outputs(shape, axes, expected_shape):
     config = InferenceConfig(
         data_type="array",
         axes=axes,
-        image_mean=[np.mean(array)] * n_channels,
-        image_std=[np.std(array)] * n_channels,
+        image_means=[np.mean(array)] * n_channels,
+        image_stds=[np.std(array)] * n_channels,
     )
 
     # create dataset

--- a/tests/dataset/test_in_memory_tiled_pred_dataset.py
+++ b/tests/dataset/test_in_memory_tiled_pred_dataset.py
@@ -57,8 +57,8 @@ def test_correct_normalized_outputs(shape, axes, expected_shape):
     config = InferenceConfig(
         data_type="array",
         axes=axes,
-        image_mean=[np.mean(array)] * n_channels,
-        image_std=[np.std(array)] * n_channels,
+        image_means=[np.mean(array)] * n_channels,
+        image_stds=[np.std(array)] * n_channels,
         tile_size=tile_size,
         tile_overlap=tile_overlap,
     )

--- a/tests/dataset/test_iterable_dataset.py
+++ b/tests/dataset/test_iterable_dataset.py
@@ -183,5 +183,7 @@ def test_compute_mean_std_transform_iterable(
 
     axes = tuple(np.delete(np.arange(stacked_array.ndim), 1))
 
-    assert np.array_equal(stacked_array.mean(axis=axes), dataset.data_config.image_mean)
-    assert np.array_equal(stacked_array.std(axis=axes), dataset.data_config.image_std)
+    assert np.array_equal(
+        stacked_array.mean(axis=axes), dataset.data_config.image_means
+    )
+    assert np.array_equal(stacked_array.std(axis=axes), dataset.data_config.image_stds)

--- a/tests/dataset/test_iterable_pred_dataset.py
+++ b/tests/dataset/test_iterable_pred_dataset.py
@@ -54,8 +54,8 @@ def test_correct_normalized_outputs(tmp_path, n_files, shape, axes, expected_sha
     config = InferenceConfig(
         data_type="tiff",
         axes=axes,
-        image_mean=[np.mean(array)] * n_channels,
-        image_std=[np.std(array)] * n_channels,
+        image_means=[np.mean(array)] * n_channels,
+        image_stds=[np.std(array)] * n_channels,
     )
 
     files = []

--- a/tests/dataset/test_iterable_tiled_pred_dataset.py
+++ b/tests/dataset/test_iterable_tiled_pred_dataset.py
@@ -66,8 +66,8 @@ def test_correct_normalized_outputs(tmp_path, n_files, shape, axes, expected_sha
     config = InferenceConfig(
         data_type="tiff",
         axes=axes,
-        image_mean=[np.mean(array)] * n_channels,
-        image_std=[np.std(array)] * n_channels,
+        image_means=[np.mean(array)] * n_channels,
+        image_stds=[np.std(array)] * n_channels,
         tile_size=tile_size,
         tile_overlap=tile_overlap,
     )

--- a/tests/test_careamist.py
+++ b/tests/test_careamist.py
@@ -663,8 +663,8 @@ def test_predict_pretrained_checkpoint(tmp_path: Path, pre_trained: Path):
 
     # instantiate CAREamist
     careamist = CAREamist(source=pre_trained, work_dir=tmp_path)
-    assert careamist.cfg.data_config.image_mean is not None
-    assert careamist.cfg.data_config.image_std is not None
+    assert careamist.cfg.data_config.image_means is not None
+    assert careamist.cfg.data_config.image_stds is not None
 
     # predict
     predicted = careamist.predict(source_array)

--- a/tests/test_lightning_prediction_datamodule.py
+++ b/tests/test_lightning_prediction_datamodule.py
@@ -37,8 +37,8 @@ def test_wrapper_unknown_type(simple_array):
         PredictDataWrapper(
             pred_data=simple_array,
             data_type="wrong_type",
-            image_mean=[0.5],
-            image_std=[0.1],
+            image_means=[0.5],
+            image_stds=[0.1],
             axes="YX",
             batch_size=2,
         )
@@ -50,8 +50,8 @@ def test_wrapper_instantiated_with_tiling(simple_array):
     data_module = PredictDataWrapper(
         pred_data=simple_array,
         data_type="array",
-        image_mean=[0.5],
-        image_std=[0.1],
+        image_means=[0.5],
+        image_stds=[0.1],
         axes="YX",
         batch_size=2,
         tile_overlap=[2, 2],
@@ -69,8 +69,8 @@ def test_wrapper_instantiated_without_tiling(simple_array):
     data_module = PredictDataWrapper(
         pred_data=simple_array,
         data_type="array",
-        image_mean=[0.5],
-        image_std=[0.1],
+        image_means=[0.5],
+        image_stds=[0.1],
         axes="YX",
         batch_size=2,
     )


### PR DESCRIPTION
### Description

Small PR, we have `image_means` and `image_stds` throughout all the code except in the Pydantic model, so I added the plural back into the name.

Since it is a list, it makes sense to me.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)