### PR TITLE
(Fix)  Upper versions for numpy, zarr and skimage deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     'pydantic>=2.5',
     'pytorch_lightning>=2.2.0',
     'pyyaml',
-    'scikit-image',
+    'scikit-image<=0.23.2',
     'zarr<3.0.0',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
+    'numpy<2.0.0',
     'torch>=2.0.0',
     'bioimageio.core>=0.6.0',
     'tifffile',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     'pytorch_lightning>=2.2.0',
     'pyyaml',
     'scikit-image',
-    'zarr',
+    'zarr<3.0.0',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Description

CI started to fail following a wave of pre-releases (skimage, zarr) and new versions (numpy). This PR fixes the versions.

- **What**: Setting upper version for numpy, zarr, and skimage.
- **Why**: Current code base is not compatible with the new pre-releases.
- **How**: Deps versions in `pyproject.toml`.


### Related Issues

- **Fixes**: https://github.com/CAREamics/careamics/issues/151


### Changes Made

- **Modified**: `zarr` and `skimage` dependencies version.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [x] PR to the documentation exists (for bug fixes / features)