### PR TITLE
Fix: stitch multiple tiled prediction outputs

### DIFF
--- a/src/careamics/prediction_utils/stitch_prediction.py
+++ b/src/careamics/prediction_utils/stitch_prediction.py
@@ -37,7 +37,9 @@ def stitch_prediction(
     last_tiles = [tile_info.last_tile for tile_info in tile_infos]
     last_tile_position = np.where(last_tiles)[0]
     image_slices = [
-        slice(None if i == 0 else last_tile_position[i - 1], last_tile_position[i] + 1)
+        slice(
+            None if i == 0 else last_tile_position[i - 1] + 1, last_tile_position[i] + 1
+        )
         for i in range(len(last_tile_position))
     ]
     image_predictions = []


### PR DESCRIPTION
### Description

Fixes a bug with stitching multiple prediction outputs

- **What**: There was a mistake when splitting tiles into groups for their respective images. This only became a problem with > 1 images.
- **How**: Very simple fix; a last tile from the previous group was being added to the next. Just needed to +1 to the index.

### Changes Made

- **Modified**: `stitch_prediction` function. +1 to index when creating `image_slices`.

### Related Issues

- Fixes #162 

### Additional Notes and Examples

I did not an extra test because I think they are added in #161


---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)