### PR TITLE
Feature: Use current weights for prediction

### DIFF
--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -493,10 +493,7 @@ class CAREamist:
 
     @overload
     def predict(  # numpydoc ignore=GL08
-        self,
-        source: CAREamicsPredictData,
-        *,
-        checkpoint: Optional[Literal["best", "last"]] = None,
+        self, source: CAREamicsPredictData
     ) -> Union[list[NDArray], NDArray]: ...
 
     @overload
@@ -513,7 +510,6 @@ class CAREamist:
         dataloader_params: Optional[dict] = None,
         read_source_func: Optional[Callable] = None,
         extension_filter: str = "",
-        checkpoint: Optional[Literal["best", "last"]] = None,
     ) -> Union[list[NDArray], NDArray]: ...
 
     @overload
@@ -528,7 +524,6 @@ class CAREamist:
         data_type: Optional[Literal["array"]] = None,
         tta_transforms: bool = True,
         dataloader_params: Optional[dict] = None,
-        checkpoint: Optional[Literal["best", "last"]] = None,
     ) -> Union[list[NDArray], NDArray]: ...
 
     def predict(
@@ -544,7 +539,6 @@ class CAREamist:
         dataloader_params: Optional[dict] = None,
         read_source_func: Optional[Callable] = None,
         extension_filter: str = "",
-        checkpoint: Optional[Literal["best", "last"]] = None,
         **kwargs: Any,
     ) -> Union[list[NDArray], NDArray]:
         """
@@ -590,8 +584,6 @@ class CAREamist:
             Function to read the source data.
         extension_filter : str, default=""
             Filter for the file extension.
-        checkpoint : {"best", "last"}, optional
-            Checkpoint to use for prediction.
         **kwargs : Any
             Unused.
 
@@ -623,7 +615,7 @@ class CAREamist:
         )
 
         predictions = self.trainer.predict(
-            model=self.model, datamodule=self.pred_datamodule, ckpt_path=checkpoint
+            model=self.model, datamodule=self.pred_datamodule
         )
         return convert_outputs(predictions, self.pred_datamodule.tiled)
 


### PR DESCRIPTION
### Description

Currently, we pass both `model` and `checkpoint` to `trainer.predict`. My understanding of the [docs](https://lightning.ai/docs/pytorch/stable/common/trainer.html#predict) is that `checkpoint` takes precedence.

It is not clear what model is the best to use (`last` vs `best`), especially in the context of Noise2Void. In order to avoid a behaviour that has not be clarified and described, this PR removes the `checkpoint` parameter altogether.

In the future, we might want to revisit that. Currently, we would advocate letting users configure the checkpoint callback and then load the correct weights themselves.

- **What**: Remove `checkpoint` parameter from `careamist.predict`.
- **Why**: Clarify which weights are used (in this case, the current ones).
- **How**: Remove the parameter from the `predict` function signature, and from the call to the `trainer`.

### Changes Made


- **Modified**: `careamist.py`.


---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)