### PR TITLE
Feature: Add an autocorrelation utility function

### DIFF
--- a/src/careamics/utils/__init__.py
+++ b/src/careamics/utils/__init__.py
@@ -7,9 +7,11 @@ __all__ = [
     "BaseEnum",
     "get_logger",
     "get_careamics_home",
+    "autocorrelation",
 ]
 
 
+from .autocorrelation import autocorrelation
 from .base_enum import BaseEnum
 from .context import cwd, get_careamics_home
 from .logging import get_logger

--- a/src/careamics/utils/autocorrelation.py
+++ b/src/careamics/utils/autocorrelation.py
@@ -1,0 +1,40 @@
+"""Autocorrelation function."""
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def autocorrelation(image: NDArray) -> NDArray:
+    """Compute the autocorrelation of an image.
+
+    This method is used to explore spatial correlations in images,
+    in particular in the noise.
+
+    The autocorrelation is normalized to the zero-shift value, which is centered in
+    the resulting images.
+
+    Parameters
+    ----------
+    image : NDArray
+        Input image.
+
+    Returns
+    -------
+    numpy.ndarray
+        Autocorrelation of the input image.
+    """
+    # normalize image
+    image = (image - np.mean(image)) / np.std(image)
+
+    # compute autocorrelation in fourier space
+    image = np.fft.fftn(image)
+    image = np.abs(image) ** 2
+    image = np.fft.ifftn(image).real
+
+    # normalize to zero shift value
+    image = image / image.flat[0]
+
+    # shift zero frequency to center
+    image = np.fft.fftshift(image)
+
+    return image

--- a/tests/utils/test_autocorrelation.py
+++ b/tests/utils/test_autocorrelation.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from careamics.utils import autocorrelation
+
+
+def test_autocorrelation():
+    """Test that the autocorrelation is normalized to the zero-shift value and that this
+    value is centered."""
+    rng = np.random.default_rng(42)
+
+    # create a random image
+    image = rng.random((5, 5))
+    center = 2
+
+    # compute autocorrelation
+    autocorr = autocorrelation(image)
+    assert autocorr.shape == image.shape
+
+    # check that the max value is 1
+    assert np.isclose(autocorr.max(), 1.0, atol=1e-6)
+
+    # check that the zero-shift value is 1
+    assert np.isclose(autocorr[center, center], 1.0, atol=1e-6)
+
+
+def test_correlation():
+    """Test the autocorrelation of an image with bands."""
+    image = np.zeros((10, 10))
+    for i in range(image.shape[0]):
+        if i % 2 == 0:
+            image[i] = 1
+
+    # compute autocorrelation
+    autocorr = autocorrelation(image)
+    assert autocorr.shape == image.shape
+
+    # check that each band maximizes the autocorrelation
+    for i in range(autocorr.shape[0]):
+        if i % 2 == 0:
+            assert np.allclose(autocorr[i], -1.0)
+        else:
+            assert np.allclose(autocorr[i], 1.0)


### PR DESCRIPTION
### Description

To check whether there are noise correlation, we often inspect the auto-correlation of an image. This PR adds an `autocorrelation` method to CAREamics, which can be used in our example notebooks.

The autocorrelation is performed in fourier space on a normalized image, and is returned as a normalized autocorrelation where the zero-shift value is on the center of the array.

- **What**: Add an image autorrelation function.
- **Why**: Allow users to easily inspect noise correlations.
- **How**:  Implemented `careamics.utils.autocorrelation`.

### Changes Made

- **Added**: `careamics.utils.autocorrelation` and the corresponding tests.

### Additional Notes and Examples

```python
from careamics.utils import autocorrelation

rng = np.random.default_rng(42)
image = rng.random((5, 5))

# compute autocorrelation
autocorr = autocorrelation(image)
```

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)