### PR TITLE
Chore: Exclude lvae training from coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           python -m pip install .[dev] ${{ github.event_name == 'schedule' && '--pre' || ''  }}
 
       - name: 🧪 Run Tests
-        run: pytest --color=yes --cov --cov-report=xml --cov-report=term-missing
+        run: pytest --color=yes --cov --cov-config=pyproject.toml --cov-report=xml --cov-report=term-missing 
 
       # If something goes wrong with --pre tests, we can open an issue in the repo
       - name: 📝 Report --pre Failures

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           python -m pip install .[dev] ${{ github.event_name == 'schedule' && '--pre' || ''  }}
 
       - name: 🧪 Run Tests
-        run: pytest --color=yes --cov --cov-config=.coveragerc --cov-report=xml --cov-report=term-missing
+        run: pytest --color=yes --cov --cov-report=xml --cov-report=term-missing
 
       # If something goes wrong with --pre tests, we can open an issue in the repo
       - name: 📝 Report --pre Failures

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           python -m pip install .[dev] ${{ github.event_name == 'schedule' && '--pre' || ''  }}
 
       - name: 🧪 Run Tests
-        run: pytest --color=yes --cov --cov-report=xml --cov-report=term-missing -m "not gpu"
+        run: pytest --color=yes --cov --cov-config=.coveragerc --cov-report=xml --cov-report=term-missing
 
       # If something goes wrong with --pre tests, we can open an issue in the repo
       - name: 📝 Report --pre Failures

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,170 @@
 .vscode
-*__pycache__
-.pytest*
-*.DS_Store*
+*.DS_Store
+**/.DS_Store
 **/.ipynb_checkpoints
+
+# torch related
+**/lightning_logs
+**/*.ckpt
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+**/__pycache__
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
 .coverage
+.coverage.*
+.cache
+nosetests.xml
 coverage.xml
-lightning_logs
-.mypy_cache
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.pytest*
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+**/.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# ruff
+.ruff_cache
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,14 +145,13 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "@overload",
     "except ImportError",
-    "\\.\\.\\.",
     "raise NotImplementedError()",
     "except PackageNotFoundError:",
 ]
 
 [tool.coverage.run]
-source = ["careamics"]
-omit = ["careamics/lvae_training/*"]
+source = ["src/careamics"]
+omit = ["src/careamics/lvae_training/*"]
 
 # https://github.com/mgedmin/check-manifest#configuration
 # add files that you want check-manifest to explicitly ignore here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,11 +137,11 @@ filterwarnings = [
 ]
 addopts = "-p no:doctest"
 
-markers = ["gpu: marks tests as requiring gpu"]
+#markers = ["gpu: marks tests as requiring gpu"]
+
 # https://coverage.readthedocs.io/en/6.4/config.html
 [tool.coverage.report]
 exclude_lines = [
-    "pragma: no cover",
     "if TYPE_CHECKING:",
     "@overload",
     "except ImportError",
@@ -152,6 +152,7 @@ exclude_lines = [
 
 [tool.coverage.run]
 source = ["careamics"]
+omit = ["careamics/lvae_training/*"]
 
 # https://github.com/mgedmin/check-manifest#configuration
 # add files that you want check-manifest to explicitly ignore here
@@ -179,4 +180,5 @@ checks = [
 ]
 exclude = [ # don't report on objects that match any of these regex
     "test_*",
+    "src/careamics/lvae_training/*",
 ]


### PR DESCRIPTION
### Description

Currently our coverage went down due to the introduction of the parallel code used to train the LVAE. Since this code is not supposed to be used by users, I kicked it out from the coverage.

Note that before that the coverage was not using the parameters in `pyproject.toml`, so this PR actually fixes the parametrization of codecov.

A reworking of `.gitignore` snuck in.

### Changes Made

- **Modified**: ci, `pyproject.toml`, and `.gitignore`.

### Related Issues

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)