### PR TITLE
Feature: Prediction writer callback initialisation

### DIFF
--- a/src/careamics/file_io/__init__.py
+++ b/src/careamics/file_io/__init__.py
@@ -1,7 +1,14 @@
 """Functions relating reading and writing image files."""
 
-__all__ = ["read", "write", "get_read_func", "get_write_func"]
+__all__ = [
+    "read",
+    "write",
+    "get_read_func",
+    "get_write_func",
+    "ReadFunc",
+    "WriteFunc",
+]
 
 from . import read, write
-from .read import get_read_func, ReadFunc
-from .write import get_write_func, WriteFunc
+from .read import ReadFunc, get_read_func
+from .write import WriteFunc, get_write_func

--- a/src/careamics/file_io/__init__.py
+++ b/src/careamics/file_io/__init__.py
@@ -3,5 +3,5 @@
 __all__ = ["read", "write", "get_read_func", "get_write_func"]
 
 from . import read, write
-from .read import get_read_func
-from .write import get_write_func
+from .read import get_read_func, ReadFunc
+from .write import get_write_func, WriteFunc

--- a/src/careamics/file_io/read/__init__.py
+++ b/src/careamics/file_io/read/__init__.py
@@ -4,8 +4,9 @@ __all__ = [
     "get_read_func",
     "read_tiff",
     "read_zarr",
+    "ReadFunc",
 ]
 
-from .get_func import get_read_func
+from .get_func import ReadFunc, get_read_func
 from .tiff import read_tiff
 from .zarr import read_zarr

--- a/src/careamics/file_io/write/__init__.py
+++ b/src/careamics/file_io/write/__init__.py
@@ -3,7 +3,8 @@
 __all__ = [
     "get_write_func",
     "write_tiff",
+    "WriteFunc"
 ]
 
-from .get_func import get_write_func
+from .get_func import get_write_func, WriteFunc
 from .tiff import write_tiff

--- a/src/careamics/file_io/write/__init__.py
+++ b/src/careamics/file_io/write/__init__.py
@@ -1,10 +1,6 @@
 """Functions relating to writing image files of different formats."""
 
-__all__ = [
-    "get_write_func",
-    "write_tiff",
-    "WriteFunc"
-]
+__all__ = ["get_write_func", "write_tiff", "WriteFunc"]
 
-from .get_func import get_write_func, WriteFunc
+from .get_func import WriteFunc, get_write_func
 from .tiff import write_tiff

--- a/src/careamics/file_io/write/tiff.py
+++ b/src/careamics/file_io/write/tiff.py
@@ -10,6 +10,7 @@ from careamics.config.support import SupportedData
 
 
 def write_tiff(file_path: Path, img: NDArray, *args, **kwargs) -> None:
+    # TODO: add link to tiffile docs for args kwrgs?
     """
     Write tiff files.
 

--- a/src/careamics/lightning/callbacks/__init__.py
+++ b/src/careamics/lightning/callbacks/__init__.py
@@ -1,6 +1,7 @@
 """Callbacks module."""
 
-__all__ = ["HyperParametersCallback", "ProgressBarCallback"]
+__all__ = ["HyperParametersCallback", "ProgressBarCallback", "PredictionWriterCallback",]
 
 from .hyperparameters_callback import HyperParametersCallback
 from .progress_bar_callback import ProgressBarCallback
+from .prediction_writer_callback import PredictionWriterCallback

--- a/src/careamics/lightning/callbacks/__init__.py
+++ b/src/careamics/lightning/callbacks/__init__.py
@@ -1,7 +1,11 @@
 """Callbacks module."""
 
-__all__ = ["HyperParametersCallback", "ProgressBarCallback", "PredictionWriterCallback",]
+__all__ = [
+    "HyperParametersCallback",
+    "ProgressBarCallback",
+    "PredictionWriterCallback",
+]
 
 from .hyperparameters_callback import HyperParametersCallback
-from .progress_bar_callback import ProgressBarCallback
 from .prediction_writer_callback import PredictionWriterCallback
+from .progress_bar_callback import ProgressBarCallback

--- a/src/careamics/lightning/callbacks/prediction_writer_callback.py
+++ b/src/careamics/lightning/callbacks/prediction_writer_callback.py
@@ -1,3 +1,5 @@
+"""Module containing PredictionWriterCallback class."""
+
 from typing import Union, Optional, Any
 from pathlib import Path
 
@@ -159,9 +161,10 @@ class PredictionWriterCallback(BasePredictionWriter):
                     "A save extension must be provided for custom data types."
                 )
             else:
-                self.save_func = save_extension
+                self.save_extension = save_extension
         else:
-            self.save_func = self.save_type.get_extension()
+            # kind of a weird pattern -> reason to move get_extension from SupportedData
+            self.save_extension = self.save_type.get_extension(self.save_type)
 
     def setup(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
         """
@@ -176,5 +179,5 @@ class PredictionWriterCallback(BasePredictionWriter):
                 logger.info("Making prediction output directory.")
                 self.dirpath.mkdir()
 
-        
+    # TODO: write hook placeholders with TODO comments 
 

--- a/src/careamics/lightning/callbacks/prediction_writer_callback.py
+++ b/src/careamics/lightning/callbacks/prediction_writer_callback.py
@@ -1,0 +1,139 @@
+from typing import Union, Optional, Any
+from pathlib import Path
+
+from pytorch_lightning import Trainer, LightningModule
+from pytorch_lightning.callbacks import BasePredictionWriter
+
+from careamics.config.support import SupportedData
+from careamics.file_io import get_write_func, WriteFunc
+from careamics.utils import get_logger
+
+logger = get_logger(__name__)
+
+class PredictionWriterCallback(BasePredictionWriter):
+    """
+    A PyTorch Lightning callback to save predictions.
+
+    Attributes
+    ----------
+    save_predictions: bool
+        A toggle to optionally switch off prediction saving.
+    save_type: SupportedData
+        The data type of the saved data.
+    save_func: WriteFunc
+        The function for saving data.
+    save_extension: str
+        The extension that will be added to the save paths.
+    save_func_kwargs: dict of {str, any}
+        Additional keyword arguments that will be passed to the save function.
+    dirpath: pathlib.Path
+        The path to the directory where prediction outputs will be saved.
+    """
+    
+    def __init__(
+            self,
+            save_type: Union[SupportedData, str]="tiff",
+            save_func: Optional[WriteFunc]=None,
+            save_extension: Optional[str]=None,
+            save_func_kwargs: Optional[dict[str, Any]]=None,
+            dirpath: Union[Path, str]="predictions"
+        ):
+        """
+        A PyTorch Lightning callback to save predictions.
+
+        Parameters
+        ----------
+        save_type: SupportedData or str, default="tiff"
+            The data type to save as, includes custom.
+        save_func: WriteFunc, optional
+            If a known `save_type` is selected this argument is ignored. For a custom
+            `save_type` a function to save the data must be passed. See notes below.
+        save_extension: str, optional
+            If a known `save_type` is selected this argument is ignored. For a custom
+            `save_type` an extension to save the data with must be passed.
+        save_func_kwargs: dict of {str: any}, optional
+            Additional keyword arguments to be passed to the save function.
+        dirpath : pathlib.Path or str, default="predictions"
+            Directory to save outputs to. If `dirpath is not absolute it is assumed to 
+            be relative to current working directory. Nested directories will not be 
+            automatically created.
+
+        Notes
+        -----
+        The `save_func` function signature must match that of the example below
+            ```
+            save_func(file_path: Path, img: NDArray, *args, **kwargs) -> None: ...
+            ```
+
+        The `save_func_kwargs` will be passed to the `save_func` doing the following:
+            ```
+            save_func(file_path=file_path, img=img, **kwargs)
+            ```
+        """
+        # TODO: look into write_interval; how tile caching should work, remember zarr !
+        super().__init__(write_interval='epoch')
+
+        # Toggle for CAREamist to switch off saving if desired
+        self.save_predictions: bool = True
+
+        self.save_type: SupportedData = SupportedData(save_type)
+        self.save_func_kwargs = save_func_kwargs
+
+        # forward declarations 
+        self.dirpath: Path
+        self.save_func: WriteFunc
+        self.save_extension: str
+        # attribute initialisation
+        self._init_dirpath(dirpath)
+        self._init_save_func(save_func)
+        self._init_save_extension(save_extension)
+
+    def _init_dirpath(self, dirpath):
+        dirpath = Path(dirpath)
+        if not dirpath.is_absolute():
+            dirpath = Path.cwd() / dirpath
+            logger.warning(
+                "Prediction output directory is not absolute, absolute path assumed to"
+                f"be '{dirpath}'"
+
+            )
+        self.dirpath = dirpath    
+
+    def _init_save_func(self, save_func: Optional[WriteFunc]):
+        if self.save_type == SupportedData.CUSTOM:
+            if save_func is None:
+                raise ValueError(
+                    "A save function must be provided for custom data types."
+                    # TODO: link to how save functions should be implemented 
+                )
+            else:
+                self.save_func = save_func
+        else:
+            self.save_func = get_write_func(self.save_type)
+
+    def _init_save_extension(self, save_extension: Optional[str]):
+        if self.save_type == SupportedData.CUSTOM:
+            if save_extension is None:
+                raise ValueError(
+                    "A save extension must be provided for custom data types."
+                )
+            else:
+                self.save_func = save_extension
+        else:
+            self.save_func = self.save_type.get_extension()
+
+    def setup(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
+        """
+        Will create the prediction output directory when predict begins.
+        
+        Called when fit, validate, test, predict, or tune begins.
+        """
+        super().setup(trainer, pl_module, stage)
+        if stage == "predict":
+            # make prediction output directory
+            if not self.dirpath.is_dir():
+                logger.info("Making prediction output directory.")
+                self.dirpath.mkdir()
+
+        
+

--- a/src/careamics/lightning/callbacks/prediction_writer_callback.py
+++ b/src/careamics/lightning/callbacks/prediction_writer_callback.py
@@ -58,6 +58,13 @@ class PredictionWriterCallback(BasePredictionWriter):
             be relative to current working directory. Nested directories will not be 
             automatically created.
 
+        Raises
+        ------
+        ValueError
+            If `save_type="custom"` but `save_func` has not been given.
+        ValueError
+            If `save_type="custom"` but `save_extension` has not been given.
+
         Notes
         -----
         The `save_func` function signature must match that of the example below
@@ -89,6 +96,14 @@ class PredictionWriterCallback(BasePredictionWriter):
         self._init_save_extension(save_extension)
 
     def _init_dirpath(self, dirpath):
+        """
+        Initialize directory path. Should only be called from `__init__`.
+
+        Parameters
+        ----------
+        dirpath : pathlib.Path
+            See `__init__` description.
+        """
         dirpath = Path(dirpath)
         if not dirpath.is_absolute():
             dirpath = Path.cwd() / dirpath
@@ -100,6 +115,19 @@ class PredictionWriterCallback(BasePredictionWriter):
         self.dirpath = dirpath    
 
     def _init_save_func(self, save_func: Optional[WriteFunc]):
+        """
+        Initialize save function. Should only be called from `__init__`.
+
+        Parameters
+        ----------
+        save_func : WriteFunc, optional
+            See `__init__` description.
+
+        Raises
+        ------
+        ValueError
+            If `self.save_type="custom"` but `save_func` has not been given.
+        """
         if self.save_type == SupportedData.CUSTOM:
             if save_func is None:
                 raise ValueError(
@@ -112,6 +140,19 @@ class PredictionWriterCallback(BasePredictionWriter):
             self.save_func = get_write_func(self.save_type)
 
     def _init_save_extension(self, save_extension: Optional[str]):
+        """
+        Initialize save extension. Should only be called from `__init__`.
+
+        Parameters
+        ----------
+        save_extension : str, optional
+            See `__init__` description.
+
+        Raises
+        ------
+        ValueError
+            If `self.save_type="custom"` but `save_extension` has not been given.
+        """
         if self.save_type == SupportedData.CUSTOM:
             if save_extension is None:
                 raise ValueError(

--- a/tests/lightning/callbacks/test_prediction_writer_callback.py
+++ b/tests/lightning/callbacks/test_prediction_writer_callback.py
@@ -1,17 +1,19 @@
 """Test PredictionWriterCallback class."""
+
 from pathlib import Path
 
 import numpy as np
-from numpy.typing import NDArray
 import pytest
+from numpy.typing import NDArray
 
-from careamics.lightning.callbacks import PredictionWriterCallback
 from careamics.file_io.write import write_tiff
-from careamics.config.support import SupportedData
+from careamics.lightning.callbacks import PredictionWriterCallback
+
 
 def save_numpy(file_path: Path, img: NDArray, *args, **kwargs) -> None:
     """Example custom save function."""
     np.save(file_path, img, *args, **kwargs)
+
 
 def test_init_tiff():
     """Test PredictionWriterCallback initialization with `save_type=="tiff"`"""

--- a/tests/lightning/callbacks/test_prediction_writer_callback.py
+++ b/tests/lightning/callbacks/test_prediction_writer_callback.py
@@ -1,0 +1,38 @@
+"""Test PredictionWriterCallback class."""
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+import pytest
+
+from careamics.lightning.callbacks import PredictionWriterCallback
+from careamics.file_io.write import write_tiff
+from careamics.config.support import SupportedData
+
+def save_numpy(file_path: Path, img: NDArray, *args, **kwargs) -> None:
+    """Example custom save function."""
+    np.save(file_path, img, *args, **kwargs)
+
+def test_init_tiff():
+    """Test PredictionWriterCallback initialization with `save_type=="tiff"`"""
+    pwc = PredictionWriterCallback(save_type="tiff")
+    assert pwc.save_func is write_tiff
+    assert pwc.save_extension == ".tiff"
+
+
+@pytest.mark.parametrize("save_func", [None, save_numpy])
+@pytest.mark.parametrize("save_extension", [None, ".npy"])
+def test_init_custom(save_func, save_extension):
+    """Test PredictionWriterCallback initialization with `save_type=="custom"`"""
+    # Test ValueError raised with save_func or save_extension = None
+    if (save_func is None) or (save_extension is None):
+        with pytest.raises(ValueError):
+            pwc = PredictionWriterCallback(
+                save_type="custom", save_func=save_func, save_extension=save_extension
+            )
+        return
+    pwc = PredictionWriterCallback(
+        save_type="custom", save_func=save_func, save_extension=save_extension
+    )
+    assert pwc.save_func is save_numpy
+    assert pwc.save_extension == ".npy"


### PR DESCRIPTION
### Description

Add the skeleton and initialisation of the `PredictionWriterCallback` class, to allow users to save predictions to disk in the future. This callback will be used by the `CAREamist` class but should also be compatible with users preferring to use the internal `lightning` API.

- **What**: 
  - Add `PredictionWriterCallback` class.
  - Implement `PredictionWriterCallback.__init__` method.
  - Add placeholder for `write_on_batch_end` hook, with docstring description of what is coming.
  - Implement `setup` hook that will create the prediction output directory when the `lightning` predict stage starts.
  - Tests for `PredictionWriterCallback.__init__`.
- **Why**: 
  - This callback will be used to save predictions to disk, this is a feature in the works for a while. This will also allow the predict command to be implemented in the CLI.

### Changes Made

- **Added**: 
  - `PredictionWriterCallback` class to the `lightning.callbacks` package.
  - Tests for the initialisation of `PredictionWriterCallback`.
- **Modified**: 
  - Package/sub-package level imports (__init__.py files.)

### Additional Notes and Examples

#### Future considerations

- There will have to be a method to update `save_type`, `save_extension`, `save_func` & `save_func_kwargs` because in the `CAREamist` class they will be decided after the initialisation of `PredictionWriterCallback`. The `CAREamist` class will have a `predict_to_disk` method that where users can pass these parameters, but the `PredictionWriterCallback` will have to be initialised during `CAREamist` initialisation because it needs to be passed to the trainer.
- For tiling/not tiling & tile caching/writing tiles directly to disk (`zarr`). I want to follow a [strategy pattern](https://refactoring.guru/design-patterns/strategy) so `PredictionWriterCallback` will interact with a strategy interface and it's only responsibility will be to select the correct one.
- As mentioned in the description, this callback should be easily usable by both the `CAREamist` class and users who are using the `lightning` API.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)