### PR TITLE
Chore: Bump ruff target python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: ruff
         exclude: "^src/careamics/lvae_training/.*|^src/careamics/models/lvae/.*"
-        args: [--fix, --target-version, py38]
+        args: [--fix, --target-version, py39]
 
   - repo: https://github.com/psf/black
     rev: 24.4.2
@@ -41,7 +41,7 @@ repos:
     rev: v1.7.0
     hooks:
       - id: numpydoc-validation
-        exclude: "^src/careamics/lvae_training/.*|^src/careamics/models/lvae/.*"      
+        exclude: "^src/careamics/lvae_training/.*|^src/careamics/models/lvae/.*"
 
   # # jupyter linting and formatting
   # - repo: https://github.com/nbQA-dev/nbQA

--- a/src/careamics/config/architectures/architecture_model.py
+++ b/src/careamics/config/architectures/architecture_model.py
@@ -1,6 +1,6 @@
 """Base model for the various CAREamics architectures."""
 
-from typing import Any, Dict
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -15,7 +15,7 @@ class ArchitectureModel(BaseModel):
     architecture: str
     """Name of the architecture."""
 
-    def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
         """
         Dump the model as a dictionary, ignoring the architecture keyword.
 

--- a/src/careamics/config/configuration_factory.py
+++ b/src/careamics/config/configuration_factory.py
@@ -1,6 +1,6 @@
 """Convenience functions to create configurations for training and inference."""
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal, Optional
 
 from .algorithm_model import AlgorithmConfig
 from .architectures import UNetModel
@@ -21,7 +21,7 @@ def _create_supervised_configuration(
     experiment_name: str,
     data_type: Literal["array", "tiff", "custom"],
     axes: str,
-    patch_size: List[int],
+    patch_size: list[int],
     batch_size: int,
     num_epochs: int,
     use_augmentations: bool = True,
@@ -37,15 +37,15 @@ def _create_supervised_configuration(
 
     Parameters
     ----------
-    algorithm : Literal["care", "n2n"]
+    algorithm : {"n2v", "care", "n2n", "custom"}
         Algorithm to use.
     experiment_name : str
         Name of the experiment.
-    data_type : Literal["array", "tiff", "custom"]
+    data_type : {"array", "tiff", "custom"}
         Type of the data.
     axes : str
         Axes of the data (e.g. SYX).
-    patch_size : List[int]
+    patch_size : list of int
         Size of the patches along the spatial dimensions (e.g. [64, 64]).
     batch_size : int
         Batch size.
@@ -55,13 +55,13 @@ def _create_supervised_configuration(
         Whether to use augmentations, by default True.
     independent_channels : bool, optional
         Whether to train all channels independently, by default False.
-    loss : Literal["mae", "mse"], optional
+    loss : {"mae", "mse"}, optional
         Loss function to use, by default "mae".
     n_channels_in : int, optional
         Number of channels in, by default 1.
     n_channels_out : int, optional
         Number of channels out, by default 1.
-    logger : Literal["wandb", "tensorboard", "none"], optional
+    logger : {"wandb", "tensorboard", "none"}, optional
         Logger to use, by default "none".
     model_kwargs : dict, optional
         UNetModel parameters, by default {}.
@@ -105,7 +105,7 @@ def _create_supervised_configuration(
 
     # augmentations
     if use_augmentations:
-        transforms: List[Dict[str, Any]] = [
+        transforms: list[dict[str, Any]] = [
             {
                 "name": SupportedTransform.XY_FLIP.value,
             },
@@ -147,7 +147,7 @@ def create_care_configuration(
     experiment_name: str,
     data_type: Literal["array", "tiff", "custom"],
     axes: str,
-    patch_size: List[int],
+    patch_size: list[int],
     batch_size: int,
     num_epochs: int,
     use_augmentations: bool = True,
@@ -185,7 +185,7 @@ def create_care_configuration(
         Type of the data.
     axes : str
         Axes of the data (e.g. SYX).
-    patch_size : List[int]
+    patch_size : list of int
         Size of the patches along the spatial dimensions (e.g. [64, 64]).
     batch_size : int
         Batch size.
@@ -236,7 +236,7 @@ def create_n2n_configuration(
     experiment_name: str,
     data_type: Literal["array", "tiff", "custom"],
     axes: str,
-    patch_size: List[int],
+    patch_size: list[int],
     batch_size: int,
     num_epochs: int,
     use_augmentations: bool = True,
@@ -270,11 +270,11 @@ def create_n2n_configuration(
     ----------
     experiment_name : str
         Name of the experiment.
-    data_type : Literal["array", "tiff", "custom"]
+    data_type : {"array", "tiff", "custom"}
         Type of the data.
     axes : str
         Axes of the data (e.g. SYX).
-    patch_size : List[int]
+    patch_size : list of int
         Size of the patches along the spatial dimensions (e.g. [64, 64]).
     batch_size : int
         Batch size.
@@ -284,13 +284,13 @@ def create_n2n_configuration(
         Whether to use augmentations, by default True.
     independent_channels : bool, optional
         Whether to train all channels independently, by default False.
-    loss : Literal["mae", "mse"], optional
+    loss : {"mae", "mse"}, optional
         Loss function to use, by default "mae".
     n_channels_in : int, optional
         Number of channels in, by default 1.
     n_channels_out : int, optional
         Number of channels out, by default -1.
-    logger : Literal["wandb", "tensorboard", "none"], optional
+    logger : {"wandb", "tensorboard", "none"}, optional
         Logger to use, by default "none".
     model_kwargs : dict, optional
         UNetModel parameters, by default {}.
@@ -325,7 +325,7 @@ def create_n2v_configuration(
     experiment_name: str,
     data_type: Literal["array", "tiff", "custom"],
     axes: str,
-    patch_size: List[int],
+    patch_size: list[int],
     batch_size: int,
     num_epochs: int,
     use_augmentations: bool = True,
@@ -378,11 +378,11 @@ def create_n2v_configuration(
     ----------
     experiment_name : str
         Name of the experiment.
-    data_type : Literal["array", "tiff", "custom"]
+    data_type : {"array", "tiff", "custom"}
         Type of the data.
     axes : str
         Axes of the data (e.g. SYX).
-    patch_size : List[int]
+    patch_size : list of int
         Size of the patches along the spatial dimensions (e.g. [64, 64]).
     batch_size : int
         Batch size.
@@ -400,11 +400,11 @@ def create_n2v_configuration(
         N2V pixel manipulation area, by default 11.
     masked_pixel_percentage : float, optional
         Percentage of pixels masked in each patch, by default 0.2.
-    struct_n2v_axis : Literal["horizontal", "vertical", "none"], optional
+    struct_n2v_axis : {"horizontal", "vertical", "none"}, optional
         Axis along which to apply structN2V mask, by default "none".
     struct_n2v_span : int, optional
         Span of the structN2V mask, by default 5.
-    logger : Literal["wandb", "tensorboard", "none"], optional
+    logger : {"wandb", "tensorboard", "none"}, optional
         Logger to use, by default "none".
     model_kwargs : dict, optional
         UNetModel parameters, by default {}.
@@ -522,7 +522,7 @@ def create_n2v_configuration(
 
     # augmentations
     if use_augmentations:
-        transforms: List[Dict[str, Any]] = [
+        transforms: list[dict[str, Any]] = [
             {
                 "name": SupportedTransform.XY_FLIP.value,
             },

--- a/src/careamics/config/data_model.py
+++ b/src/careamics/config/data_model.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pprint import pformat
-from typing import Any, Literal, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
 from numpy.typing import NDArray
 from pydantic import (
@@ -14,7 +14,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from typing_extensions import Annotated, Self
+from typing_extensions import Self
 
 from .support import SupportedTransform
 from .transformations.n2v_manipulate_model import N2VManipulateModel

--- a/src/careamics/config/transformations/transform_model.py
+++ b/src/careamics/config/transformations/transform_model.py
@@ -1,6 +1,6 @@
 """Parent model for the transforms."""
 
-from typing import Any, Dict
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -23,7 +23,7 @@ class TransformModel(BaseModel):
 
     name: str
 
-    def model_dump(self, **kwargs) -> Dict[str, Any]:
+    def model_dump(self, **kwargs) -> dict[str, Any]:
         """
         Return the model as a dictionary.
 
@@ -34,7 +34,7 @@ class TransformModel(BaseModel):
 
         Returns
         -------
-        Dict[str, Any]
+        dict of {str: Any}
             Dictionary representation of the model.
         """
         model_dict = super().model_dump(**kwargs)

--- a/src/careamics/config/validators/validator_utils.py
+++ b/src/careamics/config/validators/validator_utils.py
@@ -4,7 +4,7 @@ Validator functions.
 These functions are used to validate dimensions and axes of inputs.
 """
 
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 _AXES = "STCZYX"
 
@@ -79,14 +79,14 @@ def value_ge_than_8_power_of_2(
 
 
 def patch_size_ge_than_8_power_of_2(
-    patch_list: Optional[Union[List[int], Union[Tuple[int, ...]]]],
+    patch_list: Optional[Union[list[int], Union[tuple[int, ...]]]],
 ) -> None:
     """
     Validate that each entry is greater or equal than 8 and a power of 2.
 
     Parameters
     ----------
-    patch_list : Optional[Union[List[int]]]
+    patch_list : list of int, optional
         Patch size.
 
     Raises

--- a/src/careamics/dataset/dataset_utils/dataset_utils.py
+++ b/src/careamics/dataset/dataset_utils/dataset_utils.py
@@ -1,7 +1,5 @@
 """Dataset utilities."""
 
-from typing import List, Tuple
-
 import numpy as np
 
 from careamics.utils.logging import get_logger
@@ -10,14 +8,14 @@ logger = get_logger(__name__)
 
 
 def _get_shape_order(
-    shape_in: Tuple[int, ...], axes_in: str, ref_axes: str = "STCZYX"
-) -> Tuple[Tuple[int, ...], str, List[int]]:
+    shape_in: tuple[int, ...], axes_in: str, ref_axes: str = "STCZYX"
+) -> tuple[tuple[int, ...], str, list[int]]:
     """
     Compute a new shape for the array based on the reference axes.
 
     Parameters
     ----------
-    shape_in : Tuple[int, ...]
+    shape_in : tuple of int
         Input shape.
     axes_in : str
         Input axes.
@@ -26,7 +24,7 @@ def _get_shape_order(
 
     Returns
     -------
-    Tuple[Tuple[int, ...], str, List[int]]
+    (tuple of int, str, list of int)
         New shape, new axes, indices of axes in the new axes order.
     """
     indices = [axes_in.find(k) for k in ref_axes]

--- a/src/careamics/dataset/dataset_utils/file_utils.py
+++ b/src/careamics/dataset/dataset_utils/file_utils.py
@@ -2,7 +2,7 @@
 
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 
 import numpy as np
 
@@ -12,12 +12,12 @@ from careamics.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-def get_files_size(files: List[Path]) -> float:
+def get_files_size(files: list[Path]) -> float:
     """Get files size in MB.
 
     Parameters
     ----------
-    files : List[Path]
+    files : list of pathlib.Path
         List of files.
 
     Returns
@@ -32,7 +32,7 @@ def list_files(
     data_path: Union[str, Path],
     data_type: Union[str, SupportedData],
     extension_filter: str = "",
-) -> List[Path]:
+) -> list[Path]:
     """List recursively files in `data_path` and return a sorted list.
 
     If `data_path` is a file, its name is validated against the `data_type` using
@@ -46,17 +46,17 @@ def list_files(
 
     Parameters
     ----------
-    data_path : Union[str, Path]
+    data_path : str or pathlib.Path
         Path to the folder containing the data.
-    data_type : Union[str, SupportedData]
+    data_type : str or SupportedData
         One of the supported data type (e.g. tif, custom).
     extension_filter : str, optional
         Extension filter, by default "".
 
     Returns
     -------
-    List[Path]
-        List of pathlib.Path objects.
+    List of pathlib.Path
+        List of file paths.
 
     Raises
     ------
@@ -105,7 +105,7 @@ def list_files(
     return files
 
 
-def validate_source_target_files(src_files: List[Path], tar_files: List[Path]) -> None:
+def validate_source_target_files(src_files: list[Path], tar_files: list[Path]) -> None:
     """
     Validate source and target path lists.
 
@@ -113,9 +113,9 @@ def validate_source_target_files(src_files: List[Path], tar_files: List[Path]) -
 
     Parameters
     ----------
-    src_files : List[Path]
+    src_files : list of pathlib.Path
         List of source files.
-    tar_files : List[Path]
+    tar_files : list of pathlib.Path
         List of target files.
 
     Raises

--- a/src/careamics/dataset/dataset_utils/iterate_over_files.py
+++ b/src/careamics/dataset/dataset_utils/iterate_over_files.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
-from typing import Callable, Generator, Optional, Union
+from typing import Callable, Optional, Union
 
 from numpy.typing import NDArray
 from torch.utils.data import get_worker_info

--- a/src/careamics/dataset/iterable_pred_dataset.py
+++ b/src/careamics/dataset/iterable_pred_dataset.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Callable, Generator
+from typing import Any, Callable
 
 from numpy.typing import NDArray
 from torch.utils.data import IterableDataset

--- a/src/careamics/dataset/iterable_tiled_pred_dataset.py
+++ b/src/careamics/dataset/iterable_tiled_pred_dataset.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Callable, Generator
+from typing import Any, Callable
 
 from numpy.typing import NDArray
 from torch.utils.data import IterableDataset

--- a/src/careamics/dataset/patching/random_patching.py
+++ b/src/careamics/dataset/patching/random_patching.py
@@ -1,7 +1,6 @@
 """Random patching utilities."""
 
-from collections.abc import Generator
-from typing import List, Optional, Tuple, Union
+from typing import Generator, Optional, Union
 
 import numpy as np
 import zarr
@@ -12,10 +11,10 @@ from .validate_patch_dimension import validate_patch_dimensions
 # TOOD split in testable functions
 def extract_patches_random(
     arr: np.ndarray,
-    patch_size: Union[List[int], Tuple[int, ...]],
+    patch_size: Union[list[int], tuple[int, ...]],
     target: Optional[np.ndarray] = None,
     seed: Optional[int] = None,
-) -> Generator[Tuple[np.ndarray, Optional[np.ndarray]], None, None]:
+) -> Generator[tuple[np.ndarray, Optional[np.ndarray]], None, None]:
     """
     Generate patches from an array in a random manner.
 
@@ -32,11 +31,11 @@ def extract_patches_random(
     ----------
     arr : np.ndarray
         Input image array.
-    patch_size : Tuple[int]
+    patch_size : tuple of int
         Patch sizes in each dimension.
-    target : Optional[np.ndarray], optional
+    target : np.ndarray, optional
         Target array, by default None.
-    seed : Optional[int], optional
+    seed : int, optional
         Random seed, by default None.
 
     Yields
@@ -113,8 +112,8 @@ def extract_patches_random(
 
 def extract_patches_random_from_chunks(
     arr: zarr.Array,
-    patch_size: Union[List[int], Tuple[int, ...]],
-    chunk_size: Union[List[int], Tuple[int, ...]],
+    patch_size: Union[list[int], tuple[int, ...]],
+    chunk_size: Union[list[int], tuple[int, ...]],
     chunk_limit: Optional[int] = None,
     seed: Optional[int] = None,
 ) -> Generator[np.ndarray, None, None]:
@@ -128,13 +127,13 @@ def extract_patches_random_from_chunks(
     ----------
     arr : np.ndarray
         Input image array.
-    patch_size : Union[List[int], Tuple[int, ...]]
+    patch_size : list or tuple of int
         Patch sizes in each dimension.
-    chunk_size : Union[List[int], Tuple[int, ...]]
+    chunk_size : list or tuple of int
         Chunk sizes to load from the.
-    chunk_limit : Optional[int], optional
+    chunk_limit : int, optional
         Number of chunks to load, by default None.
-    seed : Optional[int], optional
+    seed : int, optional
         Random seed, by default None.
 
     Yields

--- a/src/careamics/dataset/patching/random_patching.py
+++ b/src/careamics/dataset/patching/random_patching.py
@@ -1,6 +1,7 @@
 """Random patching utilities."""
 
-from typing import Generator, Optional, Union
+from collections.abc import Generator
+from typing import Optional, Union
 
 import numpy as np
 import zarr

--- a/src/careamics/dataset/patching/random_patching.py
+++ b/src/careamics/dataset/patching/random_patching.py
@@ -1,6 +1,7 @@
 """Random patching utilities."""
 
-from typing import Generator, List, Optional, Tuple, Union
+from collections.abc import Generator
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import zarr

--- a/src/careamics/dataset/patching/sequential_patching.py
+++ b/src/careamics/dataset/patching/sequential_patching.py
@@ -1,6 +1,6 @@
 """Sequential patching functions."""
 
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 from skimage.util import view_as_windows
@@ -9,21 +9,21 @@ from .validate_patch_dimension import validate_patch_dimensions
 
 
 def _compute_number_of_patches(
-    arr_shape: Tuple[int, ...], patch_sizes: Union[List[int], Tuple[int, ...]]
-) -> Tuple[int, ...]:
+    arr_shape: tuple[int, ...], patch_sizes: Union[list[int], tuple[int, ...]]
+) -> tuple[int, ...]:
     """
     Compute the number of patches that fit in each dimension.
 
     Parameters
     ----------
-    arr_shape : Tuple[int, ...]
+    arr_shape : tuple of int
         Shape of the input array.
-    patch_sizes : Union[List[int], Tuple[int, ...]
+    patch_sizes : list or tuple of int
         Shape of the patches.
 
     Returns
     -------
-    Tuple[int, ...]
+    tuple of int
         Number of patches in each dimension.
     """
     if len(arr_shape) != len(patch_sizes):
@@ -47,8 +47,8 @@ def _compute_number_of_patches(
 
 
 def _compute_overlap(
-    arr_shape: Tuple[int, ...], patch_sizes: Union[List[int], Tuple[int, ...]]
-) -> Tuple[int, ...]:
+    arr_shape: tuple[int, ...], patch_sizes: Union[list[int], tuple[int, ...]]
+) -> tuple[int, ...]:
     """
     Compute the overlap between patches in each dimension.
 
@@ -57,14 +57,14 @@ def _compute_overlap(
 
     Parameters
     ----------
-    arr_shape : Tuple[int, ...]
+    arr_shape : tuple of int
         Input array shape.
-    patch_sizes : Union[List[int], Tuple[int, ...]]
+    patch_sizes : list or tuple of int
         Size of the patches.
 
     Returns
     -------
-    Tuple[int, ...]
+    tuple of int
         Overlap between patches in each dimension.
     """
     n_patches = _compute_number_of_patches(arr_shape, patch_sizes)
@@ -80,21 +80,21 @@ def _compute_overlap(
 
 
 def _compute_patch_steps(
-    patch_sizes: Union[List[int], Tuple[int, ...]], overlaps: Tuple[int, ...]
-) -> Tuple[int, ...]:
+    patch_sizes: Union[list[int], tuple[int, ...]], overlaps: tuple[int, ...]
+) -> tuple[int, ...]:
     """
     Compute steps between patches.
 
     Parameters
     ----------
-    patch_sizes : Tuple[int]
+    patch_sizes : list or tuple of int
         Size of the patches.
-    overlaps : Tuple[int]
+    overlaps : tuple of int
         Overlap between patches.
 
     Returns
     -------
-    Tuple[int]
+    tuple of int
         Steps between patches.
     """
     steps = [
@@ -107,9 +107,9 @@ def _compute_patch_steps(
 # TODO why stack the target here and not on a different dimension before this function?
 def _compute_patch_views(
     arr: np.ndarray,
-    window_shape: List[int],
-    step: Tuple[int, ...],
-    output_shape: List[int],
+    window_shape: list[int],
+    step: tuple[int, ...],
+    output_shape: list[int],
     target: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """
@@ -119,13 +119,13 @@ def _compute_patch_views(
     ----------
     arr : np.ndarray
         Array from which the views are extracted.
-    window_shape : Tuple[int]
+    window_shape : list of int
         Shape of the views.
-    step : Tuple[int]
+    step : tuple of int
         Steps between views.
-    output_shape : Tuple[int]
+    output_shape : list of int
         Shape of the output array.
-    target : Optional[np.ndarray], optional
+    target : np.ndarray, optional
         Target array, by default None.
 
     Returns
@@ -150,9 +150,9 @@ def _compute_patch_views(
 
 def extract_patches_sequential(
     arr: np.ndarray,
-    patch_size: Union[List[int], Tuple[int, ...]],
+    patch_size: Union[list[int], tuple[int, ...]],
     target: Optional[np.ndarray] = None,
-) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+) -> tuple[np.ndarray, Optional[np.ndarray]]:
     """
     Generate patches from an array in a sequential manner.
 
@@ -161,16 +161,16 @@ def extract_patches_sequential(
 
     Parameters
     ----------
-    arr : np.ndarray
+    arr : numpy.ndarray
         Input image array.
-    patch_size : Tuple[int]
+    patch_size : tuple of int
         Patch sizes in each dimension.
-    target : Optional[np.ndarray], optional
+    target : numpy.ndarray, optional
         Target array, by default None.
 
     Returns
     -------
-    Tuple[np.ndarray, Optional[np.ndarray]]
+    (numpy.ndarray, numpy.ndarray or None)
         Patches.
     """
     is_3d_patch = len(patch_size) == 3

--- a/src/careamics/dataset/patching/validate_patch_dimension.py
+++ b/src/careamics/dataset/patching/validate_patch_dimension.py
@@ -1,13 +1,13 @@
 """Patch validation functions."""
 
-from typing import List, Tuple, Union
+from typing import Union
 
 import numpy as np
 
 
 def validate_patch_dimensions(
     arr: np.ndarray,
-    patch_size: Union[List[int], Tuple[int, ...]],
+    patch_size: Union[list[int], tuple[int, ...]],
     is_3d_patch: bool,
 ) -> None:
     """
@@ -24,9 +24,9 @@ def validate_patch_dimensions(
 
     Parameters
     ----------
-    arr : np.ndarray
+    arr : numpy.ndarray
         Input array.
-    patch_size : Union[List[int], Tuple[int, ...]]
+    patch_size : list or tuple of int
         Size of the patches along each dimension of the array, except the first.
     is_3d_patch : bool
         Whether the patch is 3D or not.

--- a/src/careamics/dataset/tiling/collate_tiles.py
+++ b/src/careamics/dataset/tiling/collate_tiles.py
@@ -1,6 +1,6 @@
 """Collate function for tiling."""
 
-from typing import Any, List, Tuple
+from typing import Any
 
 import numpy as np
 from torch.utils.data.dataloader import default_collate
@@ -8,7 +8,7 @@ from torch.utils.data.dataloader import default_collate
 from careamics.config.tile_information import TileInformation
 
 
-def collate_tiles(batch: List[Tuple[np.ndarray, TileInformation]]) -> Any:
+def collate_tiles(batch: list[tuple[np.ndarray, TileInformation]]) -> Any:
     """
     Collate tiles received from CAREamics prediction dataloader.
 
@@ -19,7 +19,7 @@ def collate_tiles(batch: List[Tuple[np.ndarray, TileInformation]]) -> Any:
 
     Parameters
     ----------
-    batch : List[Tuple[np.ndarray, TileInformation], ...]
+    batch : list of (numpy.ndarray, TileInformation)
         Batch of tiles.
 
     Returns

--- a/src/careamics/dataset/tiling/tiled_patching.py
+++ b/src/careamics/dataset/tiling/tiled_patching.py
@@ -1,7 +1,8 @@
 """Tiled patching utilities."""
 
 import itertools
-from typing import Generator, Union
+from collections.abc import Generator
+from typing import Union
 
 import numpy as np
 

--- a/src/careamics/dataset/tiling/tiled_patching.py
+++ b/src/careamics/dataset/tiling/tiled_patching.py
@@ -1,8 +1,7 @@
 """Tiled patching utilities."""
 
 import itertools
-from collections.abc import Generator
-from typing import List, Tuple, Union
+from typing import Generator, Union
 
 import numpy as np
 
@@ -11,7 +10,7 @@ from careamics.config.tile_information import TileInformation
 
 def _compute_crop_and_stitch_coords_1d(
     axis_size: int, tile_size: int, overlap: int
-) -> Tuple[List[Tuple[int, int]], List[Tuple[int, int]], List[Tuple[int, int]]]:
+) -> tuple[list[tuple[int, int]], list[tuple[int, int]], list[tuple[int, int]]]:
     """
     Compute the coordinates of each tile along an axis, given the overlap.
 
@@ -26,7 +25,7 @@ def _compute_crop_and_stitch_coords_1d(
 
     Returns
     -------
-    Tuple[Tuple[int, ...], ...]
+    (list of (int, int), list of (int, int), list of (int, int))
         Tuple of all coordinates for given axis.
     """
     # Compute the step between tiles
@@ -82,9 +81,9 @@ def _compute_crop_and_stitch_coords_1d(
 
 def extract_tiles(
     arr: np.ndarray,
-    tile_size: Union[List[int], Tuple[int, ...]],
-    overlaps: Union[List[int], Tuple[int, ...]],
-) -> Generator[Tuple[np.ndarray, TileInformation], None, None]:
+    tile_size: Union[list[int], tuple[int, ...]],
+    overlaps: Union[list[int], tuple[int, ...]],
+) -> Generator[tuple[np.ndarray, TileInformation], None, None]:
     """Generate tiles from the input array with specified overlap.
 
     The tiles cover the whole array. The method returns a generator that yields
@@ -97,16 +96,16 @@ def extract_tiles(
 
     Parameters
     ----------
-    arr : np.ndarray
+    arr : numpy.ndarray
         Array of shape (S, C, (Z), Y, X).
-    tile_size : Union[List[int], Tuple[int]]
+    tile_size : list or tuple of int
         Tile sizes in each dimension, of length 2 or 3.
-    overlaps : Union[List[int], Tuple[int]]
+    overlaps : list or tuple of int
         Overlap values in each dimension, of length 2 or 3.
 
     Yields
     ------
-    Generator[Tuple[np.ndarray, TileInformation], None, None]
+    Generator of (np.ndarray, TileInformation)
         Tile generator, yields the tile and additional information.
     """
     # Iterate over num samples (S)

--- a/src/careamics/dataset/tiling/tiled_patching.py
+++ b/src/careamics/dataset/tiling/tiled_patching.py
@@ -1,7 +1,8 @@
 """Tiled patching utilities."""
 
 import itertools
-from typing import Generator, List, Tuple, Union
+from collections.abc import Generator
+from typing import List, Tuple, Union
 
 import numpy as np
 

--- a/src/careamics/file_io/read/get_func.py
+++ b/src/careamics/file_io/read/get_func.py
@@ -1,7 +1,7 @@
 """Module to get read functions."""
 
 from pathlib import Path
-from typing import Callable, Dict, Protocol, Union
+from typing import Callable, Protocol, Union
 
 from numpy.typing import NDArray
 
@@ -30,7 +30,7 @@ class ReadFunc(Protocol):
         """
 
 
-READ_FUNCS: Dict[SupportedData, ReadFunc] = {
+READ_FUNCS: dict[SupportedData, ReadFunc] = {
     SupportedData.TIFF: read_tiff,
 }
 

--- a/src/careamics/lightning/callbacks/prediction_writer_callback/prediction_writer_callback.py
+++ b/src/careamics/lightning/callbacks/prediction_writer_callback/prediction_writer_callback.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Optional, Union
 
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import BasePredictionWriter

--- a/src/careamics/lightning/callbacks/prediction_writer_callback/write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction_writer_callback/write_strategy.py
@@ -1,7 +1,8 @@
 """Module containing different strategies for writing predictions."""
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Optional, Protocol, Sequence, Union
+from typing import Any, Optional, Protocol, Union
 
 import numpy as np
 from numpy.typing import NDArray

--- a/src/careamics/lightning/callbacks/progress_bar_callback.py
+++ b/src/careamics/lightning/callbacks/progress_bar_callback.py
@@ -1,7 +1,7 @@
 """Progressbar callback."""
 
 import sys
-from typing import Dict, Union
+from typing import Union
 
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import TQDMProgressBar
@@ -71,7 +71,7 @@ class ProgressBarCallback(TQDMProgressBar):
 
     def get_metrics(
         self, trainer: Trainer, pl_module: LightningModule
-    ) -> Dict[str, Union[int, str, float, Dict[str, float]]]:
+    ) -> dict[str, Union[int, str, float, dict[str, float]]]:
         """Override this to customize the metrics displayed in the progress bar.
 
         Parameters
@@ -83,7 +83,7 @@ class ProgressBarCallback(TQDMProgressBar):
 
         Returns
         -------
-        dict
+        dict of {str: int or str or float or dict of {str: float}}
             A dictionary with the metrics to display in the progress bar.
         """
         pbar_metrics = trainer.progress_bar_metrics

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -1,7 +1,7 @@
 """Module use to build BMZ model description."""
 
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 from bioimageio.spec.model.v0_5 import (
@@ -35,27 +35,27 @@ from ._readme_factory import readme_factory
 def _create_axes(
     array: np.ndarray,
     data_config: DataConfig,
-    channel_names: Optional[List[str]] = None,
+    channel_names: Optional[list[str]] = None,
     is_input: bool = True,
-) -> List[AxisBase]:
+) -> list[AxisBase]:
     """Create axes description.
 
     Array shape is expected to be SC(Z)YX.
 
     Parameters
     ----------
-    array : np.ndarray
+    array : numpy.ndarray
         Array.
     data_config : DataModel
         CAREamics data configuration.
-    channel_names : Optional[List[str]], optional
+    channel_names : list of str, optional
         Channel names, by default None.
     is_input : bool, optional
         Whether the axes are input axes, by default True.
 
     Returns
     -------
-    List[AxisBase]
+    list of AxisBase
         List of axes description.
 
     Raises
@@ -104,30 +104,30 @@ def _create_inputs_ouputs(
     data_config: DataConfig,
     input_path: Union[Path, str],
     output_path: Union[Path, str],
-    channel_names: Optional[List[str]] = None,
-) -> Tuple[InputTensorDescr, OutputTensorDescr]:
+    channel_names: Optional[list[str]] = None,
+) -> tuple[InputTensorDescr, OutputTensorDescr]:
     """Create input and output tensor description.
 
     Input and output paths must point to a `.npy` file.
 
     Parameters
     ----------
-    input_array : np.ndarray
+    input_array : numpy.ndarray
         Input array.
-    output_array : np.ndarray
+    output_array : numpy.ndarray
         Output array.
     data_config : DataModel
         CAREamics data configuration.
-    input_path : Union[Path, str]
+    input_path : pathlib.Path or str
         Path to input .npy file.
-    output_path : Union[Path, str]
+    output_path : pathlib.Path or str
         Path to output .npy file.
-    channel_names : Optional[List[str]], optional
+    channel_names : list of str, optional
         Channel names, by default None.
 
     Returns
     -------
-    Tuple[InputTensorDescr, OutputTensorDescr]
+    tuple[InputTensorDescr, OutputTensorDescr]
         Input and output tensor descriptions.
     """
     input_axes = _create_axes(input_array, data_config, channel_names)
@@ -186,7 +186,7 @@ def create_model_description(
     config: Configuration,
     name: str,
     general_description: str,
-    authors: List[Author],
+    authors: list[Author],
     inputs: Union[Path, str],
     outputs: Union[Path, str],
     weights_path: Union[Path, str],
@@ -194,7 +194,7 @@ def create_model_description(
     careamics_version: str,
     config_path: Union[Path, str],
     env_path: Union[Path, str],
-    channel_names: Optional[List[str]] = None,
+    channel_names: Optional[list[str]] = None,
     data_description: Optional[str] = None,
 ) -> ModelDescr:
     """Create model description.
@@ -207,25 +207,25 @@ def create_model_description(
         Name fo the model.
     general_description : str
         General description of the model.
-    authors : List[Author]
+    authors : list of Author
         Authors of the model.
-    inputs : Union[Path, str]
+    inputs : pathlib.Path or str
         Path to input .npy file.
-    outputs : Union[Path, str]
+    outputs : pathlib.Path or str
         Path to output .npy file.
-    weights_path : Union[Path, str]
+    weights_path : pathlib.Path or str
         Path to model weights.
     torch_version : str
         Pytorch version.
     careamics_version : str
         CAREamics version.
-    config_path : Union[Path, str]
+    config_path : pathlib.Path or str
         Path to model configuration.
-    env_path : Union[Path, str]
+    env_path : pathlib.Path or str
         Path to environment file.
-    channel_names : Optional[List[str]], optional
+    channel_names : list of str, optional
         Channel names, by default None.
-    data_description : Optional[str], optional
+    data_description : str, optional
         Description of the data, by default None.
 
     Returns
@@ -298,7 +298,7 @@ def create_model_description(
     return model
 
 
-def extract_model_path(model_desc: ModelDescr) -> Tuple[Path, Path]:
+def extract_model_path(model_desc: ModelDescr) -> tuple[Path, Path]:
     """Return the relative path to the weights and configuration files.
 
     Parameters
@@ -308,7 +308,7 @@ def extract_model_path(model_desc: ModelDescr) -> Tuple[Path, Path]:
 
     Returns
     -------
-    Tuple[Path, Path]
+    (pathlib.Path, pathlib.Path)
         Weights and configuration paths.
     """
     weights_path = model_desc.weights.pytorch_state_dict.source.path

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -2,7 +2,7 @@
 
 import tempfile
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import pkg_resources
@@ -79,10 +79,10 @@ def export_to_bmz(
     path: Union[Path, str],
     name: str,
     general_description: str,
-    authors: List[dict],
+    authors: list[dict[str, str]],
     input_array: np.ndarray,
     output_array: np.ndarray,
-    channel_names: Optional[List[str]] = None,
+    channel_names: Optional[list[str]] = None,
     data_description: Optional[str] = None,
 ) -> None:
     """Export the model to BioImage Model Zoo format.
@@ -101,15 +101,15 @@ def export_to_bmz(
         Model name.
     general_description : str
         General description of the model.
-    authors : List[dict]
+    authors : list of {str: str}
         Authors of the model.
-    input_array : np.ndarray
+    input_array : numpy.ndarray
         Input array, should not have been normalized.
-    output_array : np.ndarray
+    output_array : numpy.ndarray
         Output array, should have been denormalized.
-    channel_names : Optional[List[str]], optional
+    channel_names : list of str, optional
         Channel names, by default None.
-    data_description : Optional[str], optional
+    data_description : str, optional
         Description of the data, by default None.
 
     Raises
@@ -186,17 +186,17 @@ def export_to_bmz(
         save_bioimageio_package(model_description, output_path=path)
 
 
-def load_from_bmz(path: Union[Path, str]) -> Tuple[CAREamicsModule, Configuration]:
+def load_from_bmz(path: Union[Path, str]) -> tuple[CAREamicsModule, Configuration]:
     """Load a model from a BioImage Model Zoo archive.
 
     Parameters
     ----------
-    path : Union[Path, str]
+    path : pathlib.Path or str
         Path to the BioImage Model Zoo archive.
 
     Returns
     -------
-    Tuple[CAREamicsKiln, Configuration]
+    (CAREamicsModule, Configuration)
         CAREamics model and configuration.
 
     Raises

--- a/src/careamics/model_io/model_io_utils.py
+++ b/src/careamics/model_io/model_io_utils.py
@@ -1,7 +1,7 @@
 """Utility functions to load pretrained models."""
 
 from pathlib import Path
-from typing import Tuple, Union
+from typing import Union
 
 import torch
 
@@ -11,7 +11,7 @@ from careamics.model_io.bmz_io import load_from_bmz
 from careamics.utils import check_path_exists
 
 
-def load_pretrained(path: Union[Path, str]) -> Tuple[CAREamicsModule, Configuration]:
+def load_pretrained(path: Union[Path, str]) -> tuple[CAREamicsModule, Configuration]:
     """
     Load a pretrained model from a checkpoint or a BioImage Model Zoo model.
 
@@ -19,12 +19,12 @@ def load_pretrained(path: Union[Path, str]) -> Tuple[CAREamicsModule, Configurat
 
     Parameters
     ----------
-    path : Union[Path, str]
+    path : pathlib.Path or str
         Path to the pretrained model.
 
     Returns
     -------
-    Tuple[CAREamicsKiln, Configuration]
+    (CAREamicsModule, Configuration)
         Tuple of CAREamics model and its configuration.
 
     Raises
@@ -44,18 +44,18 @@ def load_pretrained(path: Union[Path, str]) -> Tuple[CAREamicsModule, Configurat
         )
 
 
-def _load_checkpoint(path: Union[Path, str]) -> Tuple[CAREamicsModule, Configuration]:
+def _load_checkpoint(path: Union[Path, str]) -> tuple[CAREamicsModule, Configuration]:
     """
     Load a model from a checkpoint and return both model and configuration.
 
     Parameters
     ----------
-    path : Union[Path, str]
+    path : pathlib.Path or str
         Path to the checkpoint.
 
     Returns
     -------
-    Tuple[CAREamicsKiln, Configuration]
+    (CAREamicsModule, Configuration)
         Tuple of CAREamics model and its configuration.
 
     Raises

--- a/src/careamics/models/layers.py
+++ b/src/careamics/models/layers.py
@@ -4,7 +4,7 @@ Layer module.
 This submodule contains layers used in the CAREamics models.
 """
 
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -157,22 +157,22 @@ class Conv_Block(nn.Module):
 
 
 def _unpack_kernel_size(
-    kernel_size: Union[Tuple[int, ...], int], dim: int
-) -> Tuple[int, ...]:
+    kernel_size: Union[tuple[int, ...], int], dim: int
+) -> tuple[int, ...]:
     """Unpack kernel_size to a tuple of ints.
 
     Inspired by Kornia implementation. TODO: link
 
     Parameters
     ----------
-    kernel_size : Union[Tuple[int, ...], int]
+    kernel_size : Union[tuple[int, ...], int]
         Kernel size.
     dim : int
         Number of dimensions.
 
     Returns
     -------
-    Tuple[int, ...]
+    tuple[int, ...]
         Kernel size tuple.
     """
     if isinstance(kernel_size, int):
@@ -183,20 +183,20 @@ def _unpack_kernel_size(
 
 
 def _compute_zero_padding(
-    kernel_size: Union[Tuple[int, ...], int], dim: int
-) -> Tuple[int, ...]:
+    kernel_size: Union[tuple[int, ...], int], dim: int
+) -> tuple[int, ...]:
     """Utility function that computes zero padding tuple.
 
     Parameters
     ----------
-    kernel_size : Union[Tuple[int, ...], int]
+    kernel_size : Union[tuple[int, ...], int]
         Kernel size.
     dim : int
         Number of dimensions.
 
     Returns
     -------
-    Tuple[int, ...]
+    tuple[int, ...]
         Zero padding tuple.
     """
     kernel_dims = _unpack_kernel_size(kernel_size, dim)
@@ -245,8 +245,8 @@ def get_pascal_kernel_1d(
     >>> get_pascal_kernel_1d(6)
     tensor([ 1.,  5., 10., 10.,  5.,  1.])
     """
-    pre: List[float] = []
-    cur: List[float] = []
+    pre: list[float] = []
+    cur: list[float] = []
     for i in range(kernel_size):
         cur = [1.0] * (i + 1)
 
@@ -266,7 +266,7 @@ def get_pascal_kernel_1d(
 
 
 def _get_pascal_kernel_nd(
-    kernel_size: Union[Tuple[int, int], int],
+    kernel_size: Union[tuple[int, int], int],
     norm: bool = True,
     dim: int = 2,
     *,
@@ -282,7 +282,7 @@ def _get_pascal_kernel_nd(
 
     Parameters
     ----------
-    kernel_size : Union[Tuple[int, int], int]
+    kernel_size : Union[tuple[int, int], int]
         Kernel size for the pascal kernel.
     norm : bool
         Normalize the kernel, by default True.
@@ -420,7 +420,7 @@ class MaxBlurPool(nn.Module):
     ----------
     dim : int
         Toggles between 2D and 3D.
-    kernel_size : Union[Tuple[int, int], int]
+    kernel_size : Union[tuple[int, int], int]
         Kernel size for max pooling.
     stride : int
         Stride for pooling.
@@ -433,7 +433,7 @@ class MaxBlurPool(nn.Module):
     def __init__(
         self,
         dim: int,
-        kernel_size: Union[Tuple[int, int], int],
+        kernel_size: Union[tuple[int, int], int],
         stride: int = 2,
         max_pool_size: int = 2,
         ceil_mode: bool = False,
@@ -444,7 +444,7 @@ class MaxBlurPool(nn.Module):
         ----------
         dim : int
             Dimension of the convolution.
-        kernel_size : Union[Tuple[int, int], int]
+        kernel_size : Union[tuple[int, int], int]
             Kernel size for max pooling.
         stride : int, optional
             Stride, by default 2.

--- a/src/careamics/models/unet.py
+++ b/src/careamics/models/unet.py
@@ -4,7 +4,7 @@ UNet model.
 A UNet encoder, decoder and complete model.
 """
 
-from typing import Any, List, Tuple, Union
+from typing import Any, Union
 
 import torch
 import torch.nn as nn
@@ -104,7 +104,7 @@ class UnetEncoder(nn.Module):
             encoder_blocks.append(self.pooling)
         self.encoder_blocks = nn.ModuleList(encoder_blocks)
 
-    def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
+    def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
         """
         Forward pass.
 
@@ -115,7 +115,7 @@ class UnetEncoder(nn.Module):
 
         Returns
         -------
-        List[torch.Tensor]
+        list of torch.Tensor
             Output of each encoder block (skip connections) and final output of the
             encoder.
         """
@@ -202,7 +202,7 @@ class UnetDecoder(nn.Module):
             groups=self.groups,
         )
 
-        decoder_blocks: List[nn.Module] = []
+        decoder_blocks: list[nn.Module] = []
         for n in range(depth):
             decoder_blocks.append(upsampling)
             in_channels = (num_channels_init * 2 ** (depth - n)) * groups
@@ -240,7 +240,7 @@ class UnetDecoder(nn.Module):
             Output of the decoder.
         """
         x: torch.Tensor = features[0]
-        skip_connections: Tuple[torch.Tensor, ...] = features[-1:0:-1]
+        skip_connections: tuple[torch.Tensor, ...] = features[-1:0:-1]
 
         x = self.bottleneck(x)
 
@@ -289,10 +289,10 @@ class UnetDecoder(nn.Module):
         m = A.shape[1] // groups
         n = B.shape[1] // groups
 
-        A_groups: List[torch.Tensor] = [
+        A_groups: list[torch.Tensor] = [
             A[:, i * m : (i + 1) * m] for i in range(groups)
         ]
-        B_groups: List[torch.Tensor] = [
+        B_groups: list[torch.Tensor] = [
             B[:, i * n : (i + 1) * n] for i in range(groups)
         ]
 

--- a/src/careamics/prediction_utils/prediction_outputs.py
+++ b/src/careamics/prediction_utils/prediction_outputs.py
@@ -1,6 +1,6 @@
 """Module containing functions to convert prediction outputs to desired form."""
 
-from typing import Any, List, Literal, Tuple, Union, overload
+from typing import Any, Literal, Union, overload
 
 import numpy as np
 from numpy.typing import NDArray
@@ -9,7 +9,7 @@ from ..config.tile_information import TileInformation
 from .stitch_prediction import stitch_prediction
 
 
-def convert_outputs(predictions: List[Any], tiled: bool) -> list[NDArray]:
+def convert_outputs(predictions: list[Any], tiled: bool) -> list[NDArray]:
     """
     Convert the Lightning trainer outputs to the desired form.
 
@@ -24,7 +24,7 @@ def convert_outputs(predictions: List[Any], tiled: bool) -> list[NDArray]:
 
     Returns
     -------
-    list of numpy.ndarray or numpy.ndarray
+    list of numpy.ndarray
         List of arrays with the axes SC(Z)YX. If there is only 1 output it will not
         be in a list.
     """
@@ -44,27 +44,27 @@ def convert_outputs(predictions: List[Any], tiled: bool) -> list[NDArray]:
 # for mypy
 @overload
 def combine_batches(  # numpydoc ignore=GL08
-    predictions: List[Any], tiled: Literal[True]
-) -> Tuple[List[NDArray], List[TileInformation]]: ...
+    predictions: list[Any], tiled: Literal[True]
+) -> tuple[list[NDArray], list[TileInformation]]: ...
 
 
 # for mypy
 @overload
 def combine_batches(  # numpydoc ignore=GL08
-    predictions: List[Any], tiled: Literal[False]
-) -> List[NDArray]: ...
+    predictions: list[Any], tiled: Literal[False]
+) -> list[NDArray]: ...
 
 
 # for mypy
 @overload
 def combine_batches(  # numpydoc ignore=GL08
-    predictions: List[Any], tiled: Union[bool, Literal[True], Literal[False]]
-) -> Union[List[NDArray], Tuple[List[NDArray], List[TileInformation]]]: ...
+    predictions: list[Any], tiled: Union[bool, Literal[True], Literal[False]]
+) -> Union[list[NDArray], tuple[list[NDArray], list[TileInformation]]]: ...
 
 
 def combine_batches(
-    predictions: List[Any], tiled: bool
-) -> Union[List[NDArray], Tuple[List[NDArray], List[TileInformation]]]:
+    predictions: list[Any], tiled: bool
+) -> Union[list[NDArray], tuple[list[NDArray], list[TileInformation]]]:
     """
     If predictions are in batches, they will be combined.
 
@@ -77,7 +77,7 @@ def combine_batches(
 
     Returns
     -------
-    (list of numpy.ndarray) or tuple of (list of numpy.ndarray, list of TileInformation)
+    list of numpy.ndarray or tuple of (list of numpy.ndarray, list of TileInformation)
         Combined batches.
     """
     if tiled:
@@ -87,8 +87,8 @@ def combine_batches(
 
 
 def _combine_tiled_batches(
-    predictions: List[Tuple[NDArray, List[TileInformation]]]
-) -> Tuple[List[NDArray], List[TileInformation]]:
+    predictions: list[tuple[NDArray, list[TileInformation]]]
+) -> tuple[list[NDArray], list[TileInformation]]:
     """
     Combine batches from tiled output.
 
@@ -109,13 +109,13 @@ def _combine_tiled_batches(
     tile_infos = [
         tile_info for _, tile_info_list in predictions for tile_info in tile_info_list
     ]
-    prediction_tiles: List[NDArray] = _combine_array_batches(
+    prediction_tiles: list[NDArray] = _combine_array_batches(
         [preds for preds, _ in predictions]
     )
     return prediction_tiles, tile_infos
 
 
-def _combine_array_batches(predictions: List[NDArray]) -> List[NDArray]:
+def _combine_array_batches(predictions: list[NDArray]) -> list[NDArray]:
     """
     Combine batches of arrays.
 

--- a/src/careamics/prediction_utils/stitch_prediction.py
+++ b/src/careamics/prediction_utils/stitch_prediction.py
@@ -1,7 +1,7 @@
 """Prediction utility functions."""
 
 import builtins
-from typing import List, Union
+from typing import Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -11,9 +11,9 @@ from careamics.config.tile_information import TileInformation
 
 # TODO: why not allow input and output of torch.tensor ?
 def stitch_prediction(
-    tiles: List[np.ndarray],
-    tile_infos: List[TileInformation],
-) -> List[np.ndarray]:
+    tiles: list[np.ndarray],
+    tile_infos: list[TileInformation],
+) -> list[np.ndarray]:
     """
     Stitch tiles back together to form a full image(s).
 
@@ -54,8 +54,8 @@ def stitch_prediction(
 
 
 def stitch_prediction_single(
-    tiles: List[NDArray],
-    tile_infos: List[TileInformation],
+    tiles: list[NDArray],
+    tile_infos: list[TileInformation],
 ) -> NDArray:
     """
     Stitch tiles back together to form a full image.

--- a/src/careamics/transforms/compose.py
+++ b/src/careamics/transforms/compose.py
@@ -1,6 +1,6 @@
 """A class chaining transforms together."""
 
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Optional
 
 import numpy as np
 
@@ -20,12 +20,12 @@ ALL_TRANSFORMS = {
 }
 
 
-def get_all_transforms() -> Dict[str, type]:
+def get_all_transforms() -> dict[str, type]:
     """Return all the transforms accepted by CAREamics.
 
     Returns
     -------
-    dict
+    dict of {str: type}
         A dictionary with all the transforms accepted by CAREamics, where the keys are
         the transform names and the values are the transform classes.
     """
@@ -37,7 +37,7 @@ class Compose:
 
     Parameters
     ----------
-    transform_list : List[TRANSFORMS_UNION]
+    transform_list : list of Transform
         A list of dictionaries where each dictionary contains the name of a
         transform and its parameters.
 
@@ -47,12 +47,12 @@ class Compose:
         A callable that applies the transforms to the input data.
     """
 
-    def __init__(self, transform_list: List[TRANSFORMS_UNION]) -> None:
+    def __init__(self, transform_list: list[TRANSFORMS_UNION]) -> None:
         """Instantiate a Compose object.
 
         Parameters
         ----------
-        transform_list : List[TRANSFORMS_UNION]
+        transform_list : list of Transform
             A list of dictionaries where each dictionary contains the name of a
             transform and its parameters.
         """
@@ -64,12 +64,12 @@ class Compose:
 
         self._callable_transforms = self._chain_transforms(transforms)
 
-    def _chain_transforms(self, transforms: List[Transform]) -> Callable:
+    def _chain_transforms(self, transforms: list[Transform]) -> Callable:
         """Chain the transforms together.
 
         Parameters
         ----------
-        transforms : List[Transform]
+        transforms : list of Transform
             A list of transforms to chain together.
 
         Returns
@@ -80,7 +80,7 @@ class Compose:
 
         def _chain(
             patch: np.ndarray, target: Optional[np.ndarray]
-        ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+        ) -> tuple[np.ndarray, Optional[np.ndarray]]:
             """Chain transforms on the input data.
 
             Parameters
@@ -92,7 +92,7 @@ class Compose:
 
             Returns
             -------
-            Tuple[np.ndarray, Optional[np.ndarray]]
+            (numpy.ndarray, numpy.ndarray or None)
                 The output of the transformations.
             """
             params = (patch, target)
@@ -106,7 +106,7 @@ class Compose:
 
     def __call__(
         self, patch: np.ndarray, target: Optional[np.ndarray] = None
-    ) -> Tuple[np.ndarray, ...]:
+    ) -> tuple[np.ndarray, ...]:
         """Apply the transforms to the input data.
 
         Parameters
@@ -118,7 +118,7 @@ class Compose:
 
         Returns
         -------
-        Tuple[np.ndarray, ...]
+        tuple of numpy.ndarray
             The output of the transformations.
         """
         return self._callable_transforms(patch, target)

--- a/src/careamics/transforms/n2v_manipulate.py
+++ b/src/careamics/transforms/n2v_manipulate.py
@@ -1,6 +1,6 @@
 """N2V manipulation transform."""
 
-from typing import Any, Literal, Optional, Tuple
+from typing import Any, Literal, Optional
 
 import numpy as np
 
@@ -99,7 +99,7 @@ class N2VManipulate(Transform):
 
     def __call__(
         self, patch: np.ndarray, *args: Any, **kwargs: Any
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Apply the transform to the image.
 
         Parameters
@@ -113,7 +113,7 @@ class N2VManipulate(Transform):
 
         Returns
         -------
-        Tuple[np.ndarray, np.ndarray, np.ndarray]
+        (numpy.ndarray, numpy.ndarray, numpy.ndarray)
             Masked patch, original patch, and mask.
         """
         masked = np.zeros_like(patch)

--- a/src/careamics/transforms/pixel_manipulation.py
+++ b/src/careamics/transforms/pixel_manipulation.py
@@ -5,7 +5,7 @@ Pixel manipulation is used in N2V and similar algorithm to replace the value of
 masked pixels.
 """
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import numpy as np
 
@@ -107,7 +107,7 @@ def _odd_jitter_func(step: float, rng: np.random.Generator) -> np.ndarray:
 
 def _get_stratified_coords(
     mask_pixel_perc: float,
-    shape: Tuple[int, ...],
+    shape: tuple[int, ...],
     rng: Optional[np.random.Generator] = None,
 ) -> np.ndarray:
     """
@@ -121,9 +121,9 @@ def _get_stratified_coords(
     mask_pixel_perc : float
         Actual (quasi) percentage of masked pixels across the whole image. Used in
         calculating the distance between masked pixels across each axis.
-    shape : Tuple[int, ...]
+    shape : tuple of int
         Shape of the input patch.
-    rng : np.random.Generator or None
+    rng : numpy.random.Generator or None
         Random number generator.
 
     Returns
@@ -242,7 +242,7 @@ def uniform_manipulate(
     remove_center: bool = True,
     struct_params: Optional[StructMaskParameters] = None,
     rng: Optional[np.random.Generator] = None,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Manipulate pixels by replacing them with a neighbor values.
 
@@ -254,7 +254,7 @@ def uniform_manipulate(
 
     Parameters
     ----------
-    patch : np.ndarray
+    patch : numpy.ndarray
         Image patch, 2D or 3D, shape (y, x) or (z, y, x).
     mask_pixel_percentage : float
         Approximate percentage of pixels to be masked.
@@ -269,7 +269,7 @@ def uniform_manipulate(
 
     Returns
     -------
-    Tuple[np.ndarray]
+    tuple of numpy.ndarray
         Tuple containing the manipulated patch and the corresponding mask.
     """
     if rng is None:
@@ -322,7 +322,7 @@ def median_manipulate(
     subpatch_size: int = 11,
     struct_params: Optional[StructMaskParameters] = None,
     rng: Optional[np.random.Generator] = None,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Manipulate pixels by replacing them with the median of their surrounding subpatch.
 
@@ -348,7 +348,7 @@ def median_manipulate(
 
     Returns
     -------
-    Tuple[np.ndarray]
+    tuple of numpy.ndarray
            Tuple containing the manipulated patch, the original patch and the mask.
     """
     if rng is None:

--- a/src/careamics/transforms/xy_flip.py
+++ b/src/careamics/transforms/xy_flip.py
@@ -1,6 +1,6 @@
 """XY flip transform."""
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import numpy as np
 
@@ -16,13 +16,13 @@ class XYFlip(Transform):
 
     Attributes
     ----------
-    axis_indices : List[int]
+    axis_indices : list of int
         Indices of the axes that can be flipped.
-    rng : np.random.Generator
+    rng : numpy.random.Generator
         Random number generator.
     p : float
         Probability of applying the transform.
-    seed : Optional[int]
+    seed : int, optional
         Random seed.
 
     Parameters
@@ -33,7 +33,7 @@ class XYFlip(Transform):
         Whether to flip along the Y axis, by default True.
     p : float, optional
         Probability of applying the transform, by default 0.5.
-    seed : Optional[int], optional
+    seed : int, optional
         Random seed, by default None.
     """
 
@@ -54,7 +54,7 @@ class XYFlip(Transform):
             Whether to flip along the Y axis, by default True.
         p : float
             Probability of applying the transform, by default 0.5.
-        seed : Optional[int], optional
+        seed : int, optional
             Random seed, by default None.
         """
         if p < 0 or p > 1:
@@ -79,19 +79,19 @@ class XYFlip(Transform):
 
     def __call__(
         self, patch: np.ndarray, target: Optional[np.ndarray] = None
-    ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+    ) -> tuple[np.ndarray, Optional[np.ndarray]]:
         """Apply the transform to the source patch and the target (optional).
 
         Parameters
         ----------
-        patch : np.ndarray
+        patch : numpy.ndarray
             Patch, 2D or 3D, shape C(Z)YX.
-        target : Optional[np.ndarray], optional
+        target : numpy.ndarray, optional
             Target for the patch, by default None.
 
         Returns
         -------
-        Tuple[np.ndarray, Optional[np.ndarray]]
+        (numpy.ndarray, numpy.ndarray or None)
             Transformed patch and target.
         """
         if self.rng.random() > self.p:
@@ -110,14 +110,14 @@ class XYFlip(Transform):
 
         Parameters
         ----------
-        patch : np.ndarray
+        patch : numpy.ndarray
             Image patch, 2D or 3D, shape C(Z)YX.
         axis : int
             Axis to flip.
 
         Returns
         -------
-        np.ndarray
+        numpy.ndarray
             Flipped image patch.
         """
         return np.ascontiguousarray(np.flip(patch, axis=axis))

--- a/src/careamics/transforms/xy_random_rotate90.py
+++ b/src/careamics/transforms/xy_random_rotate90.py
@@ -1,6 +1,6 @@
 """Patch transform applying XY random 90 degrees rotations."""
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import numpy as np
 
@@ -50,7 +50,7 @@ class XYRandomRotate90(Transform):
 
     def __call__(
         self, patch: np.ndarray, target: Optional[np.ndarray] = None
-    ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+    ) -> tuple[np.ndarray, Optional[np.ndarray]]:
         """Apply the transform to the source patch and the target (optional).
 
         Parameters
@@ -62,7 +62,7 @@ class XYRandomRotate90(Transform):
 
         Returns
         -------
-        Tuple[np.ndarray, Optional[np.ndarray]]
+        (numpy.ndarray, numpy.ndarray or None)
             Transformed patch and target.
         """
         if self.rng.random() > self.p:
@@ -80,22 +80,22 @@ class XYRandomRotate90(Transform):
         return patch_transformed, target_transformed
 
     def _apply(
-        self, patch: np.ndarray, n_rot: int, axes: Tuple[int, int]
+        self, patch: np.ndarray, n_rot: int, axes: tuple[int, int]
     ) -> np.ndarray:
         """Apply the transform to the image.
 
         Parameters
         ----------
-        patch : np.ndarray
+        patch : numpy.ndarray
             Image or image patch, 2D or 3D, shape C(Z)YX.
         n_rot : int
             Number of 90 degree rotations.
-        axes : Tuple[int, int]
+        axes : (int, int)
             Axes along which to rotate the patch.
 
         Returns
         -------
-        np.ndarray
+        numpy.ndarray
             Transformed patch.
         """
         return np.ascontiguousarray(np.rot90(patch, k=n_rot, axes=axes))

--- a/src/careamics/utils/context.py
+++ b/src/careamics/utils/context.py
@@ -5,9 +5,10 @@ A convenience function to change the working directory in order to save data.
 """
 
 import os
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, Union
+from typing import Union
 
 
 def get_careamics_home() -> Path:

--- a/src/careamics/utils/logging.py
+++ b/src/careamics/utils/logging.py
@@ -9,7 +9,7 @@ import sys
 import time
 from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Generator, Optional, Union
+from typing import Any, Optional, Union
 
 LOGGERS: dict = {}
 

--- a/src/careamics/utils/logging.py
+++ b/src/careamics/utils/logging.py
@@ -7,8 +7,9 @@ The methods are responsible for the in-console logger.
 import logging
 import sys
 import time
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 LOGGERS: dict = {}
 

--- a/src/careamics/utils/logging.py
+++ b/src/careamics/utils/logging.py
@@ -9,7 +9,7 @@ import sys
 import time
 from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Generator, Optional, Union
 
 LOGGERS: dict = {}
 
@@ -100,7 +100,7 @@ class ProgressBar:
         max_value: Optional[int] = None,
         epoch: Optional[int] = None,
         num_epochs: Optional[int] = None,
-        stateful_metrics: Optional[List] = None,
+        stateful_metrics: Optional[list] = None,
         always_stateful: bool = False,
         mode: str = "train",
     ) -> None:
@@ -109,13 +109,13 @@ class ProgressBar:
 
         Parameters
         ----------
-        max_value : Optional[int], optional
+        max_value : int, optional
             Maximum progress bar value, by default None.
-        epoch : Optional[int], optional
+        epoch : int, optional
             Zero-indexed current epoch, by default None.
-        num_epochs : Optional[int], optional
+        num_epochs : int, optional
             Total number of epochs, by default None.
-        stateful_metrics : Optional[List], optional
+        stateful_metrics : List, optional
             Iterable of string names of metrics that should *not* be averaged over time.
             Metrics in this list will be displayed as-is. All others will be averaged by
             the progress bar before display, by default None.
@@ -146,8 +146,8 @@ class ProgressBar:
         self._seen_so_far = 0
         # We use a dict + list to avoid garbage collection
         # issues found in OrderedDict
-        self._values: Dict[Any, Any] = {}
-        self._values_order: List[Any] = []
+        self._values: dict[Any, Any] = {}
+        self._values_order: list[Any] = []
         self._start = time.time()
         self._last_update = 0.0
         self.spin = self.spinning_cursor() if self.max_value is None else None
@@ -159,7 +159,7 @@ class ProgressBar:
             self.message = "Denoising"
 
     def update(
-        self, current_step: int, batch_size: int = 1, values: Optional[List] = None
+        self, current_step: int, batch_size: int = 1, values: Optional[list] = None
     ) -> None:
         """
         Update the progress bar.
@@ -170,7 +170,7 @@ class ProgressBar:
             Index of the current step.
         batch_size : int, optional
             Batch size, by default 1.
-        values : Optional[List], optional
+        values : list, optional
             Updated metrics values, by default None.
         """
         values = values or []
@@ -264,7 +264,7 @@ class ProgressBar:
 
         self._last_update = now
 
-    def add(self, n: int, values: Optional[List] = None) -> None:
+    def add(self, n: int, values: Optional[list] = None) -> None:
         """
         Update the progress bar by n steps.
 
@@ -272,7 +272,7 @@ class ProgressBar:
         ----------
         n : int
             Number of steps to increase the progress bar with.
-        values : Optional[List], optional
+        values : list, optional
             Updated metrics values, by default None.
         """
         self.update(self._seen_so_far + n, 1, values=values)

--- a/src/careamics/utils/torch_utils.py
+++ b/src/careamics/utils/torch_utils.py
@@ -5,7 +5,7 @@ These functions are used to control certain aspects and behaviours of PyTorch.
 """
 
 import inspect
-from typing import Dict, Union
+from typing import Union
 
 import torch
 
@@ -64,7 +64,7 @@ def get_optimizer(name: str) -> torch.optim.Optimizer:
     return getattr(torch.optim, name)
 
 
-def get_optimizers() -> Dict[str, str]:
+def get_optimizers() -> dict[str, str]:
     """
     Return the list of all optimizers available in torch.optim.
 
@@ -106,7 +106,7 @@ def get_scheduler(
     return getattr(torch.optim.lr_scheduler, name)
 
 
-def get_schedulers() -> Dict[str, str]:
+def get_schedulers() -> dict[str, str]:
     """
     Return the list of all schedulers available in torch.optim.lr_scheduler.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable, Tuple
+from typing import Callable
 
 import numpy as np
 import pytest
@@ -234,12 +234,12 @@ def array_3D() -> np.ndarray:
 
 
 @pytest.fixture
-def patch_size() -> Tuple[int, int]:
+def patch_size() -> tuple[int, int]:
     return (64, 64)
 
 
 @pytest.fixture
-def overlaps() -> Tuple[int, int]:
+def overlaps() -> tuple[int, int]:
     return (32, 32)
 
 

--- a/tests/test_careamist.py
+++ b/tests/test_careamist.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Tuple
 
 import numpy as np
 import pytest
@@ -13,7 +12,7 @@ from careamics.dataset.dataset_utils import reshape_array
 from careamics.lightning.callbacks import HyperParametersCallback, ProgressBarCallback
 
 
-def random_array(shape: Tuple[int, ...], seed: int = 42):
+def random_array(shape: tuple[int, ...], seed: int = 42):
     """Return a random array with values between 0 and 255."""
     rng = np.random.default_rng(seed)
     return (rng.integers(0, 255, shape)).astype(np.float32)


### PR DESCRIPTION
### Description

Since we are no longer supporting python 3.8, we need to bump the python version target of ruff.

### Notes

Strong probability of small merge conflicts with other PRs!