### PR TITLE
Feature: add CAREamist predict to disk method

### DIFF
--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -693,7 +693,6 @@ class CAREamist:
         write_extension: Optional[str] = None,
         write_func: Optional[WriteFunc] = None,
         write_func_kwargs: Optional[dict[str, Any]] = None,
-        predict_dir: Optional[Path] = None,
     ) -> None:
         if (
             self.cfg.data_config.image_means is None
@@ -702,11 +701,6 @@ class CAREamist:
             raise ValueError("Mean and std must be provided in the configuration.")
 
         # TODO: raise error for predict dataset not iterable
-
-        # assign predict dir
-        # TODO: absolute vs relative
-        if predict_dir is not None:
-            self.prediction_writer.dirpath = predict_dir
 
         tiled = tile_size is not None
         write_strategy = create_write_strategy(

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -695,6 +695,12 @@ class CAREamist:
         write_func_kwargs: Optional[dict[str, Any]] = None,
         predict_dir: Optional[Path] = None,
     ) -> None:
+        if (
+            self.cfg.data_config.image_means is None
+            or self.cfg.data_config.image_stds is None
+        ):
+            raise ValueError("Mean and std must be provided in the configuration.")
+
         # TODO: raise error for predict dataset not iterable
 
         # assign predict dir

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -23,7 +23,6 @@ from careamics.config.support import (
     SupportedData,
     SupportedLogger,
 )
-from careamics.dataset import IterablePredDataset, IterableTiledPredDataset
 from careamics.dataset.dataset_utils import reshape_array
 from careamics.file_io import WriteFunc
 from careamics.lightning import (
@@ -223,7 +222,7 @@ class CAREamist:
 
     def _define_callbacks(self, callbacks: Optional[list[Callback]] = None) -> None:
         """
-        Define the callbacks.
+        Define the callbacks for the training loop.
 
         Parameters
         ----------
@@ -729,7 +728,7 @@ class CAREamist:
         )
         self.prediction_writer.write_strategy = write_strategy
 
-        # turns writing predictions on 
+        # turns writing predictions on
         with self.prediction_writer.writing_predictions(True):
             # predict (without returning predictions, saves memory)
             self.trainer.predict(

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -185,13 +185,13 @@ class CAREamist:
 
         # TODO: move to method
         # prediction writer callback reference
-        # placeholder write strategy — will be changed at runtime
+        # placeholder write strategy — will be changed at predict_to_disk call
+        # TODO: use a placeholder write strategy that will raise an error?
         write_strategy = create_write_strategy("tiff", tiled=False)
         self.prediction_writer = PredictionWriterCallback(
             write_strategy=write_strategy, dirpath=self.work_dir / "predictions"
         )
-        # TODO: update so writing_predictions can be initialised as False ?
-        self.prediction_writer.writing_predictions = False
+        self.prediction_writer.set_writing_predictions(False)
         # not the most elegant
         self.callbacks.append(self.prediction_writer)
 
@@ -715,9 +715,9 @@ class CAREamist:
             extension_filter=extension_filter,
             dataloader_params=dataloader_params,
         )
-        dataset = self.pred_datamodule.predict_dataset
-        if not isinstance(dataset, (IterablePredDataset, IterableTiledPredDataset)):
-            raise TypeError()
+        # dataset = self.pred_datamodule.data
+        # if not isinstance(dataset, (IterablePredDataset, IterableTiledPredDataset)):
+        #     raise TypeError()
 
         tiled = tile_size is not None
         write_strategy = create_write_strategy(
@@ -729,7 +729,8 @@ class CAREamist:
         )
         self.prediction_writer.write_strategy = write_strategy
 
-        with self.prediction_writer.writing_predictions_context(True):
+        # turns writing predictions on 
+        with self.prediction_writer.writing_predictions(True):
             # predict (without returning predictions, saves memory)
             self.trainer.predict(
                 model=self.model,

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -716,10 +716,7 @@ class CAREamist:
             dataloader_params=dataloader_params,
         )
         dataset = self.pred_datamodule.predict_dataset
-        if not (
-            isinstance(dataset, IterablePredDataset)
-            or isinstance(IterableTiledPredDataset)
-        ):
+        if not isinstance(dataset, (IterablePredDataset, IterableTiledPredDataset)):
             raise TypeError()
 
         tiled = tile_size is not None
@@ -732,10 +729,13 @@ class CAREamist:
         )
         self.prediction_writer.write_strategy = write_strategy
 
-        # predict (without returning predictions, saves memory)
-        self.trainer.predict(
-            model=self.model, datamodule=self.pred_datamodule, return_predictions=False
-        )
+        with self.prediction_writer.writing_predictions_context(True):
+            # predict (without returning predictions, saves memory)
+            self.trainer.predict(
+                model=self.model,
+                datamodule=self.pred_datamodule,
+                return_predictions=False,
+            )
 
     def export_to_bmz(
         self,

--- a/src/careamics/dataset/iterable_pred_dataset.py
+++ b/src/careamics/dataset/iterable_pred_dataset.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Callable, Generator, Optional
+from typing import Any, Callable, Generator
 
 from numpy.typing import NDArray
 from torch.utils.data import IterableDataset
@@ -73,8 +73,8 @@ class IterablePredDataset(IterableDataset):
         self.data_files = src_files
         self.axes = prediction_config.axes
         self.read_source_func = read_source_func
-        # if iteration has started, keeps track of file index
-        self.current_file_index: Optional[int] = None
+        # keep track of the file index that corresponds with each sample
+        self.sample_file_indices: list[int] = []
 
         # check mean and std and create normalize transform
         if (
@@ -111,8 +111,8 @@ class IterablePredDataset(IterableDataset):
             self.image_means is not None and self.image_stds is not None
         ), "Mean and std must be provided"
 
-        # reset file index
-        self.current_file_index = None
+        # reset file index list
+        self.sample_file_indices = []
 
         for file_index, (sample, _) in enumerate(
             iterate_over_files(
@@ -121,10 +121,11 @@ class IterablePredDataset(IterableDataset):
                 read_source_func=self.read_source_func,
             )
         ):
-            self.current_file_index = file_index
             # sample has S dimension
             for i in range(sample.shape[0]):
 
-                transformed_sample, _ = self.patch_transform(patch=sample[i])
+                # save file index that corresponds to each sample
+                self.sample_file_indices.append(file_index)
 
+                transformed_sample, _ = self.patch_transform(patch=sample[i])
                 yield transformed_sample

--- a/src/careamics/lightning/__init__.py
+++ b/src/careamics/lightning/__init__.py
@@ -9,9 +9,16 @@ __all__ = [
     "create_predict_datamodule",
     "HyperParametersCallback",
     "ProgressBarCallback",
+    "PredictionWriterCallback",
+    "create_write_strategy",
 ]
 
-from .callbacks import HyperParametersCallback, ProgressBarCallback
+from .callbacks import (
+    HyperParametersCallback,
+    PredictionWriterCallback,
+    ProgressBarCallback,
+    create_write_strategy,
+)
 from .lightning_module import CAREamicsModule, create_careamics_module
 from .predict_data_module import PredictDataModule, create_predict_datamodule
 from .train_data_module import TrainDataModule, create_train_datamodule

--- a/src/careamics/lightning/callbacks/__init__.py
+++ b/src/careamics/lightning/callbacks/__init__.py
@@ -4,8 +4,9 @@ __all__ = [
     "HyperParametersCallback",
     "ProgressBarCallback",
     "PredictionWriterCallback",
+    "create_write_strategy",
 ]
 
 from .hyperparameters_callback import HyperParametersCallback
-from .prediction_writer_callback import PredictionWriterCallback
+from .prediction_writer_callback import PredictionWriterCallback, create_write_strategy
 from .progress_bar_callback import ProgressBarCallback

--- a/src/careamics/lightning/callbacks/prediction_writer_callback/file_path_utils.py
+++ b/src/careamics/lightning/callbacks/prediction_writer_callback/file_path_utils.py
@@ -25,7 +25,16 @@ def get_sample_file_path(
     Path
         The file path corresponding to the sample with the ID `sample_id`.
     """
-    return dataset.data_files[sample_id]
+    if dataset.current_file_index is None:
+        raise ValueError(
+            "Current file index is `None` because dataset iteration has not commenced."
+        )
+    file_path: Path = dataset.data_files[dataset.current_file_index]
+    if "S" in dataset.axes:
+        sample_file_name = f"{file_path.stem}_{sample_id}"
+        file_path = (file_path.parent / sample_file_name).with_suffix(file_path.suffix)
+
+    return file_path
 
 
 def create_write_file_path(

--- a/src/careamics/lightning/callbacks/prediction_writer_callback/prediction_writer_callback.py
+++ b/src/careamics/lightning/callbacks/prediction_writer_callback/prediction_writer_callback.py
@@ -198,7 +198,7 @@ class PredictionWriterCallback(BasePredictionWriter):
             Stage of training e.g. 'predict', 'fit', 'validate'.
         """
         super().setup(trainer, pl_module, stage)
-        if stage == "predict":
+        if (stage == "predict") and self._writing_predictions:
             # make prediction output directory
             logger.info("Making prediction output directory.")
             self.dirpath.mkdir(parents=True, exist_ok=True)

--- a/src/careamics/lightning/callbacks/prediction_writer_callback/prediction_writer_callback.py
+++ b/src/careamics/lightning/callbacks/prediction_writer_callback/prediction_writer_callback.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Optional, Sequence, Union
 
@@ -75,7 +76,7 @@ class PredictionWriterCallback(BasePredictionWriter):
 
         # forward declaration
         self._dirpath: Path
-        # property setter sets self_dirpath
+        # property setter sets self.dirpath
         # mypy problem with properties https://github.com/python/mypy/issues/3004
         self.dirpath = dirpath  # type: ignore
 
@@ -164,6 +165,19 @@ class PredictionWriterCallback(BasePredictionWriter):
                 f"be '{value}'"
             )
         self._dirpath = value_
+
+    @contextmanager
+    def writing_predictions_context(self, flag: bool):
+
+        # save current value to restore to after context
+        previous_value = self.writing_predictions
+
+        # set value and yield (state withing `with` statement block)
+        self.writing_predictions = flag
+        yield
+
+        # state after exiting `with` statement block
+        self.writing_predictions = previous_value
 
     def setup(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
         """

--- a/src/careamics/lightning/callbacks/prediction_writer_callback/prediction_writer_callback.py
+++ b/src/careamics/lightning/callbacks/prediction_writer_callback/prediction_writer_callback.py
@@ -77,7 +77,7 @@ class PredictionWriterCallback(BasePredictionWriter):
         self._dirpath: Path
         # property setter sets self_dirpath
         # mypy problem with properties https://github.com/python/mypy/issues/3004
-        self.dirpath = dirpath # type: ignore
+        self.dirpath = dirpath  # type: ignore
 
     @classmethod
     def from_write_func_params(

--- a/src/careamics/lightning/callbacks/prediction_writer_callback/prediction_writer_callback.py
+++ b/src/careamics/lightning/callbacks/prediction_writer_callback/prediction_writer_callback.py
@@ -168,7 +168,21 @@ class PredictionWriterCallback(BasePredictionWriter):
 
     @contextmanager
     def writing_predictions(self, flag: bool):
+        """
+        A context manager that will temporarily set writing predictions on or off.
 
+        The toggle will return to what it previously was after exiting the `with` block.
+
+        Parameters
+        ----------
+        flag : bool
+            Whether writing predictions will be set to on or off during the `with`
+            block.
+
+        Yields
+        ------
+        None
+        """
         # save current value to restore to after context
         previous_value = self._writing_predictions
 
@@ -180,6 +194,14 @@ class PredictionWriterCallback(BasePredictionWriter):
         self._writing_predictions = previous_value
 
     def set_writing_predictions(self, flag: bool) -> None:
+        """
+        Turn writing predictions on or off.
+
+        Parameters
+        ----------
+        flag : bool
+            Whether writing predictions will be set to on or off.
+        """
         self._writing_predictions = flag
 
     def setup(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:

--- a/src/careamics/lightning/callbacks/prediction_writer_callback/write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction_writer_callback/write_strategy.py
@@ -115,6 +115,9 @@ class CacheTiles(WriteStrategy):
         self.tile_cache: list[NDArray] = []
         self.tile_info_cache: list[TileInformation] = []
 
+        # sample count
+        self.sample_count = 0
+
     @property
     def last_tiles(self) -> list[bool]:
         """
@@ -187,8 +190,9 @@ class CacheTiles(WriteStrategy):
             )
 
             # write prediction
-            sample_id = tile_infos[0].sample_id  # need this to select correct file name
-            input_file_path = get_sample_file_path(dataset=dataset, sample_id=sample_id)
+            input_file_path = get_sample_file_path(
+                dataset=dataset, sample_index=self.sample_count
+            )
             file_path = create_write_file_path(
                 dirpath=dirpath,
                 file_path=input_file_path,
@@ -197,6 +201,8 @@ class CacheTiles(WriteStrategy):
             self.write_func(
                 file_path=file_path, img=prediction_image[0], **self.write_func_kwargs
             )
+
+            self.sample_count += 1
 
     def _has_last_tile(self) -> bool:
         """
@@ -339,6 +345,7 @@ class WriteImage(WriteStrategy):
         self.write_func: WriteFunc = write_func
         self.write_extension: str = write_extension
         self.write_func_kwargs: dict[str, Any] = write_func_kwargs
+        self.sample_index = 0
 
     def write_batch(
         self,
@@ -386,8 +393,10 @@ class WriteImage(WriteStrategy):
 
         for i in range(prediction.shape[0]):
             prediction_image = prediction[0]
-            sample_id = batch_idx * dl.batch_size + i
-            input_file_path = get_sample_file_path(dataset=ds, sample_id=sample_id)
+            sample_index = batch_idx * dl.batch_size + i
+            input_file_path = get_sample_file_path(
+                dataset=ds, sample_index=sample_index
+            )
             file_path = create_write_file_path(
                 dirpath=dirpath,
                 file_path=input_file_path,

--- a/src/careamics/prediction_utils/__init__.py
+++ b/src/careamics/prediction_utils/__init__.py
@@ -5,8 +5,16 @@ __all__ = [
     "stitch_prediction_single",
     "convert_outputs",
     "validate_unet_tile_size",
+    "TiledPredOutput",
+    "UnTiledPredOutput",
+    "PredOutput",
 ]
 
-from .prediction_outputs import convert_outputs
+from .prediction_outputs import (
+    PredOutput,
+    TiledPredOutput,
+    UnTiledPredOutput,
+    convert_outputs,
+)
 from .stitch_prediction import stitch_prediction, stitch_prediction_single
 from .validate_args import validate_unet_tile_size

--- a/src/careamics/prediction_utils/__init__.py
+++ b/src/careamics/prediction_utils/__init__.py
@@ -4,7 +4,9 @@ __all__ = [
     "stitch_prediction",
     "stitch_prediction_single",
     "convert_outputs",
+    "validate_unet_tile_size",
 ]
 
 from .prediction_outputs import convert_outputs
 from .stitch_prediction import stitch_prediction, stitch_prediction_single
+from .validate_args import validate_unet_tile_size

--- a/src/careamics/prediction_utils/prediction_outputs.py
+++ b/src/careamics/prediction_utils/prediction_outputs.py
@@ -8,6 +8,11 @@ from numpy.typing import NDArray
 from ..config.tile_information import TileInformation
 from .stitch_prediction import stitch_prediction
 
+# TODO: type hint functions correctly, pretty difficult with mypy
+TiledPredOutput = List[Tuple[NDArray, List[TileInformation]]]
+UnTiledPredOutput = List[NDArray]
+PredOutput = Union[TiledPredOutput]
+
 
 def convert_outputs(predictions: List[Any], tiled: bool) -> list[NDArray]:
     """

--- a/src/careamics/prediction_utils/validate_args.py
+++ b/src/careamics/prediction_utils/validate_args.py
@@ -1,0 +1,15 @@
+"""Module for validating prediction arguments."""
+
+
+def validate_unet_tile_size(model_depth: int, tile_size: tuple[int, ...]):
+    # tile size must be equal to k*2^n,
+    # where n is the number of pooling layers (equal to the depth) and k is an integer
+    tile_increment = 2**model_depth
+    for i, t in enumerate(tile_size):
+        if t % tile_increment != 0:
+            raise ValueError(
+                f"Tile size must be divisible by {tile_increment} along "
+                f"all axes (got {t} for axis {i}). If your image size is "
+                f"smaller along one axis (e.g. Z), consider padding the "
+                f"image."
+            )

--- a/src/careamics/prediction_utils/validate_args.py
+++ b/src/careamics/prediction_utils/validate_args.py
@@ -2,6 +2,21 @@
 
 
 def validate_unet_tile_size(model_depth: int, tile_size: tuple[int, ...]):
+    """
+    Validate that `tile_size` is equal to `k*2^depth` where `k` is an integer.
+
+    Parameters
+    ----------
+    model_depth : int
+        The depth of the UNet model.
+    tile_size : tuple of int
+        The tile size.
+
+    Raises
+    ------
+    ValueError
+        If `tile_size` is not equal to `k*2^depth` where `k` is an integer.
+    """
     # tile size must be equal to k*2^n,
     # where n is the number of pooling layers (equal to the depth) and k is an integer
     tile_increment = 2**model_depth

--- a/tests/dataset/test_iterable_pred_dataset.py
+++ b/tests/dataset/test_iterable_pred_dataset.py
@@ -109,4 +109,4 @@ def test_file_index_update(tmp_path):
     ds = IterablePredDataset(pred_config, src_files=src_files)
 
     for i, _ in enumerate(ds):
-        assert ds.current_file_index == i
+        assert ds.sample_file_indices[i] == i

--- a/tests/dataset/test_iterable_pred_dataset.py
+++ b/tests/dataset/test_iterable_pred_dataset.py
@@ -88,3 +88,25 @@ def test_correct_normalized_outputs(tmp_path, n_files, shape, axes, expected_sha
         for j in range(i + 1, len(dataset)):
             img2 = dataset[j]
             assert not np.allclose(img, img2)
+
+
+def test_file_index_update(tmp_path):
+    """Test interal dataset attribute `current_file_index` updates during iteration."""
+    axes = "YX"
+    input_shape = (16, 16)
+    # create files
+    src_files = [tmp_path / f"{i}.tiff" for i in range(2)]
+    for file_path in src_files:
+        arr = np.random.rand(*input_shape)
+        tifffile.imwrite(file_path, arr)
+
+    pred_config = InferenceConfig(
+        data_type="tiff",
+        axes=axes,
+        image_means=[0],
+        image_stds=[0],
+    )
+    ds = IterablePredDataset(pred_config, src_files=src_files)
+
+    for i, _ in enumerate(ds):
+        assert ds.current_file_index == i

--- a/tests/dataset/test_iterable_tiled_pred_dataset.py
+++ b/tests/dataset/test_iterable_tiled_pred_dataset.py
@@ -128,4 +128,4 @@ def test_file_index_update(tmp_path):
 
     for i, _ in enumerate(ds):
         # floor divide by 9, because there are 9 tiles per sample
-        assert ds.current_file_index == i // 9
+        assert ds.sample_file_indices[i // 9] == i // 9

--- a/tests/lightning/callbacks/prediction_writer_callback/test_file_path_utils.py
+++ b/tests/lightning/callbacks/prediction_writer_callback/test_file_path_utils.py
@@ -1,7 +1,11 @@
 from pathlib import Path
-from unittest.mock import Mock
+
+import numpy as np
+import pytest
+from tifffile import imwrite
 
 from careamics.config import InferenceConfig
+from careamics.config.tile_information import TileInformation
 from careamics.dataset import IterablePredDataset, IterableTiledPredDataset
 from careamics.lightning.callbacks.prediction_writer_callback.file_path_utils import (
     create_write_file_path,
@@ -9,38 +13,88 @@ from careamics.lightning.callbacks.prediction_writer_callback.file_path_utils im
 )
 
 
-def test_get_sample_file_path_tiled_ds():
+@pytest.mark.parametrize("axes", ["YX", "SYX"])
+def test_get_sample_file_path_tiled(tmp_path, axes):
+    """Test file name generation for tiled prediction dataset."""
+    input_shape = (2, 16, 16) if "S" in axes else (16, 16)
+    tile_size = (8, 8)
+    tile_overlap = (4, 4)
+    # create files
+    src_files = [tmp_path / f"{i}.tiff" for i in range(2)]
+    for file_path in src_files:
+        arr = np.random.rand(*input_shape)
+        imwrite(file_path, arr)
 
-    # Create DS with mock InferenceConfig
-    src_files = [f"{i}.ext" for i in range(2)]
-    pred_config = Mock(spec=InferenceConfig)
-    # attrs used in DS initialization
-    pred_config.axes = Mock()
-    pred_config.tile_size = Mock()
-    pred_config.tile_overlap = Mock()
-    pred_config.image_means = [Mock()]
-    pred_config.image_stds = [Mock()]
+    pred_config = InferenceConfig(
+        data_type="tiff",
+        tile_size=tile_size,
+        tile_overlap=tile_overlap,
+        axes=axes,
+        image_means=[0],
+        image_stds=[0],
+    )
     ds = IterableTiledPredDataset(pred_config, src_files=src_files)
 
-    for i in range(2):
-        file_path = get_sample_file_path(ds, sample_id=i)
-        assert file_path == f"{i}.ext"
+    for sample in ds:
+        sample: tuple[np.ndarray, TileInformation]
+        _, tile_info = sample
+        file_path = get_sample_file_path(ds, sample_id=tile_info.sample_id)
+        file_index = ds.current_file_index
+        # if samples axis for each sample, the index is added to the filename.
+        if "S" in axes:
+            save_path = tmp_path / f"{file_index}_{tile_info.sample_id}.tiff"
+        else:
+            save_path = tmp_path / f"{file_index}.tiff"
+        assert file_path == save_path
 
 
-def test_get_sample_file_path_untiled_ds():
+@pytest.mark.parametrize("axes", ["YX", "SYX"])
+def test_get_sample_file_path_untiled(tmp_path, axes):
+    """Test file name generation for untiled prediction dataset."""
+    input_shape = (2, 16, 16) if "S" in axes else (16, 16)
+    tile_size = (8, 8)
+    tile_overlap = (4, 4)
+    # create files
+    src_files = [tmp_path / f"{i}.tiff" for i in range(2)]
+    for file_path in src_files:
+        arr = np.random.rand(*input_shape)
+        imwrite(file_path, arr)
 
-    # Create DS with mock InferenceConfig
-    src_files = [f"{i}.ext" for i in range(2)]
-    pred_config = Mock(spec=InferenceConfig)
-    # attrs used in DS initialization
-    pred_config.axes = Mock()
-    pred_config.image_means = [Mock()]
-    pred_config.image_stds = [Mock()]
+    pred_config = InferenceConfig(
+        data_type="tiff",
+        tile_size=tile_size,
+        tile_overlap=tile_overlap,
+        axes=axes,
+        image_means=[0],
+        image_stds=[0],
+    )
     ds = IterablePredDataset(pred_config, src_files=src_files)
 
-    for i in range(2):
+    for i, _ in enumerate(ds):
         file_path = get_sample_file_path(ds, sample_id=i)
-        assert file_path == f"{i}.ext"
+        file_index = ds.current_file_index
+        # if samples axis for each sample, the index is added to the filename.
+        if "S" in axes:
+            save_path = tmp_path / f"{file_index}_{i}.tiff"
+        else:
+            save_path = tmp_path / f"{file_index}.tiff"
+        assert file_path == save_path
+
+
+def test_get_sample_file_path_error():
+    """Test error is raised if dataset iteration has not commenced."""
+    src_files = [f"{i}.ext" for i in range(2)]
+    pred_config = InferenceConfig(
+        data_type="tiff",
+        tile_size=(8, 8),
+        tile_overlap=(4, 4),
+        axes="YX",
+        image_means=[0],
+        image_stds=[0],
+    )
+    ds = IterablePredDataset(pred_config, src_files=src_files)
+    with pytest.raises(ValueError):
+        get_sample_file_path(ds, sample_id=0)
 
 
 def test_create_write_file_path():

--- a/tests/lightning/callbacks/prediction_writer_callback/test_file_path_utils.py
+++ b/tests/lightning/callbacks/prediction_writer_callback/test_file_path_utils.py
@@ -52,8 +52,6 @@ def test_get_sample_file_path_tiled(tmp_path, axes):
 def test_get_sample_file_path_untiled(tmp_path, axes):
     """Test file name generation for untiled prediction dataset."""
     input_shape = (2, 16, 16) if "S" in axes else (16, 16)
-    tile_size = (8, 8)
-    tile_overlap = (4, 4)
     # create files
     src_files = [tmp_path / f"{i}.tiff" for i in range(2)]
     for file_path in src_files:
@@ -62,8 +60,6 @@ def test_get_sample_file_path_untiled(tmp_path, axes):
 
     pred_config = InferenceConfig(
         data_type="tiff",
-        tile_size=tile_size,
-        tile_overlap=tile_overlap,
         axes=axes,
         image_means=[0],
         image_stds=[0],

--- a/tests/lightning/callbacks/prediction_writer_callback/test_prediction_writer_callback.py
+++ b/tests/lightning/callbacks/prediction_writer_callback/test_prediction_writer_callback.py
@@ -266,8 +266,8 @@ def test_set_writing_predictions(prediction_writer_callback, initial_value):
     prediction_writer_callback.set_writing_predictions(new_value)
     assert prediction_writer_callback._writing_predictions == new_value
 
-
-def test_setup_prediction_directory_creation(prediction_writer_callback, dirpath):
+@pytest.mark.parametrize("writing_predictions", [True, False])
+def test_setup_prediction_directory_creation(prediction_writer_callback, dirpath, writing_predictions):
     """
     Test prediction directory is created when `setup` is called at `stage="predict"`.
     """
@@ -275,9 +275,11 @@ def test_setup_prediction_directory_creation(prediction_writer_callback, dirpath
     pl_module = Mock(spec=LightningModule)
     stage = "predict"
 
+    prediction_writer_callback._writing_predictions = writing_predictions
     prediction_writer_callback.setup(trainer=trainer, pl_module=pl_module, stage=stage)
 
-    assert os.path.isdir(dirpath)
+    # makes directory only if writing predictions is turned on
+    assert os.path.isdir(dirpath) == writing_predictions
 
 
 def test_write_on_batch_end(prediction_writer_callback):

--- a/tests/lightning/callbacks/prediction_writer_callback/test_prediction_writer_callback.py
+++ b/tests/lightning/callbacks/prediction_writer_callback/test_prediction_writer_callback.py
@@ -229,6 +229,27 @@ def test_set_dirpath_relative_path(prediction_writer_callback):
         assert prediction_writer_callback._dirpath == mock_cwd / relative_path
 
 
+@pytest.mark.parametrize("initial_value", [True, False])
+def test_writing_predictions_context(prediction_writer_callback, initial_value):
+    """
+    Test that the context manager for writing predictions works as expected.
+    """
+    # initialize value
+    prediction_writer_callback.writing_predictions = initial_value
+
+    temp_value = True
+    with prediction_writer_callback.writing_predictions_context(temp_value):
+        assert prediction_writer_callback.writing_predictions == temp_value
+    # make sure it is restored to it's initial value
+    assert prediction_writer_callback.writing_predictions == initial_value
+
+    # for value is false
+    temp_value = False
+    with prediction_writer_callback.writing_predictions_context(temp_value):
+        assert prediction_writer_callback.writing_predictions == temp_value
+    assert prediction_writer_callback.writing_predictions == initial_value
+
+
 def test_setup_prediction_directory_creation(prediction_writer_callback, dirpath):
     """
     Test prediction directory is created when `setup` is called at `stage="predict"`.

--- a/tests/lightning/callbacks/prediction_writer_callback/test_prediction_writer_callback.py
+++ b/tests/lightning/callbacks/prediction_writer_callback/test_prediction_writer_callback.py
@@ -266,8 +266,11 @@ def test_set_writing_predictions(prediction_writer_callback, initial_value):
     prediction_writer_callback.set_writing_predictions(new_value)
     assert prediction_writer_callback._writing_predictions == new_value
 
+
 @pytest.mark.parametrize("writing_predictions", [True, False])
-def test_setup_prediction_directory_creation(prediction_writer_callback, dirpath, writing_predictions):
+def test_setup_prediction_directory_creation(
+    prediction_writer_callback, dirpath, writing_predictions
+):
     """
     Test prediction directory is created when `setup` is called at `stage="predict"`.
     """

--- a/tests/lightning/callbacks/prediction_writer_callback/test_prediction_writer_callback.py
+++ b/tests/lightning/callbacks/prediction_writer_callback/test_prediction_writer_callback.py
@@ -212,21 +212,21 @@ def test_initialization(prediction_writer_callback, write_strategy, dirpath):
     assert prediction_writer_callback.dirpath == Path(dirpath).resolve()
 
 
-def test_init_dirpath_absolute_path(prediction_writer_callback):
+def test_set_dirpath_absolute_path(prediction_writer_callback):
     """Test initialization of dirpath with absolute path."""
     absolute_path = Path("/absolute/path").absolute()
-    prediction_writer_callback._init_dirpath(absolute_path)
-    assert prediction_writer_callback.dirpath == absolute_path
+    prediction_writer_callback.dirpath = absolute_path
+    assert prediction_writer_callback._dirpath == absolute_path
 
 
-def test_init_dirpath_relative_path(prediction_writer_callback):
+def test_set_dirpath_relative_path(prediction_writer_callback):
     """Test initialization of dirpath with relatice path."""
     relative_path = "relative/path"
     # patch pathlib.Path.cwd to return
     mock_cwd = Path("/current/working/dir")
     with patch("pathlib.Path.cwd", return_value=mock_cwd):
-        prediction_writer_callback._init_dirpath(relative_path)
-        assert prediction_writer_callback.dirpath == mock_cwd / relative_path
+        prediction_writer_callback.dirpath = relative_path
+        assert prediction_writer_callback._dirpath == mock_cwd / relative_path
 
 
 def test_setup_prediction_directory_creation(prediction_writer_callback, dirpath):

--- a/tests/lightning/callbacks/prediction_writer_callback/test_prediction_writer_callback.py
+++ b/tests/lightning/callbacks/prediction_writer_callback/test_prediction_writer_callback.py
@@ -207,7 +207,7 @@ def test_smoke_n2v_untiled_tiff(tmp_path, minimum_configuration):
 
 def test_initialization(prediction_writer_callback, write_strategy, dirpath):
     """Test `PredictionWriterCallback` initializes as expected."""
-    assert prediction_writer_callback.writing_predictions is True
+    assert prediction_writer_callback._writing_predictions is True
     assert prediction_writer_callback.write_strategy is write_strategy
     assert prediction_writer_callback.dirpath == Path(dirpath).resolve()
 
@@ -235,19 +235,36 @@ def test_writing_predictions_context(prediction_writer_callback, initial_value):
     Test that the context manager for writing predictions works as expected.
     """
     # initialize value
-    prediction_writer_callback.writing_predictions = initial_value
+    prediction_writer_callback._writing_predictions = initial_value
 
     temp_value = True
-    with prediction_writer_callback.writing_predictions_context(temp_value):
-        assert prediction_writer_callback.writing_predictions == temp_value
+    with prediction_writer_callback.writing_predictions(temp_value):
+        assert prediction_writer_callback._writing_predictions == temp_value
     # make sure it is restored to it's initial value
-    assert prediction_writer_callback.writing_predictions == initial_value
+    assert prediction_writer_callback._writing_predictions == initial_value
 
     # for value is false
     temp_value = False
-    with prediction_writer_callback.writing_predictions_context(temp_value):
-        assert prediction_writer_callback.writing_predictions == temp_value
-    assert prediction_writer_callback.writing_predictions == initial_value
+    with prediction_writer_callback.writing_predictions(temp_value):
+        assert prediction_writer_callback._writing_predictions == temp_value
+    assert prediction_writer_callback._writing_predictions == initial_value
+
+
+@pytest.mark.parametrize("initial_value", [True, False])
+def test_set_writing_predictions(prediction_writer_callback, initial_value):
+    """
+    Test that `set_writing_predictions` changes the value of `_writing_predictions.
+    """
+    # initialize value
+    prediction_writer_callback._writing_predictions = initial_value
+
+    new_value = True
+    prediction_writer_callback.set_writing_predictions(new_value)
+    assert prediction_writer_callback._writing_predictions == new_value
+
+    new_value = False
+    prediction_writer_callback.set_writing_predictions(new_value)
+    assert prediction_writer_callback._writing_predictions == new_value
 
 
 def test_setup_prediction_directory_creation(prediction_writer_callback, dirpath):
@@ -308,7 +325,7 @@ def test_write_on_batch_end_writing_predictions_off(prediction_writer_callback):
     Ensure `PredictionWriterCallback.write_strategy.write_batch` is not called when
     `PredictionWriterCallback.writing_predictions=False`.
     """
-    prediction_writer_callback.writing_predictions = False
+    prediction_writer_callback._writing_predictions = False
 
     trainer = Mock(spec=Trainer)
     pl_module = Mock(spec=LightningModule)

--- a/tests/test_careamist.py
+++ b/tests/test_careamist.py
@@ -819,14 +819,17 @@ def test_predict_to_disk_YX_tiff(tmp_path, minimum_configuration, tiled):
 
 @pytest.mark.parametrize("tiled", [True, False])
 def test_predict_to_disk_SYX_tiff(tmp_path, minimum_configuration, tiled):
+    n_files = 2
     n_samples = 2
     train_array = random_array((n_samples, 32, 32))
 
     # save files
     train_dir = tmp_path / "train"
     train_dir.mkdir()
-    file_name = "image.tiff"
-    tifffile.imwrite(train_dir / file_name, train_array)
+    file_names = [f"image_{i}.tiff" for i in range(n_files)]
+    for file_name in file_names:
+        train_file = train_dir / file_name
+        tifffile.imwrite(train_file, train_array)
 
     # create configuration
     config = Configuration(**minimum_configuration)
@@ -855,9 +858,10 @@ def test_predict_to_disk_SYX_tiff(tmp_path, minimum_configuration, tiled):
     )
 
     predict_dir = tmp_path / "predictions"
-    for i in range(n_samples):
-        predict_file = predict_dir / f"{(Path(file_name).stem)}_{i}.tiff"
-        assert predict_file.is_file()
+    for file_name in file_names:
+        for j in range(n_samples):
+            predict_file = predict_dir / f"{(Path(file_name).stem)}_{j}.tiff"
+            assert predict_file.is_file()
 
 
 def test_export_bmz_pretrained_prediction(tmp_path: Path, pre_trained: Path):


### PR DESCRIPTION
### Description

- **What**: Add a `predict_to_disk` method to the `CAREamist` class. It uses the `PredictionWriterCallback`; an instance of which has been added as an attribute of `CAREamist`.
- **Why**: Allows users of the `CAREamist` class to write predictions to disk.
- **How**: 
  - Add an instance of `PredictionWriterCallback` as an attribute of `CAREamist` and append it to the list of callbacks.
  - The bulk of `CAREamist.predict` has been moved to `CAREamist._predict_implementation`; for reuse between `predict` and `predict_to_disk` but allow the parameter `return_predictions` to be set to `True` or `False` respectively.
  - `PredictionWriterCallback` has a context manager for toggling writing predictions on and off (added for aesthetic reasons), but it might also be useful for the lightning API users.
  - The file names for the predictions are taken from the dataset classes so they match the input files.

#### Getting the file names

This is what has caused the most trouble. I have come up with a solution that works, but I dislike it because it introduces a lot of coupling between the `WriteStrategy` classes and the dataset classes. Additionally, I can envision situations where it breaks down.

Currently, I have modified `IterablePredDataset` and `IterableTiledPredDataset` so that they store a list to keep track of the file to which a sample belongs. Then, in the `WriteStrategy`, if the index of the sample is known the file name can be retrieved from the dataset. The concrete implementations are as follows:
- In the `WriteImage` strategy the index of the sample can be calculated from the batch index and the batch size. 
- In the `CacheTiles` strategy the sample index is kept track of with an internal attribute `sample_count`; this is bad because there is no reset mechanism and if the same instance of the `CacheTiles` object is used again it will fail.

*Notes:* 
- In the datasets I tried having just a `current_file_index` attribute, but the way lightning pre-fetches batches meant it didn't work.

*Alternatives:*
- The datasets return the filename that the sample/tile belongs to. This will take some extra work because there are some places where a batch length of 2 is used to infer whether a prediction is tiled or not, which would obviously not hold anymore.

### Changes Made

- **Added**: 
  - `CAREamist.predict_to_disk` method.
  - `CAREamist._predict_implementation` method.
  - `CAREamist.prediction_writer` attribute.
  - `validate_unet_tile_size` function (in `prediction_utils` package).
  - `IterablePredDataset.sample_file_indices` & `IterableTiledPredDataset.sample_file_indices` attributes.
  - Tests
- **Modified**: 
  - `PredictionWriterCallback` class.
  - `CacheTiles` class.
  - `WriteImage` class.
  - `get_sample_file_path` function (in `lightning.callbacks.prediction_writer_callback.file_utils` module).
  - `IterablePredDataset.__iter__` & `IterableTiledPredDataset.__iter__` methods.

### Breaking changes

Shouldn't alter the behaviour of the rest of the code base.

### Additional Notes and Examples

Currently if there is more than one sample in a file, say 2, so it has the shape (2, 32, 32) with the axes being `"SYX"` and the file name "image.tiff". Then, there will be a separate file saved for each sample prediction called "image_0.tiff" and "image_1.tiff". It is implemented this way because it was the path of least resistance, but if you think this will be too inconvenient or confusing to users then I can change it with a little more work by altering the `WriteStrategy` classes.

Also, I realised I am missing a couple tests, I will add them shortly.

###

*Need opinions on:*
- A better way to get/generate the file names for the predictions. Should they be returned with the batches by the dataset classes? Or just leave it as it is for now even though it introduces a lot of coupling.
- Should I update the implementation so the saved file structure mirrors the input data (instead of 1 file per sample).

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)