### PR TITLE
Fix: Use the experiment-name in config as WandB logger name

### DIFF
--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -181,7 +181,7 @@ class CAREamist:
         if self.cfg.training_config.has_logger():
             if self.cfg.training_config.logger == SupportedLogger.WANDB:
                 self.experiment_logger: LOGGER_TYPES = WandbLogger(
-                    name=experiment_name,
+                    name=self.cfg.experiment_name,
                     save_dir=self.work_dir / Path("logs"),
                 )
             elif self.cfg.training_config.logger == SupportedLogger.TENSORBOARD:


### PR DESCRIPTION
### Description

- **What**: The name given to the WandB logger was the argument `experiment_name`, of the `CAREamist.__init__` method, which has the default value `"CAREamics"`. Now the logger name comes from the config. 
- **Why**: One would expect the logger name to be the experiment name in the config, which is also used to save checkpoints. Failing to set the `experiment_name` argument when initialising a `CAREamist` object result in the logger name being `"CAREamics"`.
- **How**: Pass `self.cfg.experiment_name` to the logger instead of `experiment_name`.

### Changes Made

- **Modified**: `CAREamist.__init__` method.

### Related Issues

- Fixes #190 

### Breaking changes

None

### Additional Notes and Examples

This results in the `experiment_name` argument being unused. The docstring says: "If `source` is a checkpoint, then `experiment_name` is used to name the checkpoint, and is recorded in the configuration." I'm not sure if these docs are left over from old behaviour and they are now incorrect, or the `experiment_name` parameter is meant to be doing something that it is currently not doing. I will open an issue to document this.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)