### PR TITLE
Fix: Set bioimage.core<=0.6.5 to stop tests from failing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     'numpy<2.0.0',
     'torch>=2.0.0',
     'torchvision',
-    'bioimageio.core>=0.6.0',
+    'bioimageio.core<=0.6.5',
     'tifffile',
     'psutil',
     'pydantic>=2.5',


### PR DESCRIPTION
### Description

A change since bioimage.core version 0.6.5 is causing careamics tests to fail. Although curiously only if more than one test is run at once, if a test is run individually then it will pass. According to the error messages there is a SHA256 mismatch for some of the files.

This is intended as a temporary fix whilst a proper fix for versions above 0.6.5 is found. 

Since the tests pass individually when the version is greater 0.6.5 I assume careamics is actually compatible with versions greater than 0.6.5 but there is just a problem in the test environment.

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)