### PR TITLE
Revert: Set bioimageio.core>=0.6.0 as before

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     'numpy<2.0.0',
     'torch>=2.0.0',
     'torchvision',
-    'bioimageio.core<=0.6.5',
+    'bioimageio.core>=0.6.0',
     'tifffile',
     'psutil',
     'pydantic>=2.5',


### PR DESCRIPTION
### Description

The bioimage.core version was set to bioimage.core<=0.6.5 in #193 because the bioimageio-spec version 0.5.3 had a bug (not present in 0.5.2) that was causing CAREamics tests to fail.

The fix https://github.com/bioimage-io/spec-bioimage-io/pull/620 and subsequent bioimageio-spec patch release 0.5.3.2 has resolved the issue so pyproject.toml file can be reverted to how it was before #193.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)