### PR TITLE
Fix: Use Codecov CLI version v0.7.3 in github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Coverage
         uses: codecov/codecov-action@v3
+        with:
+          version: v0.7.3
 
   deploy:
     name: Release


### PR DESCRIPTION
### Description

CI is failing for mac os with Codecov version v0.8.0. This sets the codecov-cli to the last working version, v0.7.3.

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)