### PR TITLE
Fixing circular import error arising from importing `UNet` in `models/__init__.py`

### DIFF
--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -252,7 +252,7 @@ def create_model_description(
 
     # weights description
     architecture_descr = ArchitectureFromLibraryDescr(
-        import_from="careamics.models",
+        import_from="careamics.models.unet",
         callable=f"{config.algorithm_config.model.architecture}",
         kwargs=config.algorithm_config.model.model_dump(),
     )

--- a/src/careamics/models/__init__.py
+++ b/src/careamics/models/__init__.py
@@ -1,8 +1,5 @@
 """Models package."""
 
-__all__ = ["model_factory", "UNet", "LVAE"]
+__all__ = ["model_factory"]
 
-
-from .lvae.lvae import LadderVAE as LVAE
 from .model_factory import model_factory
-from .unet import UNet

--- a/src/careamics/models/lvae/__init__.py
+++ b/src/careamics/models/lvae/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["LadderVAE"]
+
+from .lvae import LadderVAE

--- a/src/careamics/prediction_utils/lvae_prediction.py
+++ b/src/careamics/prediction_utils/lvae_prediction.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import torch
 
-from careamics.models import LVAE
+from careamics.models.lvae import LadderVAE as LVAE
 from careamics.models.lvae.likelihoods import LikelihoodModule
 
 # TODO: convert these functions to lightning module `predict_step`

--- a/tests/models/test_model_factory.py
+++ b/tests/models/test_model_factory.py
@@ -8,7 +8,8 @@ from careamics.config.architectures import (
     register_model,
 )
 from careamics.config.support import SupportedArchitecture
-from careamics.models import UNet, model_factory
+from careamics.models import model_factory
+from careamics.models.unet import UNet
 
 
 def test_model_registry_unet():


### PR DESCRIPTION
### Description

This PR fixes circular import error arising from importing `UNet` in `models/__init__.py`.
Specifically, the error was arising because pre-commit hooks were reordering import statements in `models/__init__.py` in a lexicographic order, putting import of `UNet` after import of `model_factory`, which is also importing `UNet`.  

- **What**: Removed imports of `UNet` and `LadderVAE` modules from `models/__init__.py`, mirrored changes in impacted scripts.
- **Why**: It avoids circular imports and makes importing `UNet` and `LadderVAE` more explicit.

---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)