### PR TITLE
Update authors list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,12 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "BSD-3-Clause" }
 authors = [
+    { name = 'CAREamics team', email = 'rse@fht.org' },
+    { name = 'Ashesh', email = 'ashesh.ashesh@fht.org' },
+    { name = 'Federico Carrara', email = 'federico.carrara@fht.org' },
     { name = 'Melisande Croft', email = 'melisande.croft@fht.org' },
     { name = 'Joran Deschamps', email = 'joran.deschamps@fht.org' },
+    { name = 'Vera Galinova', email = 'vera.galinova@fht.org' },
     { name = 'Igor Zubarev', email = 'igor.zubarev@fht.org' },
 ]
 classifiers = [


### PR DESCRIPTION
### Description

There are problems between TOML -> PyPi metadata (e.g. https://github.com/pypi/warehouse/issues/9400), so in our case only the first author in the author list is shown, instead of all the authors...

Therefore, in this PR, I add the CAREamics team as first in the list (with the rse email), and then alphabetically the people who have contributed code.

I also update the list to account for the recent LVAE push!