### PR TITLE
feat: enabling `Adamax` optimizer for LVAE-based split models

### DIFF
--- a/src/careamics/config/optimizer_models.py
+++ b/src/careamics/config/optimizer_models.py
@@ -44,7 +44,9 @@ class OptimizerModel(BaseModel):
     )
 
     # Mandatory field
-    name: Literal["Adam", "SGD", "Adamax"] = Field(default="Adam", validate_default=True)
+    name: Literal["Adam", "SGD", "Adamax"] = Field(
+        default="Adam", validate_default=True
+    )
     """Name of the optimizer, supported optimizers are defined in SupportedOptimizer."""
 
     # Optional parameters, empty dict default value to allow filtering dictionary

--- a/src/careamics/config/optimizer_models.py
+++ b/src/careamics/config/optimizer_models.py
@@ -44,7 +44,7 @@ class OptimizerModel(BaseModel):
     )
 
     # Mandatory field
-    name: Literal["Adam", "SGD"] = Field(default="Adam", validate_default=True)
+    name: Literal["Adam", "SGD", "Adamax"] = Field(default="Adam", validate_default=True)
     """Name of the optimizer, supported optimizers are defined in SupportedOptimizer."""
 
     # Optional parameters, empty dict default value to allow filtering dictionary

--- a/src/careamics/config/support/supported_optimizers.py
+++ b/src/careamics/config/support/supported_optimizers.py
@@ -19,7 +19,7 @@ class SupportedOptimizer(str, BaseEnum):
     # Adagrad = "Adagrad"
     ADAM = "Adam"
     # AdamW = "AdamW"
-    # Adamax = "Adamax"
+    ADAMAX = "Adamax"
     # LBFGS = "LBFGS"
     # NAdam = "NAdam"
     # RAdam = "RAdam"

--- a/src/careamics/lightning/lightning_module.py
+++ b/src/careamics/lightning/lightning_module.py
@@ -287,6 +287,8 @@ class VAEModule(L.LightningModule):
         # save optimizer and lr_scheduler names and parameters
         self.optimizer_name = self.algorithm_config.optimizer.name
         self.optimizer_params = self.algorithm_config.optimizer.parameters
+        if self.optimizer_name == SupportedOptimizer.ADAMAX:
+            self.optimizer_params["params"] = self.model.parameters()
         self.lr_scheduler_name = self.algorithm_config.lr_scheduler.name
         self.lr_scheduler_params = self.algorithm_config.lr_scheduler.parameters
 


### PR DESCRIPTION
### Description

LVAE split models preferably use `Adamax` as their optimizer. 
`Adamax` requires the model parameters/weights as an argument (i.e., `model.parameters()` where `model` is a `torch.nn.Module` instance). The problem with this is that the initialization of the LVAE model happens in `VAEModule` (lightning module), once the parameters for the optimizer are already set (see `OptimizerModel` and `VAEAlgorithmConfig`).
Therefore, the current solution proposes to add `model.parameters` to the optimizer parameter config in the lightning module `__init__`

- **What**: Enabled the use of `Adamax` optimizer for `LVAE` based model.
- **Why**: LVAE-based splitting methods achieve best performance using `Adamax`
- **How**: Describe how you implemented these changes. Provide an overview of the approach and any important implementation details.

### Additional Notes and Examples

A few points to aid discussion:
- Is there a better way to implement this while keeping the lightning module clean?
- Do we want to enable `Adamax` also for FCN models?

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)