### PR TITLE
refac: removed noise model parameters from `LadderVAE` module

### DIFF
--- a/src/careamics/config/architectures/lvae_model.py
+++ b/src/careamics/config/architectures/lvae_model.py
@@ -32,10 +32,6 @@ class LVAEModel(ArchitectureModel):
 
     predict_logvar: Literal[None, "pixelwise"] = None
 
-    # TODO this parameter is exessive -> Remove & refactor
-    enable_noise_model: bool = Field(
-        default=True,
-    )
     analytical_kl: bool = Field(
         default=False,
     )

--- a/src/careamics/models/lvae/lvae.py
+++ b/src/careamics/models/lvae/lvae.py
@@ -38,7 +38,6 @@ class LadderVAE(nn.Module):
         decoder_dropout: float,
         nonlinearity: str,
         predict_logvar: bool,
-        enable_noise_model: bool,
         analytical_kl: bool,
     ):
         """
@@ -62,7 +61,6 @@ class LadderVAE(nn.Module):
         self.decoder_dropout = decoder_dropout
         self.nonlin = nonlinearity
         self.predict_logvar = predict_logvar
-        self.enable_noise_model = enable_noise_model
 
         self.analytical_kl = analytical_kl
         # -------------------------------------------------------

--- a/src/careamics/models/lvae/lvae.py
+++ b/src/careamics/models/lvae/lvae.py
@@ -61,13 +61,11 @@ class LadderVAE(nn.Module):
         self.decoder_dropout = decoder_dropout
         self.nonlin = nonlinearity
         self.predict_logvar = predict_logvar
-
         self.analytical_kl = analytical_kl
         # -------------------------------------------------------
 
         # -------------------------------------------------------
         # Model attributes -> Hardcoded
-        self.model_type = ModelType.LadderVae  # TODO remove !
         self.model_type = ModelType.LadderVae  # TODO remove !
         self.encoder_blocks_per_layer = 1
         self.decoder_blocks_per_layer = 1
@@ -91,14 +89,6 @@ class LadderVAE(nn.Module):
         self._var_clip_max = 20
         self._stochastic_use_naive_exponential = False
         self._enable_topdown_normalize_factor = True
-
-        # Noise model attributes -> Hardcoded
-        # TODO: now noise model is handled separately --> REMOVE!
-        self.noise_model_type = "gmm"
-        self.denoise_channel = (
-            "input"  # 4 values for denoise_channel {'Ch1', 'Ch2', 'input','all'}
-        ) # maybe this is still needed for evaluation
-        self.noise_model_learnable = False
 
         # Attributes that handle LC -> Hardcoded
         self.enable_multiscale = (

--- a/src/careamics/models/lvae/lvae.py
+++ b/src/careamics/models/lvae/lvae.py
@@ -93,10 +93,11 @@ class LadderVAE(nn.Module):
         self._enable_topdown_normalize_factor = True
 
         # Noise model attributes -> Hardcoded
+        # TODO: now noise model is handled separately --> REMOVE!
         self.noise_model_type = "gmm"
         self.denoise_channel = (
             "input"  # 4 values for denoise_channel {'Ch1', 'Ch2', 'input','all'}
-        )
+        ) # maybe this is still needed for evaluation
         self.noise_model_learnable = False
 
         # Attributes that handle LC -> Hardcoded

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,6 @@ def minimum_algorithm_musplit() -> dict:
         "loss": "musplit",
         "model": {
             "architecture": "LVAE",
-            "enable_noise_model": False,
             "z_dims": (128, 128, 128),
             "multiscale_count": 4,
             "predict_logvar": "pixelwise",
@@ -155,7 +154,6 @@ def minimum_algorithm_denoisplit() -> dict:
         "loss": "denoisplit",
         "model": {
             "architecture": "LVAE",
-            "enable_noise_model": False,
             "z_dims": (128, 128, 128),
             "multiscale_count": 4,
         },

--- a/tests/prediction_utils/test_lvae_prediction.py
+++ b/tests/prediction_utils/test_lvae_prediction.py
@@ -29,7 +29,6 @@ def minimum_lvae_params():
         "decoder_dropout": 0.1,
         "nonlinearity": "ELU",
         "predict_logvar": "pixelwise",
-        "enable_noise_model": False,
         "analytical_kl": False,
     }
 


### PR DESCRIPTION
### Description

- **What**: Remove superfluous noise model-related parameters (e.g., `enable_noise_model`) from `LadderVAE` `torch.nn.Module` class.
- **Why**: These parameters are not used anymore since noise model has been moved out of the main model class.
- **How**: Deleted parameters, tested resulting code.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)