### PR TITLE
fix: making range parameter mandatory in `psnr()`

### DIFF
--- a/src/careamics/utils/metrics.py
+++ b/src/careamics/utils/metrics.py
@@ -11,28 +11,33 @@ import torch
 from skimage.metrics import peak_signal_noise_ratio
 
 
-def psnr(gt: np.ndarray, pred: np.ndarray, range: float = 255.0) -> float:
-    """
-    Peak Signal to Noise Ratio.
-
+def psnr(gt: np.ndarray, pred: np.ndarray, data_range: float) -> float:
+    """Peak Signal to Noise Ratio.
+    
     This method calls skimage.metrics.peak_signal_noise_ratio. See:
     https://scikit-image.org/docs/dev/api/skimage.metrics.html.
-
+    
+    NOTE: to avoid unwanted behaviors (e.g., data_range inferred from array dtype),
+    the data_range parameter is mandatory.
+    
     Parameters
     ----------
-    gt : NumPy array
-        Ground truth image.
-    pred : NumPy array
-        Predicted image.
-    range : float, optional
-        The images pixel range, by default 255.0.
+    gt : np.ndarray
+        Ground truth array.
+    pred : np.ndarray
+        Predicted array.
+    data_range : float
+        The images pixel range.
 
     Returns
     -------
     float
         PSNR value.
     """
-    return peak_signal_noise_ratio(gt, pred, data_range=range)
+    if data_range is None:
+        raise ValueError("data_range must be provided")
+    return peak_signal_noise_ratio(gt, pred, data_range=data_range)
+
 
 
 def _zero_mean(x: np.ndarray) -> np.ndarray:

--- a/src/careamics/utils/metrics.py
+++ b/src/careamics/utils/metrics.py
@@ -13,13 +13,13 @@ from skimage.metrics import peak_signal_noise_ratio
 
 def psnr(gt: np.ndarray, pred: np.ndarray, data_range: float) -> float:
     """Peak Signal to Noise Ratio.
-    
+
     This method calls skimage.metrics.peak_signal_noise_ratio. See:
     https://scikit-image.org/docs/dev/api/skimage.metrics.html.
-    
+
     NOTE: to avoid unwanted behaviors (e.g., data_range inferred from array dtype),
     the data_range parameter is mandatory.
-    
+
     Parameters
     ----------
     gt : np.ndarray
@@ -37,7 +37,6 @@ def psnr(gt: np.ndarray, pred: np.ndarray, data_range: float) -> float:
     if data_range is None:
         raise ValueError("data_range must be provided")
     return peak_signal_noise_ratio(gt, pred, data_range=data_range)
-
 
 
 def _zero_mean(x: np.ndarray) -> np.ndarray:

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -4,6 +4,7 @@ import pytest
 from careamics.utils.metrics import (
     _zero_mean,
     scale_invariant_psnr,
+    psnr
 )
 
 
@@ -28,3 +29,10 @@ def test_zero_mean(x):
 )
 def test_scale_invariant_psnr(gt, pred, result):
     assert scale_invariant_psnr(gt, pred) == pytest.approx(result, rel=5e-3)
+
+
+def test_psnr_no_range():
+    gt_ = np.random.rand(8, 8)
+    pred_ = np.random.rand(8, 8)
+    with pytest.raises(ValueError):
+        psnr(gt_, pred_, None)

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -1,11 +1,7 @@
 import numpy as np
 import pytest
 
-from careamics.utils.metrics import (
-    _zero_mean,
-    scale_invariant_psnr,
-    psnr
-)
+from careamics.utils.metrics import _zero_mean, psnr, scale_invariant_psnr
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

- **What**: We force user to provide a `data_range` as input to `psnr()` function.
- **Why**: out `psnr()` function is based on `peak_signal_noise_ratio` function from `skimage`. This function infers the data range from the data type (e.g., 255 if data in `np.uint8`), producing weird results in some cases.
- **How**: If `data_range` is not provided raise a `ValueError`.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)