### PR TITLE
Feature: Transform multiple arrays identically to `patch` and `target`

### DIFF
--- a/src/careamics/transforms/compose.py
+++ b/src/careamics/transforms/compose.py
@@ -113,7 +113,7 @@ class Compose:
         target : Optional[np.ndarray]
             Target data, by default None.
         **additional_arrays : NDArray
-            Additional arrays that will be tranformed identically to `patch` and
+            Additional arrays that will be transformed identically to `patch` and
             `target`.
 
         Returns
@@ -164,15 +164,15 @@ class Compose:
         target : Optional[np.ndarray], optional
             Target data, by default None.
         **additional_arrays : NDArray
-            Additional arrays that will be tranformed identically to `patch` and
+            Additional arrays that will be transformed identically to `patch` and
             `target`.
 
         Returns
         -------
         NDArray
-            The tranformed patch.
+            The transformed patch.
         NDArray | None
-            The tranformed target.
+            The transformed target.
         dict of {str, NDArray}
             Transformed additional arrays. Keys correspond to the keyword argument
             names.

--- a/src/careamics/transforms/compose.py
+++ b/src/careamics/transforms/compose.py
@@ -104,7 +104,7 @@ class Compose:
         target: Optional[NDArray],
         **additional_arrays: NDArray,
     ) -> Tuple[NDArray, Optional[NDArray], dict[str, NDArray]]:
-        """Chain transforms on the input data.
+        """Chain transforms on the input data, with additional arrays.
 
         Parameters
         ----------
@@ -112,6 +112,9 @@ class Compose:
             Input data.
         target : Optional[np.ndarray]
             Target data, by default None.
+        **additional_arrays : NDArray
+            Additional arrays that will be tranformed identically to `patch` and
+            `target`.
 
         Returns
         -------
@@ -152,6 +155,28 @@ class Compose:
         target: Optional[NDArray] = None,
         **additional_arrays: NDArray,
     ) -> tuple[NDArray, Optional[NDArray], dict[str, NDArray]]:
+        """Apply the transforms to the input data, including additional arrays.
+
+        Parameters
+        ----------
+        patch : np.ndarray
+            The input data.
+        target : Optional[np.ndarray], optional
+            Target data, by default None.
+        **additional_arrays : NDArray
+            Additional arrays that will be tranformed identically to `patch` and
+            `target`.
+
+        Returns
+        -------
+        NDArray
+            The tranformed patch.
+        NDArray | None
+            The tranformed target.
+        dict of {str, NDArray}
+            Transformed additional arrays. Keys correspond to the keyword argument
+            names.
+        """
         return self._chain_transforms_additional_arrays(
             patch, target, **additional_arrays
         )

--- a/src/careamics/transforms/compose.py
+++ b/src/careamics/transforms/compose.py
@@ -149,7 +149,7 @@ class Compose:
         # TODO: solve casting Compose.__call__ ouput
         return cast(Tuple[NDArray, ...], self._chain_transforms(patch, target))
 
-    def tranform_with_additional_arrays(
+    def transform_with_additional_arrays(
         self,
         patch: NDArray,
         target: Optional[NDArray] = None,

--- a/src/careamics/transforms/n2v_manipulate.py
+++ b/src/careamics/transforms/n2v_manipulate.py
@@ -3,6 +3,7 @@
 from typing import Any, Literal, Optional, Tuple
 
 import numpy as np
+from numpy.typing import NDArray
 
 from careamics.config.support import SupportedPixelManipulation, SupportedStructAxis
 from careamics.transforms.transform import Transform
@@ -98,8 +99,8 @@ class N2VManipulate(Transform):
         self.rng = np.random.default_rng(seed=seed)
 
     def __call__(
-        self, patch: np.ndarray, *args: Any, **kwargs: Any
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        self, patch: NDArray, *args: Any, **kwargs: Any
+    ) -> Tuple[NDArray, NDArray, NDArray]:
         """Apply the transform to the image.
 
         Parameters
@@ -142,5 +143,8 @@ class N2VManipulate(Transform):
         else:
             raise ValueError(f"Unknown masking strategy ({self.strategy}).")
 
+        # TODO: Output does not match other transforms, how to resolve?
+        #     - Don't include in Compose and apply after if algorithm is N2V?
+        #     - or just don't return patch? but then mask is in the target position
         # TODO why return patch?
         return masked, patch, mask

--- a/src/careamics/transforms/normalize.py
+++ b/src/careamics/transforms/normalize.py
@@ -104,7 +104,7 @@ class Normalize(Transform):
         target : NDArray, optional
             Target for the patch, by default None.
         **additional_arrays : NDArray
-            Additional arrays that will be tranformed identically to `patch` and
+            Additional arrays that will be transformed identically to `patch` and
             `target`.
 
         Returns

--- a/src/careamics/transforms/normalize.py
+++ b/src/careamics/transforms/normalize.py
@@ -90,8 +90,11 @@ class Normalize(Transform):
         self.eps = 1e-6
 
     def __call__(
-        self, patch: np.ndarray, target: Optional[NDArray] = None
-    ) -> tuple[NDArray, Optional[NDArray]]:
+        self,
+        patch: np.ndarray,
+        target: Optional[NDArray] = None,
+        **additional_arrays: NDArray,
+    ) -> tuple[NDArray, Optional[NDArray], dict[str, NDArray]]:
         """Apply the transform to the source patch and the target (optional).
 
         Parameters
@@ -111,6 +114,11 @@ class Normalize(Transform):
                 f"Number of means (got a list of size {len(self.image_means)}) and "
                 f"number of channels (got shape {patch.shape} for C(Z)YX) do not match."
             )
+        if len(additional_arrays) != 0:
+            raise NotImplementedError(
+                "Transforming additional arrays is currently not supported for "
+                "`Normalize`."
+            )
 
         # reshape mean and std and apply the normalization to the patch
         means = _reshape_stats(self.image_means, patch.ndim)
@@ -129,7 +137,7 @@ class Normalize(Transform):
         else:
             norm_target = None
 
-        return norm_patch, norm_target
+        return norm_patch, norm_target, additional_arrays
 
     def _apply(self, patch: NDArray, mean: NDArray, std: NDArray) -> NDArray:
         """

--- a/src/careamics/transforms/normalize.py
+++ b/src/careamics/transforms/normalize.py
@@ -103,6 +103,9 @@ class Normalize(Transform):
             Patch, 2D or 3D, shape C(Z)YX.
         target : NDArray, optional
             Target for the patch, by default None.
+        **additional_arrays : NDArray
+            Additional arrays that will be tranformed identically to `patch` and
+            `target`.
 
         Returns
         -------

--- a/src/careamics/transforms/xy_flip.py
+++ b/src/careamics/transforms/xy_flip.py
@@ -1,8 +1,9 @@
 """XY flip transform."""
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import numpy as np
+from numpy.typing import NDArray
 
 from careamics.transforms.transform import Transform
 
@@ -78,8 +79,11 @@ class XYFlip(Transform):
         self.rng = np.random.default_rng(seed=seed)
 
     def __call__(
-        self, patch: np.ndarray, target: Optional[np.ndarray] = None
-    ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+        self,
+        patch: NDArray,
+        target: Optional[NDArray] = None,
+        **additional_arrays: NDArray,
+    ) -> tuple[NDArray, Optional[NDArray], dict[str, NDArray]]:
         """Apply the transform to the source patch and the target (optional).
 
         Parameters
@@ -95,17 +99,20 @@ class XYFlip(Transform):
             Transformed patch and target.
         """
         if self.rng.random() > self.p:
-            return patch, target
+            return patch, target, additional_arrays
 
         # choose an axis to flip
         axis = self.rng.choice(self.axis_indices)
 
         patch_transformed = self._apply(patch, axis)
         target_transformed = self._apply(target, axis) if target is not None else None
+        additional_transformed = {
+            key: self._apply(array, axis) for key, array in additional_arrays.items()
+        }
 
-        return patch_transformed, target_transformed
+        return patch_transformed, target_transformed, additional_transformed
 
-    def _apply(self, patch: np.ndarray, axis: int) -> np.ndarray:
+    def _apply(self, patch: NDArray, axis: int) -> NDArray:
         """Apply the transform to the image.
 
         Parameters

--- a/src/careamics/transforms/xy_flip.py
+++ b/src/careamics/transforms/xy_flip.py
@@ -92,6 +92,9 @@ class XYFlip(Transform):
             Patch, 2D or 3D, shape C(Z)YX.
         target : Optional[np.ndarray], optional
             Target for the patch, by default None.
+        **additional_arrays : NDArray
+            Additional arrays that will be tranformed identically to `patch` and
+            `target`.
 
         Returns
         -------

--- a/src/careamics/transforms/xy_flip.py
+++ b/src/careamics/transforms/xy_flip.py
@@ -93,7 +93,7 @@ class XYFlip(Transform):
         target : Optional[np.ndarray], optional
             Target for the patch, by default None.
         **additional_arrays : NDArray
-            Additional arrays that will be tranformed identically to `patch` and
+            Additional arrays that will be transformed identically to `patch` and
             `target`.
 
         Returns

--- a/src/careamics/transforms/xy_random_rotate90.py
+++ b/src/careamics/transforms/xy_random_rotate90.py
@@ -3,6 +3,7 @@
 from typing import Optional, Tuple
 
 import numpy as np
+from numpy.typing import NDArray
 
 from careamics.transforms.transform import Transform
 
@@ -49,8 +50,11 @@ class XYRandomRotate90(Transform):
         self.rng = np.random.default_rng(seed=seed)
 
     def __call__(
-        self, patch: np.ndarray, target: Optional[np.ndarray] = None
-    ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+        self,
+        patch: NDArray,
+        target: Optional[NDArray] = None,
+        **additional_arrays: NDArray,
+    ) -> tuple[NDArray, Optional[NDArray], dict[str, NDArray]]:
         """Apply the transform to the source patch and the target (optional).
 
         Parameters
@@ -66,7 +70,7 @@ class XYRandomRotate90(Transform):
             Transformed patch and target.
         """
         if self.rng.random() > self.p:
-            return patch, target
+            return patch, target, additional_arrays
 
         # number of rotations
         n_rot = self.rng.integers(1, 4)
@@ -76,12 +80,14 @@ class XYRandomRotate90(Transform):
         target_transformed = (
             self._apply(target, n_rot, axes) if target is not None else None
         )
+        additional_transformed = {
+            key: self._apply(array, n_rot, axes)
+            for key, array in additional_arrays.items()
+        }
 
-        return patch_transformed, target_transformed
+        return patch_transformed, target_transformed, additional_transformed
 
-    def _apply(
-        self, patch: np.ndarray, n_rot: int, axes: Tuple[int, int]
-    ) -> np.ndarray:
+    def _apply(self, patch: NDArray, n_rot: int, axes: Tuple[int, int]) -> NDArray:
         """Apply the transform to the image.
 
         Parameters

--- a/src/careamics/transforms/xy_random_rotate90.py
+++ b/src/careamics/transforms/xy_random_rotate90.py
@@ -64,7 +64,7 @@ class XYRandomRotate90(Transform):
         target : Optional[np.ndarray], optional
             Target for the patch, by default None.
         **additional_arrays : NDArray
-            Additional arrays that will be tranformed identically to `patch` and
+            Additional arrays that will be transformed identically to `patch` and
             `target`.
 
         Returns

--- a/src/careamics/transforms/xy_random_rotate90.py
+++ b/src/careamics/transforms/xy_random_rotate90.py
@@ -63,6 +63,9 @@ class XYRandomRotate90(Transform):
             Patch, 2D or 3D, shape C(Z)YX.
         target : Optional[np.ndarray], optional
             Target for the patch, by default None.
+        **additional_arrays : NDArray
+            Additional arrays that will be tranformed identically to `patch` and
+            `target`.
 
         Returns
         -------

--- a/tests/transforms/test_compose.py
+++ b/tests/transforms/test_compose.py
@@ -47,8 +47,8 @@ def test_compose_with_target(ordered_array):
     source_transformed, target_transformed = compose(source, target)
 
     # apply them manually
-    t1_source, t1_target = transform_list[0](source, target)
-    t2_source, t2_target = transform_list[1](t1_source, t1_target)
+    t1_source, t1_target, _ = transform_list[0](source, target)
+    t2_source, t2_target, _ = transform_list[1](t1_source, t1_target)
 
     # check the results
     assert (source_transformed == t2_source).all()
@@ -72,9 +72,12 @@ def test_compose_n2v(ordered_array):
     # apply the transforms
     normalize = Normalize(image_means=means, image_stds=stds)
     xyflip = XYFlip(seed=seed)
-
     xyrotate = XYRandomRotate90(seed=seed)
-    array_aug, _ = xyrotate(*xyflip(*normalize(array[0])))
+    array_aug, *_ = xyrotate(
+        *xyflip(*normalize(array[0])[:2])[  # ignore additional_arrays (element no. 3)
+            :2
+        ]  # ignore additional_arrays (element no. 3)
+    )
 
     # instantiate Compose
     compose = Compose(transform_list_pydantic)

--- a/tests/transforms/test_compose.py
+++ b/tests/transforms/test_compose.py
@@ -157,7 +157,7 @@ def test_compose_additional_arrays(ordered_array):
 
     compose = Compose(transforms)
 
-    augmented, _, additional_augmented = compose.tranform_with_additional_arrays(
+    augmented, _, additional_augmented = compose.transform_with_additional_arrays(
         array, **additional_arrays
     )
     assert np.array_equal(augmented, additional_augmented["arr"])

--- a/tests/transforms/test_compose.py
+++ b/tests/transforms/test_compose.py
@@ -139,3 +139,25 @@ def test_random_composition(ordered_array, shape):
         result_array, result_mask = compose(array, mask)
         assert not np.array_equal(result_array, array)
         assert not np.array_equal(result_mask, mask)
+
+
+def test_compose_additional_arrays(ordered_array):
+    """Test additional arrays get tranformed in the same way as the patch."""
+    seed = 24
+    # create inputs
+    shape = (2, 2, 5, 5)
+    array = ordered_array(shape)
+    additional_arrays = {"arr": ordered_array(shape)}
+
+    # create tranforms
+    transforms = [
+        XYFlipModel(name="XYFlip", seed=seed),
+        XYRandomRotate90Model(name="XYRandomRotate90", seed=seed),
+    ]
+
+    compose = Compose(transforms)
+
+    augmented, _, additional_augmented = compose.tranform_with_additional_arrays(
+        array, **additional_arrays
+    )
+    assert np.array_equal(augmented, additional_augmented["arr"])

--- a/tests/transforms/test_normalize.py
+++ b/tests/transforms/test_normalize.py
@@ -56,7 +56,7 @@ def test_normalize_denormalize(channels):
     )
 
     # Apply the transform, removing the sample dimension
-    normalized, _ = norm(patch=array[0])
+    normalized, *_ = norm(patch=array[0])
     assert np.abs(normalized.mean()) < 0.02
     assert np.abs(normalized.std() - 1) < 0.2
 

--- a/tests/transforms/test_normalize.py
+++ b/tests/transforms/test_normalize.py
@@ -69,3 +69,24 @@ def test_normalize_denormalize(channels):
     # Apply the denormalize transform
     denormalized = denorm(patch=normalized[np.newaxis, ...])  # need to add batch dim
     assert np.isclose(denormalized, array, atol=1e-6).all()
+
+
+# long name sorry
+def test_transform_additional_arrays_not_implemented(ordered_array):
+    """Test normalize raises not implemented if additional arrays are used"""
+    # create inputs
+    shape = (2, 2, 5, 5)
+    array = ordered_array(shape)
+    additional_arrays = {"arr": ordered_array(shape)}
+
+    # Compute mean and std
+    means, stds = compute_normalization_stats(image=array)
+
+    # Create the transform
+    norm = Normalize(
+        image_means=means,
+        image_stds=stds,
+    )
+
+    with pytest.raises(NotImplementedError):
+        norm(array, **additional_arrays)

--- a/tests/transforms/test_tta.py
+++ b/tests/transforms/test_tta.py
@@ -69,8 +69,8 @@ def test_same_transforms(shape):
     flip = XYFlip(seed=42)
 
     for _ in range(100):
-        rotated, _ = rot(tensor)
-        flipped, _ = flip(rotated)
+        rotated, *_ = rot(tensor)
+        flipped, *_ = flip(rotated)
 
         # check that is in the augmented list
         assert any(torch.allclose(torch.Tensor(flipped), aug) for aug in augmented)

--- a/tests/transforms/test_xy_flip.py
+++ b/tests/transforms/test_xy_flip.py
@@ -46,7 +46,7 @@ def test_flip_xy(ordered_array, shape):
     # apply augmentation 5 times
     for _ in range(4):
         r.random()  # consume random number
-        augmented, _ = aug(array)
+        augmented, *_ = aug(array)
 
         # draw axis
         axis = r.choice(axes)
@@ -82,7 +82,7 @@ def test_flip_single_axis(ordered_array, shape, flip_x):
 
     # apply augmentation 5 times
     for _ in range(5):
-        augmented, _ = aug(array)
+        augmented, *_ = aug(array)
 
         assert np.array_equal(augmented, np.flip(array, axis=axis))
 
@@ -105,7 +105,7 @@ def test_flip_mask(ordered_array):
 
     # apply augmentation 5 times
     for _ in range(5):
-        aug_array, aug_mask = aug(patch=array, target=mask)
+        aug_array, aug_mask, _ = aug(patch=array, target=mask)
         r.random()  # consume random number
         axis = r.choice(axes)
 
@@ -123,7 +123,7 @@ def test_p(ordered_array):
 
     # apply augmentation 5 times
     for _ in range(5):
-        augmented, _ = aug(array)
+        augmented, *_ = aug(array)
 
         assert np.array_equal(augmented, array)
 
@@ -132,6 +132,6 @@ def test_p(ordered_array):
 
     # apply augmentation 5 times
     for _ in range(5):
-        augmented, _ = aug(array)
+        augmented, *_ = aug(array)
 
         assert not np.array_equal(augmented, array)

--- a/tests/transforms/test_xy_flip.py
+++ b/tests/transforms/test_xy_flip.py
@@ -55,6 +55,43 @@ def test_flip_xy(ordered_array, shape):
 
 
 @pytest.mark.parametrize(
+    "shape",
+    [
+        # 2D
+        (1, 2, 2),
+        (2, 2, 2),
+        # 3D
+        (1, 2, 2, 2),
+        (2, 2, 2, 2),
+    ],
+)
+def test_additional_arrays_flip_xy(ordered_array, shape):
+    """Test flipping for 2D and 3D arrays."""
+    # create array
+    array: np.ndarray = ordered_array(shape)
+    additional_arrays = {"arr": ordered_array(shape)}
+
+    # create augmentation
+    aug = XYFlip(p=1, seed=42)
+    r = np.random.default_rng(seed=42)
+
+    # potential flips
+    axes = [-2, -1]
+    flips = [np.flip(array, axis=axis) for axis in axes]
+
+    # apply augmentation 5 times
+    for _ in range(4):
+        r.random()  # consume random number
+        augmented, _, additional_augmented = aug(array, **additional_arrays)
+
+        # draw axis
+        axis = r.choice(axes)
+
+        assert np.array_equal(augmented, flips[axis])
+        assert np.array_equal(augmented, additional_augmented["arr"])
+
+
+@pytest.mark.parametrize(
     "shape, flip_x",
     [
         # 2D

--- a/tests/transforms/test_xy_random_rotate90.py
+++ b/tests/transforms/test_xy_random_rotate90.py
@@ -34,7 +34,7 @@ def test_xy_rotate(ordered_array, shape):
     # check rotations
     for _ in range(5):
         r.random()  # consume random number
-        augmented, _ = aug(array)
+        augmented, *_ = aug(array)
 
         assert np.array_equal(augmented, rots[r.integers(1, 4) - 1])
 
@@ -65,7 +65,7 @@ def test_mask_rotate(ordered_array):
     # apply augmentation 10 times
     for _ in range(5):
         r.random()  # consume random number
-        augmented_p, augmented_m = aug(array, mask)
+        augmented_p, augmented_m, _ = aug(array, mask)
         n_rot = r.integers(1, 4)
 
         assert np.array_equal(augmented_p, array_rots[n_rot - 1])
@@ -82,7 +82,7 @@ def test_p(ordered_array):
 
     # apply augmentation 5 times
     for _ in range(5):
-        augmented, _ = aug(array)
+        augmented, *_ = aug(array)
 
         assert np.array_equal(augmented, array)
 
@@ -91,6 +91,6 @@ def test_p(ordered_array):
 
     # apply augmentation 5 times
     for _ in range(5):
-        augmented, _ = aug(array)
+        augmented, *_ = aug(array)
 
         assert not np.array_equal(augmented, array)

--- a/tests/transforms/test_xy_random_rotate90.py
+++ b/tests/transforms/test_xy_random_rotate90.py
@@ -39,6 +39,43 @@ def test_xy_rotate(ordered_array, shape):
         assert np.array_equal(augmented, rots[r.integers(1, 4) - 1])
 
 
+@pytest.mark.parametrize(
+    "shape",
+    [
+        # 2D
+        (1, 2, 2),
+        (2, 2, 2),
+        # 3D
+        (1, 2, 2, 2),
+        (2, 2, 2, 2),
+    ],
+)
+def test_additional_arrays_xy_rotate(ordered_array, shape):
+    """Test rotation for 2D and 3D arrays with a fixed seed."""
+    # create array
+    array: np.ndarray = ordered_array(shape)
+    additional_arrays = {"arr": ordered_array(shape)}
+
+    # create augmentation
+    aug = XYRandomRotate90(p=1, seed=42)
+    r = np.random.default_rng(seed=42)
+
+    axes = (2, 3) if len(array.shape) == 4 else (1, 2)
+    rots = [
+        np.rot90(array, k=1, axes=axes),
+        np.rot90(array, k=2, axes=axes),
+        np.rot90(array, k=3, axes=axes),
+    ]
+
+    # check rotations
+    for _ in range(5):
+        r.random()  # consume random number
+        augmented, _, additional_augmented = aug(array, **additional_arrays)
+
+        assert np.array_equal(augmented, rots[r.integers(1, 4) - 1])
+        assert np.array_equal(augmented, additional_augmented["arr"])
+
+
 def test_mask_rotate(ordered_array):
     """Test rotating masks in 3D."""
     aug = XYRandomRotate90(p=1, seed=42)


### PR DESCRIPTION
### Description

- **What**: Add option in `XYFilp` and `XYRandomRotate90` to transform additional arrays identically to the patch and target. Include the ability to compose these transforms. Also fixed some type hint issues, but some remain.
- **Why**: The LVAE training requires the identical transformation of multiple arrays, including images and noise arrays. Previously it was implemented with the `Albumentations` library. Original motivation came from this comment chain https://github.com/CAREamics/careamics/pull/223#discussion_r1733656634.
- **How**: A few options were considered, but ultimately I went with what I thought would require the least amount of the code base to change. Additional arrays can passed to the transform `__call__` function as kwargs, and they will be returned as a dict after the augmented patch and target. Composition of transforms with additional arrays has been kept as a separate method, `Compose.transform_with_additional_arrays`, mostly to not have to change too much of the code base, this can be revised and integrated with `Compose.__call__` later if desired.

### Changes Made

- **Added**: 
  - Tests for the new functionality.
  - `_chain_transforms_additional_arrays` and `transform_with_additional_arrays` methods to `Compose`.
- **Modified**: 
  -  add `**additional_arrays: NDArray` argument to the `__call__` method of some transforms.
  - A few existing tests that needed to modify the unpacking of transform outputs, now that they output a tuple of 3 rather than 2.

### Breaking changes

Code calling transforms directly, the output is now a tuple of 3 rather than 2.


### Additional Notes and Examples

#### Note

One of the biggest pain points that hasn't been fully resolved is that the `N2VManipulate` transform doesn't have the same function signature in the `__call__` method as the other transforms, it returns 3 arrays rather than 2. We know it gets applied last in the algorithm but we could make it more explicit somehow, this would resolve some annoying type hinting.

#### Converting LVAE transform code

https://github.com/CAREamics/careamics/blob/b008187292f269455272c92c9009d45a330e7ca0/src/careamics/lvae_training/dataset/vae_dataset.py#L867-L881

To convert the code snippet above, I think (not tested) the following can be done, assuming `self.rotation_transform` is created using the CAREamics `Compose` instead of that from Albumentations:

```python
img_kwargs = {}
for i, img in enumerate(img_tuples):
    for k in range(len(img)):
        img_kwargs[f"img{i}_{k}"] = img[k]

noise_kwargs = {}
for i, nimg in enumerate(noise_tuples):
    for k in range(len(nimg)):
        noise_kwargs[f"noise{i}_{k}"] = nimg[k]

img, _, rot_dic = self._rotation_transform.transform_with_additional_arrays(
    img_tuples[0][0], **img_kwargs, **noise_kwargs
)
```

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)