### PR TITLE
Add custom transforms to convenience functions, and other API improvement

### DIFF
--- a/src/careamics/config/configuration_factory.py
+++ b/src/careamics/config/configuration_factory.py
@@ -577,7 +577,7 @@ def create_n2n_configuration(
     ...     patch_size=[64, 64],
     ...     batch_size=32,
     ...     num_epochs=100,
-    ...     use_augmentations=[]
+    ...     augmentations=[]
     ... )
 
     A list of transforms can be passed to the `augmentations` parameter to replace the

--- a/src/careamics/config/configuration_factory.py
+++ b/src/careamics/config/configuration_factory.py
@@ -13,7 +13,6 @@ from .support import (
 )
 from .training_model import TrainingConfig
 from .transformations import (
-    TRANSFORMS_UNION,
     N2VManipulateModel,
     TransformModel,
     XYFlipModel,
@@ -75,7 +74,7 @@ def _create_configuration(
     patch_size: list[int],
     batch_size: int,
     num_epochs: int,
-    augmentations: list[TRANSFORMS_UNION],
+    augmentations: list[TransformModel],
     independent_channels: bool,
     loss: Literal["n2v", "mae", "mse"],
     n_channels_in: int,
@@ -183,7 +182,7 @@ def _create_supervised_configuration(
     batch_size: int,
     num_epochs: int,
     use_augmentations: bool = True,
-    augmentations: Optional[list[TRANSFORMS_UNION]] = None,
+    augmentations: Optional[list[TransformModel]] = None,
     independent_channels: bool = True,
     loss: Literal["mae", "mse"] = "mae",
     n_channels_in: int = 1,
@@ -251,7 +250,7 @@ def _create_supervised_configuration(
     # augmentations
     if use_augmentations:
         if augmentations is None:
-            transform_list: list[TRANSFORMS_UNION] = [
+            transform_list: list[TransformModel] = [
                 XYFlipModel(),
                 XYRandomRotate90Model(),
             ]
@@ -287,7 +286,7 @@ def create_care_configuration(
     batch_size: int,
     num_epochs: int,
     use_augmentations: bool = True,
-    augmentations: Optional[list[TRANSFORMS_UNION]] = None,
+    augmentations: Optional[list[TransformModel]] = None,
     independent_channels: bool = True,
     loss: Literal["mae", "mse"] = "mae",
     n_channels_in: int = 1,
@@ -454,7 +453,7 @@ def create_n2n_configuration(
     batch_size: int,
     num_epochs: int,
     use_augmentations: bool = True,
-    augmentations: Optional[list[TRANSFORMS_UNION]] = None,
+    augmentations: Optional[list[TransformModel]] = None,
     independent_channels: bool = True,
     loss: Literal["mae", "mse"] = "mae",
     n_channels_in: int = 1,
@@ -621,7 +620,7 @@ def create_n2v_configuration(
     batch_size: int,
     num_epochs: int,
     use_augmentations: bool = True,
-    augmentations: Optional[list[TRANSFORMS_UNION]] = None,
+    augmentations: Optional[list[TransformModel]] = None,
     independent_channels: bool = True,
     use_n2v2: bool = False,
     n_channels: int = 1,
@@ -823,7 +822,7 @@ def create_n2v_configuration(
     # augmentations
     if use_augmentations:
         if augmentations is None:
-            transform_list: list[TRANSFORMS_UNION] = [
+            transform_list: list[TransformModel] = [
                 XYFlipModel(),
                 XYRandomRotate90Model(),
             ]

--- a/src/careamics/config/configuration_factory.py
+++ b/src/careamics/config/configuration_factory.py
@@ -27,7 +27,7 @@ def _create_unet(
     n_channels_out: int,
     independent_channels: bool,
     use_n2v2: bool,
-    model_kwargs: Optional[dict[str, Any]] = None,
+    model_params: Optional[dict[str, Any]] = None,
 ) -> UNetModel:
     """
     Create a dictionary with the parameters of the UNet model.
@@ -44,7 +44,7 @@ def _create_unet(
         Whether to train all channels independently.
     use_n2v2 : bool
         Whether to use N2V2.
-    model_kwargs : dict
+    model_params : dict
         UNetModel parameters.
 
     Returns
@@ -52,18 +52,18 @@ def _create_unet(
     UNetModel
         UNet model with the specified parameters.
     """
-    if model_kwargs is None:
-        model_kwargs = {}
+    if model_params is None:
+        model_params = {}
 
-    model_kwargs["n2v2"] = use_n2v2
-    model_kwargs["conv_dims"] = 3 if "Z" in axes else 2
-    model_kwargs["in_channels"] = n_channels_in
-    model_kwargs["num_classes"] = n_channels_out
-    model_kwargs["independent_channels"] = independent_channels
+    model_params["n2v2"] = use_n2v2
+    model_params["conv_dims"] = 3 if "Z" in axes else 2
+    model_params["in_channels"] = n_channels_in
+    model_params["num_classes"] = n_channels_out
+    model_params["independent_channels"] = independent_channels
 
     return UNetModel(
         architecture=SupportedArchitecture.UNET.value,
-        **model_kwargs,
+        **model_params,
     )
 
 
@@ -81,8 +81,9 @@ def _create_configuration(
     n_channels_in: int,
     n_channels_out: int,
     logger: Literal["wandb", "tensorboard", "none"],
-    model_kwargs: Optional[dict],
     use_n2v2: bool = False,
+    model_params: Optional[dict] = None,
+    dataloader_params: Optional[dict] = None,
 ) -> Configuration:
     """
     Create a configuration for training N2V, CARE or Noise2Noise.
@@ -115,10 +116,12 @@ def _create_configuration(
         Number of channels out.
     logger : {"wandb", "tensorboard", "none"}
         Logger to use.
-    model_kwargs : dict
-        UNetModel parameters.
     use_n2v2 : bool, optional
         Whether to use N2V2, by default False.
+    model_params : dict
+        UNetModel parameters.
+    dataloader_params : dict
+        Parameters for the dataloader, see PyTorch notes, by default None.
 
     Returns
     -------
@@ -132,7 +135,7 @@ def _create_configuration(
         n_channels_out=n_channels_out,
         independent_channels=independent_channels,
         use_n2v2=use_n2v2,
-        model_kwargs=model_kwargs,
+        model_params=model_params,
     )
 
     # algorithm model
@@ -150,6 +153,7 @@ def _create_configuration(
         patch_size=patch_size,
         batch_size=batch_size,
         transforms=augmentations,
+        dataloader_params=dataloader_params,
     )
 
     # training model
@@ -185,7 +189,8 @@ def _create_supervised_configuration(
     n_channels_in: int = 1,
     n_channels_out: int = 1,
     logger: Literal["wandb", "tensorboard", "none"] = "none",
-    model_kwargs: Optional[dict] = None,
+    model_params: Optional[dict] = None,
+    dataloader_params: Optional[dict] = None,
 ) -> Configuration:
     """
     Create a configuration for training CARE or Noise2Noise.
@@ -221,8 +226,10 @@ def _create_supervised_configuration(
         Number of channels out, by default 1.
     logger : Literal["wandb", "tensorboard", "none"], optional
         Logger to use, by default "none".
-    model_kwargs : dict, optional
+    model_params : dict, optional
         UNetModel parameters, by default {}.
+    dataloader_params : dict, optional
+        Parameters for the dataloader, see PyTorch notes, by default None.
 
     Returns
     -------
@@ -267,7 +274,8 @@ def _create_supervised_configuration(
         n_channels_in=n_channels_in,
         n_channels_out=n_channels_out,
         logger=logger,
-        model_kwargs=model_kwargs,
+        model_params=model_params,
+        dataloader_params=dataloader_params,
     )
 
 
@@ -285,7 +293,8 @@ def create_care_configuration(
     n_channels_in: int = 1,
     n_channels_out: int = -1,
     logger: Literal["wandb", "tensorboard", "none"] = "none",
-    model_kwargs: Optional[dict] = None,
+    model_params: Optional[dict] = None,
+    dataloader_params: Optional[dict] = None,
 ) -> Configuration:
     """
     Create a configuration for training CARE.
@@ -337,8 +346,10 @@ def create_care_configuration(
         Number of channels out, by default -1.
     logger : Literal["wandb", "tensorboard", "none"], optional
         Logger to use, by default "none".
-    model_kwargs : dict, optional
-        UNetModel parameters, by default {}.
+    model_params : dict, optional
+        UNetModel parameters, by default None.
+    dataloader_params : dict, optional
+        Parameters for the dataloader, see PyTorch notes, by default None.
 
     Returns
     -------
@@ -430,7 +441,8 @@ def create_care_configuration(
         n_channels_in=n_channels_in,
         n_channels_out=n_channels_out,
         logger=logger,
-        model_kwargs=model_kwargs,
+        model_params=model_params,
+        dataloader_params=dataloader_params,
     )
 
 
@@ -448,7 +460,8 @@ def create_n2n_configuration(
     n_channels_in: int = 1,
     n_channels_out: int = -1,
     logger: Literal["wandb", "tensorboard", "none"] = "none",
-    model_kwargs: Optional[dict] = None,
+    model_params: Optional[dict] = None,
+    dataloader_params: Optional[dict] = None,
 ) -> Configuration:
     """
     Create a configuration for training Noise2Noise.
@@ -500,8 +513,10 @@ def create_n2n_configuration(
         Number of channels out, by default -1.
     logger : Literal["wandb", "tensorboard", "none"], optional
         Logger to use, by default "none".
-    model_kwargs : dict, optional
+    model_params : dict, optional
         UNetModel parameters, by default {}.
+    dataloader_params : dict, optional
+        Parameters for the dataloader, see PyTorch notes, by default None.
 
     Returns
     -------
@@ -593,7 +608,8 @@ def create_n2n_configuration(
         n_channels_in=n_channels_in,
         n_channels_out=n_channels_out,
         logger=logger,
-        model_kwargs=model_kwargs,
+        model_params=model_params,
+        dataloader_params=dataloader_params,
     )
 
 
@@ -614,7 +630,8 @@ def create_n2v_configuration(
     struct_n2v_axis: Literal["horizontal", "vertical", "none"] = "none",
     struct_n2v_span: int = 5,
     logger: Literal["wandb", "tensorboard", "none"] = "none",
-    model_kwargs: Optional[dict] = None,
+    model_params: Optional[dict] = None,
+    dataloader_params: Optional[dict] = None,
 ) -> Configuration:
     """
     Create a configuration for training Noise2Void.
@@ -652,9 +669,9 @@ def create_n2v_configuration(
     be manipulated by N2V. The `masked_pixel_percentage` parameter specifies how many
     pixels per patch will be manipulated.
 
-    The parameters of the UNet can be specified in the `model_kwargs` (passed as a
+    The parameters of the UNet can be specified in the `model_params` (passed as a
     parameter-value dictionary). Note that `use_n2v2` and 'n_channels' override the
-    corresponding parameters passed in `model_kwargs`.
+    corresponding parameters passed in `model_params`.
 
     If you pass "horizontal" or "vertical" to `struct_n2v_axis`, then structN2V mask
     will be applied to each manipulated pixel.
@@ -694,8 +711,10 @@ def create_n2v_configuration(
         Span of the structN2V mask, by default 5.
     logger : Literal["wandb", "tensorboard", "none"], optional
         Logger to use, by default "none".
-    model_kwargs : dict, optional
-        UNetModel parameters, by default {}.
+    model_params : dict, optional
+        UNetModel parameters, by default None.
+    dataloader_params : dict, optional
+        Parameters for the dataloader, see PyTorch notes, by default None.
 
     Returns
     -------
@@ -855,5 +874,6 @@ def create_n2v_configuration(
         n_channels_in=n_channels,
         n_channels_out=n_channels,
         logger=logger,
-        model_kwargs=model_kwargs,
+        model_params=model_params,
+        dataloader_params=dataloader_params,
     )

--- a/src/careamics/config/configuration_factory.py
+++ b/src/careamics/config/configuration_factory.py
@@ -260,9 +260,10 @@ def _create_supervised_configuration(
         Batch size.
     num_epochs : int
         Number of epochs.
-    augmentations : list of transforms, optional
+    augmentations : list of transforms, default=None
         List of transforms to apply, either both or one of XYFlipModel and
-        XYRandomRotate90Model.
+        XYRandomRotate90Model. By default, it applies both XYFlip (on X and Y)
+        and XYRandomRotate90 (in XY) to the images.
     independent_channels : bool, optional
         Whether to train all channels independently, by default False.
     loss : Literal["mae", "mse"], optional
@@ -368,9 +369,10 @@ def create_care_configuration(
         Batch size.
     num_epochs : int
         Number of epochs.
-    augmentations : list of transforms, optional
+    augmentations : list of transforms, default=None
         List of transforms to apply, either both or one of XYFlipModel and
-        XYRandomRotate90Model.
+        XYRandomRotate90Model. By default, it applies both XYFlip (on X and Y)
+        and XYRandomRotate90 (in XY) to the images.
     independent_channels : bool, optional
         Whether to train all channels independently, by default False.
     loss : Literal["mae", "mse"], optional
@@ -531,9 +533,10 @@ def create_n2n_configuration(
         Batch size.
     num_epochs : int
         Number of epochs.
-    augmentations : list of transforms, optional
+    augmentations : list of transforms, default=None
         List of transforms to apply, either both or one of XYFlipModel and
-        XYRandomRotate90Model.
+        XYRandomRotate90Model. By default, it applies both XYFlip (on X and Y)
+        and XYRandomRotate90 (in XY) to the images.
     independent_channels : bool, optional
         Whether to train all channels independently, by default False.
     loss : Literal["mae", "mse"], optional
@@ -717,9 +720,10 @@ def create_n2v_configuration(
         Batch size.
     num_epochs : int
         Number of epochs.
-    augmentations : list of transforms, optional
+    augmentations : list of transforms, default=None
         List of transforms to apply, either both or one of XYFlipModel and
-        XYRandomRotate90Model.
+        XYRandomRotate90Model. By default, it applies both XYFlip (on X and Y)
+        and XYRandomRotate90 (in XY) to the images.
     independent_channels : bool, optional
         Whether to train all channels together, by default True.
     use_n2v2 : bool, optional

--- a/src/careamics/config/data_model.py
+++ b/src/careamics/config/data_model.py
@@ -10,7 +10,6 @@ from numpy.typing import NDArray
 from pydantic import (
     BaseModel,
     ConfigDict,
-    Discriminator,
     Field,
     PlainSerializer,
     field_validator,
@@ -19,9 +18,7 @@ from pydantic import (
 from typing_extensions import Annotated, Self
 
 from .support import SupportedTransform
-from .transformations.n2v_manipulate_model import N2VManipulateModel
-from .transformations.xy_flip_model import XYFlipModel
-from .transformations.xy_random_rotate90_model import XYRandomRotate90Model
+from .transformations import TRANSFORMS_UNION, N2VManipulateModel
 from .validators import check_axes_validity, patch_size_ge_than_8_power_of_2
 
 
@@ -46,17 +43,6 @@ def np_float_to_scientific_str(x: float) -> str:
 
 Float = Annotated[float, PlainSerializer(np_float_to_scientific_str, return_type=str)]
 """Annotated float type, used to serialize floats to strings."""
-
-
-TRANSFORMS_UNION = Annotated[
-    Union[
-        XYFlipModel,
-        XYRandomRotate90Model,
-        N2VManipulateModel,
-    ],
-    Discriminator("name"),  # used to tell the different transform models apart
-]
-"""Available transforms in CAREamics."""
 
 
 class DataConfig(BaseModel):

--- a/src/careamics/config/support/supported_transforms.py
+++ b/src/careamics/config/support/supported_transforms.py
@@ -9,3 +9,4 @@ class SupportedTransform(str, BaseEnum):
     XY_FLIP = "XYFlip"
     XY_RANDOM_ROTATE90 = "XYRandomRotate90"
     N2V_MANIPULATE = "N2VManipulate"
+    NORMALIZE = "Normalize"

--- a/src/careamics/config/transformations/__init__.py
+++ b/src/careamics/config/transformations/__init__.py
@@ -5,11 +5,14 @@ __all__ = [
     "XYFlipModel",
     "NormalizeModel",
     "XYRandomRotate90Model",
-    "XorYFlipModel",
+    "TransformModel",
+    "TRANSFORMS_UNION",
 ]
 
 
 from .n2v_manipulate_model import N2VManipulateModel
 from .normalize_model import NormalizeModel
+from .transform_model import TransformModel
+from .transform_union import TRANSFORMS_UNION
 from .xy_flip_model import XYFlipModel
 from .xy_random_rotate90_model import XYRandomRotate90Model

--- a/src/careamics/config/transformations/transform_union.py
+++ b/src/careamics/config/transformations/transform_union.py
@@ -1,0 +1,20 @@
+"""Type used to represent all transformations users can create."""
+
+from typing import Union
+
+from pydantic import Discriminator
+from typing_extensions import Annotated
+
+from .n2v_manipulate_model import N2VManipulateModel
+from .xy_flip_model import XYFlipModel
+from .xy_random_rotate90_model import XYRandomRotate90Model
+
+TRANSFORMS_UNION = Annotated[
+    Union[
+        XYFlipModel,
+        XYRandomRotate90Model,
+        N2VManipulateModel,
+    ],
+    Discriminator("name"),  # used to tell the different transform models apart
+]
+"""Available transforms in CAREamics."""

--- a/src/careamics/lightning/train_data_module.py
+++ b/src/careamics/lightning/train_data_module.py
@@ -9,8 +9,8 @@ from numpy.typing import NDArray
 from torch.utils.data import DataLoader
 
 from careamics.config import DataConfig
-from careamics.config.data_model import TRANSFORMS_UNION
 from careamics.config.support import SupportedData
+from careamics.config.transformations import TRANSFORMS_UNION
 from careamics.dataset.dataset_utils import (
     get_files_size,
     list_files,

--- a/src/careamics/lightning/train_data_module.py
+++ b/src/careamics/lightning/train_data_module.py
@@ -10,7 +10,7 @@ from torch.utils.data import DataLoader
 
 from careamics.config import DataConfig
 from careamics.config.support import SupportedData
-from careamics.config.transformations import TRANSFORMS_UNION
+from careamics.config.transformations import TransformModel
 from careamics.dataset.dataset_utils import (
     get_files_size,
     list_files,
@@ -472,7 +472,7 @@ def create_train_datamodule(
     axes: str,
     batch_size: int,
     val_data: Optional[Union[str, Path, NDArray]] = None,
-    transforms: Optional[list[TRANSFORMS_UNION]] = None,
+    transforms: Optional[list[TransformModel]] = None,
     train_target_data: Optional[Union[str, Path, NDArray]] = None,
     val_target_data: Optional[Union[str, Path, NDArray]] = None,
     read_source_func: Optional[Callable] = None,

--- a/src/careamics/transforms/compose.py
+++ b/src/careamics/transforms/compose.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Tuple, cast
 
 import numpy as np
 
-from careamics.config.transformations import TRANSFORMS_UNION
+from careamics.config.transformations import TransformModel
 
 from .n2v_manipulate import N2VManipulate
 from .normalize import Normalize
@@ -36,7 +36,7 @@ class Compose:
 
     Parameters
     ----------
-    transform_list : List[TRANSFORMS_UNION]
+    transform_list : List[TransformModel]
         A list of dictionaries where each dictionary contains the name of a
         transform and its parameters.
 
@@ -46,12 +46,12 @@ class Compose:
         A callable that applies the transforms to the input data.
     """
 
-    def __init__(self, transform_list: List[TRANSFORMS_UNION]) -> None:
+    def __init__(self, transform_list: List[TransformModel]) -> None:
         """Instantiate a Compose object.
 
         Parameters
         ----------
-        transform_list : List[TRANSFORMS_UNION]
+        transform_list : List[TransformModel]
             A list of dictionaries where each dictionary contains the name of a
             transform and its parameters.
         """

--- a/src/careamics/transforms/compose.py
+++ b/src/careamics/transforms/compose.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Tuple, cast
 
 import numpy as np
 
-from careamics.config.data_model import TRANSFORMS_UNION
+from careamics.config.transformations import TRANSFORMS_UNION
 
 from .n2v_manipulate import N2VManipulate
 from .normalize import Normalize

--- a/tests/config/test_configuration_factory.py
+++ b/tests/config/test_configuration_factory.py
@@ -5,11 +5,168 @@ from careamics.config import (
     create_n2n_configuration,
     create_n2v_configuration,
 )
+from careamics.config.configuration_factory import (
+    _create_supervised_configuration,
+    _create_unet,
+)
 from careamics.config.support import (
     SupportedPixelManipulation,
     SupportedStructAxis,
     SupportedTransform,
 )
+from careamics.config.transformations import (
+    N2VManipulateModel,
+    XYFlipModel,
+    XYRandomRotate90Model,
+)
+
+
+def test_model_creation():
+    """Test that the correct parameters are passed to the model."""
+    model_kwargs = {
+        "depth": 4,
+        "conv_dims": 2,
+        "n2v2": False,
+        "in_channels": 2,
+        "num_classes": 5,
+        "independent_channels": False,
+    }
+
+    # choose different parameters
+    axes = "XYZ"
+    conv_dims = 3
+    in_channels = 3
+    num_classes = 4
+    independent_channels = True
+    use_n2v2 = True
+
+    model = _create_unet(
+        axes=axes,
+        n_channels_in=in_channels,
+        n_channels_out=num_classes,
+        independent_channels=independent_channels,
+        use_n2v2=use_n2v2,
+        model_kwargs=model_kwargs,
+    )
+
+    assert model.depth == model_kwargs["depth"]
+    assert model.conv_dims == conv_dims
+    assert model.n2v2 == use_n2v2
+    assert model.in_channels == in_channels
+    assert model.num_classes == num_classes
+    assert model.independent_channels == independent_channels
+
+
+def test_supervised_configuration_error_with_channel_axes():
+    """Test that an error is raised if channels are in axes, but the input channel
+    number is not specified."""
+    with pytest.raises(ValueError):
+        _create_supervised_configuration(
+            algorithm="n2n",
+            experiment_name="test",
+            data_type="tiff",
+            axes="CYX",
+            patch_size=[64, 64],
+            batch_size=8,
+            num_epochs=100,
+        )
+
+
+def test_supervised_configuration_error_without_channel_axes():
+    """Test that an error is raised if channels are not in axes, but the input channel
+    number is specified and greater than 1."""
+    with pytest.raises(ValueError):
+        _create_supervised_configuration(
+            algorithm="n2n",
+            experiment_name="test",
+            data_type="tiff",
+            axes="YX",
+            patch_size=[64, 64],
+            batch_size=8,
+            num_epochs=100,
+            n_channels_in=2,
+        )
+
+
+def test_supervised_configuration_channels():
+    """Test that no error is raised if channels are in axes and the input channel
+    are specified."""
+    _create_supervised_configuration(
+        algorithm="n2n",
+        experiment_name="test",
+        data_type="tiff",
+        axes="CYX",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+        n_channels_in=4,
+    )
+
+
+def test_supervised_configuration_aug():
+    """Test that the default augmentations are present."""
+    config = _create_supervised_configuration(
+        algorithm="n2n",
+        experiment_name="test",
+        data_type="tiff",
+        axes="YX",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+    )
+    assert len(config.data_config.transforms) == 2
+    assert config.data_config.transforms[0].name == SupportedTransform.XY_FLIP.value
+    assert (
+        config.data_config.transforms[1].name
+        == SupportedTransform.XY_RANDOM_ROTATE90.value
+    )
+
+
+def test_supervised_configuration_no_aug():
+    """Test that disabling augmentation results in empty transform list."""
+    config = _create_supervised_configuration(
+        algorithm="n2n",
+        experiment_name="test",
+        data_type="tiff",
+        axes="YX",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+        use_augmentations=False,
+    )
+    assert len(config.data_config.transforms) == 0
+
+
+def test_supervised_configuration_no_aug_with_transforms_passed():
+    """Test that the augmentation flag also disables passing transforms."""
+    config = _create_supervised_configuration(
+        algorithm="n2n",
+        experiment_name="test",
+        data_type="tiff",
+        axes="YX",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+        use_augmentations=False,
+        augmentations=[XYFlipModel()],
+    )
+    assert len(config.data_config.transforms) == 0
+
+
+def test_supervised_configuration_passing_transforms():
+    """Test that transforms can be passed to the configuration."""
+    config = _create_supervised_configuration(
+        algorithm="n2n",
+        experiment_name="test",
+        data_type="tiff",
+        axes="YX",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+        augmentations=[XYFlipModel()],
+    )
+    assert len(config.data_config.transforms) == 1
+    assert config.data_config.transforms[0].name == SupportedTransform.XY_FLIP.value
 
 
 def test_n2n_configuration():
@@ -22,140 +179,40 @@ def test_n2n_configuration():
         batch_size=8,
         num_epochs=100,
     )
-
-    assert config.data_config.transforms[0].name == SupportedTransform.XY_FLIP.value
-    assert (
-        config.data_config.transforms[1].name
-        == SupportedTransform.XY_RANDOM_ROTATE90.value
-    )
-    assert not config.algorithm_config.model.is_3D()
+    assert config.algorithm_config.algorithm == "n2n"
 
 
-def test_n2n_3d_configuration():
-    """Test that a 3D N2N configuration can be created."""
-    config = create_care_configuration(
-        experiment_name="test",
-        data_type="tiff",
-        axes="ZYX",
-        patch_size=[64, 64, 64],
-        batch_size=8,
-        num_epochs=100,
-    )
-    assert config.data_config.transforms[0].name == SupportedTransform.XY_FLIP.value
-    assert (
-        config.data_config.transforms[1].name
-        == SupportedTransform.XY_RANDOM_ROTATE90.value
-    )
-    assert config.algorithm_config.model.is_3D()
+def test_n2n_configuration_n_channels():
+    """Test the behaviour of the number of channels in and out."""
+    n_channels_in = 4
+    n_channels_out = 5
 
-
-def test_n2n_3d_errors():
-    """Test that errors are raised if the axes are incompatible with the patches."""
-    with pytest.raises(ValueError):
-        create_n2n_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="ZYX",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=100,
-        )
-
-    with pytest.raises(ValueError):
-        create_n2n_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64, 64],
-            batch_size=8,
-            num_epochs=100,
-        )
-
-
-def test_n2n_channels_errors():
-    """Test that error are raised if the number of input channel and the axes are not
-    compatible."""
-    with pytest.raises(ValueError):
-        create_n2n_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YXC",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=100,
-        )
-
-    with pytest.raises(ValueError):
-        create_n2n_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=100,
-            n_channels_in=5,
-        )
-
-
-def test_n2n_aug_off():
-    """Test that the augmentations are correctly disabled."""
+    # n_channels_out not specified
     config = create_n2n_configuration(
         experiment_name="test",
         data_type="tiff",
-        axes="YX",
+        axes="CYX",
         patch_size=[64, 64],
         batch_size=8,
         num_epochs=100,
-        use_augmentations=False,
+        n_channels_in=n_channels_in,
     )
-    assert len(config.data_config.transforms) == 0
+    assert config.algorithm_config.model.in_channels == n_channels_in
+    assert config.algorithm_config.model.num_classes == n_channels_in
 
-
-@pytest.mark.parametrize("ind_channels", [True, False])
-def test_n2n_independent_channels(ind_channels):
-    """Test that independent channels are correctly passed."""
+    # specify n_channels_out
     config = create_n2n_configuration(
         experiment_name="test",
         data_type="tiff",
-        axes="YXC",
+        axes="CYX",
         patch_size=[64, 64],
         batch_size=8,
         num_epochs=100,
-        n_channels_in=4,
-        independent_channels=ind_channels,
+        n_channels_in=n_channels_in,
+        n_channels_out=n_channels_out,
     )
-    assert config.algorithm_config.model.independent_channels == ind_channels
-
-
-def test_n2n_channels_equal():
-    """Test that channels in and out are equal if only channels_in is set."""
-    config = create_n2n_configuration(
-        experiment_name="test",
-        data_type="tiff",
-        axes="YXC",
-        patch_size=[64, 64],
-        batch_size=8,
-        num_epochs=100,
-        n_channels_in=4,
-    )
-    assert config.algorithm_config.model.in_channels == 4
-    assert config.algorithm_config.model.num_classes == 4
-
-
-def test_n2n_channels_different():
-    """Test that channels in and out can be different."""
-    config = create_n2n_configuration(
-        experiment_name="test",
-        data_type="tiff",
-        axes="YXC",
-        patch_size=[64, 64],
-        batch_size=8,
-        num_epochs=100,
-        n_channels_in=4,
-        n_channels_out=5,
-    )
-    assert config.algorithm_config.model.in_channels == 4
-    assert config.algorithm_config.model.num_classes == 5
+    assert config.algorithm_config.model.in_channels == n_channels_in
+    assert config.algorithm_config.model.num_classes == n_channels_out
 
 
 def test_care_configuration():
@@ -168,132 +225,40 @@ def test_care_configuration():
         batch_size=8,
         num_epochs=100,
     )
-
-    assert config.data_config.transforms[0].name == SupportedTransform.XY_FLIP.value
-    assert (
-        config.data_config.transforms[1].name
-        == SupportedTransform.XY_RANDOM_ROTATE90.value
-    )
-    assert not config.algorithm_config.model.is_3D()
+    assert config.algorithm_config.algorithm == "care"
 
 
-def test_care_3d_configuration():
-    """Test that a 3D care configuration can be created."""
+def test_care_configuration_n_channels():
+    """Test the behaviour of the number of channels in and out."""
+    n_channels_in = 4
+    n_channels_out = 5
+
+    # n_channels_out not specified
     config = create_care_configuration(
         experiment_name="test",
         data_type="tiff",
-        axes="ZYX",
-        patch_size=[64, 64, 64],
-        batch_size=8,
-        num_epochs=100,
-    )
-    assert config.data_config.transforms[0].name == SupportedTransform.XY_FLIP.value
-    assert config.algorithm_config.model.is_3D()
-
-
-def test_care_3d_errors():
-    """Test that errors are raised if the axes are incompatible with the patches."""
-    with pytest.raises(ValueError):
-        create_care_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="ZYX",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=100,
-        )
-
-    with pytest.raises(ValueError):
-        create_care_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64, 64],
-            batch_size=8,
-            num_epochs=100,
-        )
-
-
-def test_care_channels_errors():
-    """Test that error are raised if the number of input channel and the axes are not
-    compatible."""
-    with pytest.raises(ValueError):
-        create_care_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YXC",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=100,
-        )
-
-    with pytest.raises(ValueError):
-        create_care_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=100,
-            n_channels_in=5,
-        )
-
-
-def test_care_aug_off():
-    """Test that the augmentations are correctly disabled."""
-    config = create_care_configuration(
-        experiment_name="test",
-        data_type="tiff",
-        axes="YX",
+        axes="CYX",
         patch_size=[64, 64],
         batch_size=8,
         num_epochs=100,
-        use_augmentations=False,
+        n_channels_in=n_channels_in,
     )
-    assert len(config.data_config.transforms) == 0
+    assert config.algorithm_config.model.in_channels == n_channels_in
+    assert config.algorithm_config.model.num_classes == n_channels_in
 
-
-@pytest.mark.parametrize("ind_channels", [True, False])
-def test_care_independent_channels(ind_channels):
-    """Test that independent channels are correctly passed."""
+    # specify n_channels_out
     config = create_care_configuration(
         experiment_name="test",
         data_type="tiff",
-        axes="YXC",
+        axes="CYX",
         patch_size=[64, 64],
         batch_size=8,
         num_epochs=100,
-        n_channels_in=4,
-        independent_channels=ind_channels,
+        n_channels_in=n_channels_in,
+        n_channels_out=n_channels_out,
     )
-    assert config.algorithm_config.model.independent_channels == ind_channels
-
-
-def test_care_chanels_out():
-    """Test that channels out are set to channels in if not speicifed."""
-    config = create_care_configuration(
-        experiment_name="test",
-        data_type="tiff",
-        axes="YXC",
-        patch_size=[64, 64],
-        batch_size=8,
-        num_epochs=100,
-        n_channels_in=4,
-    )
-    assert config.algorithm_config.model.num_classes == 4
-
-    # otherwise set independently
-    config = create_care_configuration(
-        experiment_name="test",
-        data_type="tiff",
-        axes="YXC",
-        patch_size=[64, 64],
-        batch_size=8,
-        num_epochs=100,
-        n_channels_in=4,
-        n_channels_out=5,
-    )
-    assert config.algorithm_config.model.num_classes == 5
+    assert config.algorithm_config.model.in_channels == n_channels_in
+    assert config.algorithm_config.model.num_classes == n_channels_out
 
 
 def test_n2v_configuration():
@@ -306,15 +271,12 @@ def test_n2v_configuration():
         batch_size=8,
         num_epochs=100,
     )
+    assert config.algorithm_config.algorithm == "n2v"
+    assert config.algorithm_config.loss == "n2v"
     assert (
         config.data_config.transforms[-1].name
         == SupportedTransform.N2V_MANIPULATE.value
     )
-    assert (
-        config.data_config.transforms[-1].strategy
-        == SupportedPixelManipulation.UNIFORM.value
-    )
-    assert not config.algorithm_config.model.is_3D()
 
 
 def test_n2v_3d_configuration():
@@ -338,33 +300,8 @@ def test_n2v_3d_configuration():
     assert config.algorithm_config.model.is_3D()
 
 
-def test_n2v_3d_error():
-    """Test that errors are raised if algorithm `is_3D` and data axes are
-    incompatible."""
-    with pytest.raises(ValueError):
-        create_n2v_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="ZYX",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=100,
-        )
-
-    with pytest.raises(ValueError):
-        create_n2v_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64, 64],
-            batch_size=8,
-            num_epochs=100,
-        )
-
-
-def test_n2v_model_parameters():
-    """Test passing N2V UNet parameters, and that explicit parameters override the
-    model_kwargs ones."""
+def test_n2v_configuration_default_transforms():
+    """Test the default n2v transforms."""
     config = create_n2v_configuration(
         experiment_name="test",
         data_type="tiff",
@@ -372,90 +309,20 @@ def test_n2v_model_parameters():
         patch_size=[64, 64],
         batch_size=8,
         num_epochs=100,
-        independent_channels=False,
-        use_n2v2=False,
-        model_kwargs={
-            "depth": 4,
-            "n2v2": True,
-            "in_channels": 2,
-            "num_classes": 5,
-            "independent_channels": True,
-        },
     )
-    assert config.algorithm_config.model.depth == 4
-    assert not config.algorithm_config.model.n2v2
-    assert not config.algorithm_config.model.independent_channels
-
-    # set to 1 because no C specified
-    assert config.algorithm_config.model.in_channels == 1
-    assert config.algorithm_config.model.num_classes == 1
-
-
-def test_n2v_model_parameters_channels():
-    """Test that the number of channels in the function call has priority over the
-    model kwargs."""
-    config = create_n2v_configuration(
-        experiment_name="test",
-        data_type="tiff",
-        axes="YXC",
-        patch_size=[64, 64],
-        batch_size=8,
-        num_epochs=100,
-        n_channels=4,
-        model_kwargs={
-            "depth": 4,
-            "n2v2": True,
-            "in_channels": 2,
-            "num_classes": 5,
-        },
+    assert len(config.data_config.transforms) == 3
+    assert config.data_config.transforms[0].name == SupportedTransform.XY_FLIP.value
+    assert (
+        config.data_config.transforms[1].name
+        == SupportedTransform.XY_RANDOM_ROTATE90.value
     )
-    assert config.algorithm_config.model.in_channels == 4
-    assert config.algorithm_config.model.num_classes == 4
-
-
-@pytest.mark.parametrize("ind_channels", [True, False])
-def test_n2v_independent_channels(ind_channels):
-    """Test that the idnependent channels parameter is passed correctly."""
-    config = create_n2v_configuration(
-        experiment_name="test",
-        data_type="tiff",
-        axes="YXC",
-        patch_size=[64, 64],
-        batch_size=8,
-        num_epochs=100,
-        n_channels=4,
-        independent_channels=ind_channels,
+    assert (
+        config.data_config.transforms[2].name == SupportedTransform.N2V_MANIPULATE.value
     )
-    assert config.algorithm_config.model.independent_channels == ind_channels
 
 
-def test_n2v_model_parameters_channels_error():
-    """Test that an error is raised if the number of channels is not specified and
-    C in axes, or C in axes and number of channels not specified."""
-    with pytest.raises(ValueError):
-        create_n2v_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YXC",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=100,
-        )
-
-    with pytest.raises(ValueError):
-        create_n2v_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=100,
-            n_channels=5,
-        )
-
-
-def test_n2v_no_aug():
-    """Test that N2V configuration can be created without augmentation."""
+def test_n2v_configuration_no_aug():
+    """Test that the N2V configuration can be created without augmentation."""
     config = create_n2v_configuration(
         experiment_name="test",
         data_type="tiff",
@@ -465,14 +332,14 @@ def test_n2v_no_aug():
         num_epochs=100,
         use_augmentations=False,
     )
-    assert len(config.data_config.transforms) == 1
+    assert len(config.data_config.transforms) == 1  # only N2V manipulate
     assert (
         config.data_config.transforms[0].name == SupportedTransform.N2V_MANIPULATE.value
     )
 
 
-def test_n2v_augmentation_parameters():
-    """Test that N2V configuration can be created with augmentation parameters."""
+def test_n2v_configuration_no_aug_with_transforms_passed():
+    """Test that the augmentation flag also disables passing transforms."""
     config = create_n2v_configuration(
         experiment_name="test",
         data_type="tiff",
@@ -480,15 +347,23 @@ def test_n2v_augmentation_parameters():
         patch_size=[64, 64],
         batch_size=8,
         num_epochs=100,
-        roi_size=17,
-        masked_pixel_percentage=0.5,
+        use_augmentations=False,
+        augmentations=[XYFlipModel(), XYRandomRotate90Model()],
     )
-    assert config.data_config.transforms[-1].roi_size == 17
-    assert config.data_config.transforms[-1].masked_pixel_percentage == 0.5
+    assert len(config.data_config.transforms) == 1  # only N2V manipulate
+    assert (
+        config.data_config.transforms[0].name == SupportedTransform.N2V_MANIPULATE.value
+    )
 
 
-def test_n2v2():
-    """Test that N2V2 configuration can be created."""
+def test_n2v_configuration_passing_n2v_manipulate():
+    """Test that N2V manipulate is ignored when explicitely passed."""
+    use_n2v2 = True
+    roi_size = 15
+    masked_pixel_percentage = 0.5
+    struct_mask_axis = SupportedStructAxis.HORIZONTAL.value
+    struct_n2v_span = 15
+
     config = create_n2v_configuration(
         experiment_name="test",
         data_type="tiff",
@@ -496,28 +371,35 @@ def test_n2v2():
         patch_size=[64, 64],
         batch_size=8,
         num_epochs=100,
-        use_n2v2=True,
+        augmentations=[
+            XYFlipModel(),
+            N2VManipulateModel(
+                strategy=SupportedPixelManipulation.UNIFORM.value,
+                roi_size=5,
+                masked_pixel_percentage=0.7,
+                struct_mask_axis=SupportedStructAxis.VERTICAL.value,
+                struct_mask_span=7,
+            ),
+        ],
+        use_n2v2=use_n2v2,  # median strategy
+        roi_size=roi_size,
+        masked_pixel_percentage=masked_pixel_percentage,
+        struct_n2v_axis=struct_mask_axis,
+        struct_n2v_span=struct_n2v_span,
+    )
+    assert len(config.data_config.transforms) == 2
+    assert config.data_config.transforms[0].name == SupportedTransform.XY_FLIP.value
+    assert (
+        config.data_config.transforms[1].name == SupportedTransform.N2V_MANIPULATE.value
     )
     assert (
-        config.data_config.transforms[-1].strategy
+        config.data_config.transforms[1].strategy
         == SupportedPixelManipulation.MEDIAN.value
     )
-
-
-def test_structn2v():
-    """Test that StructN2V configuration can be created."""
-    config = create_n2v_configuration(
-        experiment_name="test",
-        data_type="tiff",
-        axes="YX",
-        patch_size=[64, 64],
-        batch_size=8,
-        num_epochs=100,
-        struct_n2v_axis=SupportedStructAxis.HORIZONTAL.value,
-        struct_n2v_span=7,
-    )
+    assert config.data_config.transforms[1].roi_size == roi_size
     assert (
-        config.data_config.transforms[-1].struct_mask_axis
-        == SupportedStructAxis.HORIZONTAL.value
+        config.data_config.transforms[1].masked_pixel_percentage
+        == masked_pixel_percentage
     )
-    assert config.data_config.transforms[-1].struct_mask_span == 7
+    assert config.data_config.transforms[1].struct_mask_axis == struct_mask_axis
+    assert config.data_config.transforms[1].struct_mask_span == struct_n2v_span

--- a/tests/config/test_configuration_factory.py
+++ b/tests/config/test_configuration_factory.py
@@ -6,6 +6,7 @@ from careamics.config import (
     create_n2v_configuration,
 )
 from careamics.config.configuration_factory import (
+    _create_configuration,
     _create_supervised_configuration,
     _create_unet,
 )
@@ -46,7 +47,7 @@ def test_model_creation():
         n_channels_out=num_classes,
         independent_channels=independent_channels,
         use_n2v2=use_n2v2,
-        model_kwargs=model_kwargs,
+        model_params=model_kwargs,
     )
 
     assert model.depth == model_kwargs["depth"]
@@ -55,6 +56,64 @@ def test_model_creation():
     assert model.in_channels == in_channels
     assert model.num_classes == num_classes
     assert model.independent_channels == independent_channels
+
+
+def test_create_configuration():
+    """Test that the methods correctly passes all parameters."""
+    algorithm = "care"
+    experiment_name = "test"
+    data_type = "tiff"
+    axes = "CYX"
+    patch_size = [128, 128]
+    batch_size = 8
+    num_epochs = 100
+    transform_list = [XYFlipModel(), XYRandomRotate90Model()]
+    independent_channels = False
+    loss = "mse"
+    n_channels_in = 2
+    n_channels_out = 3
+    logger = "tensorboard"
+    model_params = {
+        "depth": 5,
+    }
+    dataloader_params = {
+        "num_workers": 4,
+    }
+
+    # instantiate config
+    config = _create_configuration(
+        algorithm=algorithm,
+        experiment_name=experiment_name,
+        data_type=data_type,
+        axes=axes,
+        patch_size=patch_size,
+        batch_size=batch_size,
+        num_epochs=num_epochs,
+        augmentations=transform_list,
+        independent_channels=independent_channels,
+        loss=loss,
+        n_channels_in=n_channels_in,
+        n_channels_out=n_channels_out,
+        logger=logger,
+        model_params=model_params,
+        dataloader_params=dataloader_params,
+    )
+
+    assert config.algorithm_config.algorithm == algorithm
+    assert config.experiment_name == experiment_name
+    assert config.data_config.data_type == data_type
+    assert config.data_config.axes == axes
+    assert config.data_config.patch_size == patch_size
+    assert config.data_config.batch_size == batch_size
+    assert config.training_config.num_epochs == num_epochs
+    assert config.data_config.transforms == transform_list
+    assert config.algorithm_config.model.independent_channels == independent_channels
+    assert config.algorithm_config.loss == loss
+    assert config.algorithm_config.model.in_channels == n_channels_in
+    assert config.algorithm_config.model.num_classes == n_channels_out
+    assert config.training_config.logger == logger
+    assert config.algorithm_config.model.depth == model_params["depth"]
+    assert config.data_config.dataloader_params == dataloader_params
 
 
 def test_supervised_configuration_error_with_channel_axes():


### PR DESCRIPTION
### Description

Following https://github.com/CAREamics/careamics/issues/231, there is a lack of flexibility in the way users can specify the transforms in the config convenience functions. The choice to users comes down to using only the default augmentations or no augmentation at all.

In passing, I also added the `dataloader_params` parameter by request of students during the MBL course.

This PR does a few things:
- Refactor `TRANSFORMS_UNION` type in its own module in order to find it more easily.
- Add an `augmentations` parameter that allows user to pass non-default augmentations. 
- Remove `use_augmentations`.
- Type explicitely the Pydantic trnasfroms
- Add `dataloader_params` to allow setting PyTorch dataloader parameters (as expected by the configuration).
- Rename `model_kwargs` to `model_params` for clarity.
- Refactor the convenience functions and tests in order to minimize duplicated code.

Summary:

- **What**: Allow users to pass non-default augmentations and dataloader parameters.
- **Why**: Enable cases where augmentations are useful but need to be different from the default ones (e.g. no rotations), and cases where users might want to add some dataloader parameters.
- **How**: Added two new parameters to the convenience functions.

### Changes Made

- **Addded**: `transform_union.py` to hold `TRANSFORMS_UNION`.
- **Modified**: `configuration_factory.py`, corresponding tests and the imports of `TRANSFORMS_UNION`.

### Related Issues

- Fixes https://github.com/CAREamics/careamics/issues/231

### Breaking changes

Any call that uses the convenience functions together with the parameter `model_kwargs`.

This PR will require an update to the doc and the examples.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)