### PR TITLE
fix: set upper Pydantic version to 2.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     'bioimageio.core>=0.6.0',
     'tifffile',
     'psutil',
-    'pydantic>=2.5',
+    'pydantic>=2.5,<2.9',
     'pytorch_lightning>=2.2.0',
     'pyyaml',
     'scikit-image<=0.23.2',


### PR DESCRIPTION
### Description

Following the release of Pydantic 2.9, exporting to the BMZ format raises a validation error. This causes our CI to fail. While waiting for the BMZ to be compatible with the latest Pydantic, let's fix the upper version to 2.8.