### PR TITLE
tooling: Add parallel testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           python -m pip install .[dev] ${{ github.event_name == 'schedule' && '--pre' || ''  }}
 
       - name: 🧪 Run Tests
-        run: pytest --color=yes --cov --cov-config=pyproject.toml --cov-report=xml --cov-report=term-missing 
+        run: pytest --color=yes --cov --cov-config=pyproject.toml --cov-report=xml --cov-report=term-missing -n auto
 
       # If something goes wrong with --pre tests, we can open an issue in the repo
       - name: 📝 Report --pre Failures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "sybil",      # doctesting
+    "sybil",        # doctesting
+    "pytest-xdist", # parallel testing
 ]
 
 # notebooks


### PR DESCRIPTION
### Description

The testing is becoming quite lengthy due to the LVAE addition. This PR add parallel testing to the CI using `pytest-xdist`.

### Changes Made

- **Modified**: `pyproject.toml` and `ci.yml`.
