### PR TITLE
Chore: Split test CIs into CAREamics official and LVAE

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,14 +10,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  check-manifest:
-    # check-manifest is a tool that checks that all files in version control are
-    # included in the sdist (unless explicitly excluded)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: pipx run check-manifest
-
   test:
     name: ${{ matrix.platform }} (${{ matrix.python-version }})
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,57 @@
+name: codecov
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check-manifest:
+    # check-manifest is a tool that checks that all files in version control are
+    # included in the sdist (unless explicitly excluded)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: pipx run check-manifest
+
+  test:
+    name: ${{ matrix.platform }} (${{ matrix.python-version }})
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9"]
+        platform: [ubuntu-latest]
+
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v3
+
+      - name: 🐍 Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache-dependency-path: "pyproject.toml"
+          cache: "pip"
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install -U pip
+          # if running a cron job, we add the --pre flag to test against pre-releases
+          python -m pip install .[dev] ${{ github.event_name == 'schedule' && '--pre' || ''  }}
+
+      - name: 🧪 Run Tests
+        run: pytest --color=yes --cov --cov-config=pyproject.toml --cov-report=xml --cov-report=term-missing 
+
+      - name: Coverage
+        uses: codecov/codecov-action@v3
+        with:
+          version: v0.7.3

--- a/.github/workflows/lvae.yml
+++ b/.github/workflows/lvae.yml
@@ -13,14 +13,6 @@ on:
     - cron: "0 0 * * 0"
 
 jobs:
-  check-manifest:
-    # check-manifest is a tool that checks that all files in version control are
-    # included in the sdist (unless explicitly excluded)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: pipx run check-manifest
-
   test:
     name: ${{ matrix.platform }} (${{ matrix.python-version }})
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/lvae.yml
+++ b/.github/workflows/lvae.yml
@@ -1,4 +1,4 @@
-name: CI
+name: lvae
 
 on:
   push:
@@ -27,9 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-        platform: [ubuntu-latest, macos-13, windows-latest]
+        python-version: ["3.9"]
+        platform: [ubuntu-latest, windows-latest]
 
     steps:
       - name: 🛑 Cancel Previous Runs
@@ -53,7 +52,7 @@ jobs:
           python -m pip install .[dev] ${{ github.event_name == 'schedule' && '--pre' || ''  }}
 
       - name: 🧪 Run Tests
-        run: pytest --color=yes -m "not lvae"
+        run: pytest --color=yes -m lvae
 
       # If something goes wrong with --pre tests, we can open an issue in the repo
       - name: 📝 Report --pre Failures
@@ -69,37 +68,3 @@ jobs:
           filename: .github/TEST_FAIL_TEMPLATE.md
           update_existing: true
 
-  deploy:
-    name: Release
-    needs: test
-    if: success() && startsWith(github.ref, 'refs/tags/') && github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
-
-      # This permission allows writing releases
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
-
-      - name: Build
-        run: |
-          python -m pip install build
-          python -m build
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-
-      - uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 2%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,10 @@ filterwarnings = [
 ]
 addopts = "-p no:doctest"
 
-#markers = ["gpu: marks tests as requiring gpu"]
+markers = [
+    # "gpu: marks tests as requiring gpu",
+    "lvae: marks tests as testing lvae",
+]
 
 # https://coverage.readthedocs.io/en/6.4/config.html
 [tool.coverage.report]

--- a/tests/config/architectures/test_lvae_model.py
+++ b/tests/config/architectures/test_lvae_model.py
@@ -3,6 +3,8 @@ import pytest
 from careamics.config.architectures import LVAEModel
 from careamics.config.support import SupportedActivation
 
+pytestmark = pytest.mark.lvae
+
 
 def test_instantiation():
     """Test that LVAEModel can be instantiated."""

--- a/tests/dataset/test_iterable_dataset.py
+++ b/tests/dataset/test_iterable_dataset.py
@@ -150,7 +150,7 @@ def test_extracting_val_files(tmp_path, ordered_array, percentage):
 def test_compute_mean_std_transform_welford(tmp_path, shape, axes, patch_size):
     """Test that mean and std are computed and correctly added to the configuration
     and transform."""
-    n_files = 100
+    n_files = 10
     files = []
     array = np.random.randint(0, np.iinfo(np.uint16).max, (n_files, *shape))
 
@@ -194,7 +194,7 @@ def test_compute_mean_std_transform_welford_with_targets(
 ):
     """Test that mean and std are computed and correctly added to the configuration
     and transform."""
-    n_files = 100
+    n_files = 10
     files = []
     target_files = []
     array = np.random.randint(0, np.iinfo(np.uint16).max, (n_files, *shape))

--- a/tests/lightning/test_LVAE_lightning_module.py
+++ b/tests/lightning/test_LVAE_lightning_module.py
@@ -25,6 +25,8 @@ from careamics.models.lvae.noise_models import (
 )
 from careamics.utils.metrics import RunningPSNR
 
+pytestmark = pytest.mark.lvae
+
 
 # TODO: move to conftest.py as pytest.fixture
 def create_dummy_noise_model(

--- a/tests/likelihood_modules/test_likelihoods.py
+++ b/tests/likelihood_modules/test_likelihoods.py
@@ -13,6 +13,8 @@ from careamics.config.nm_model import GaussianMixtureNMConfig, MultiChannelNMCon
 from careamics.models.lvae.likelihoods import likelihood_factory
 from careamics.models.lvae.noise_models import noise_model_factory
 
+pytestmark = pytest.mark.lvae
+
 
 # TODO: move to conftest.py as pytest.fixture
 def create_dummy_noise_model(

--- a/tests/losses/test_lvae_losses.py
+++ b/tests/losses/test_lvae_losses.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
 #     )
 #     Likelihood = Union[LikelihoodModule, GaussianLikelihood, NoiseModelLikelihood]
 
+pytestmark = pytest.mark.lvae
+
 
 # TODO: move to conftest.py as pytest.fixture
 def create_dummy_noise_model(

--- a/tests/models/lvae/test_dataset.py
+++ b/tests/models/lvae/test_dataset.py
@@ -12,6 +12,8 @@ from careamics.lvae_training.dataset.vae_data_config import (
 )
 from careamics.lvae_training.dataset.vae_dataset import MultiChDloader
 
+pytestmark = pytest.mark.lvae
+
 
 @pytest.fixture
 def dummy_data_path_biorc(tmp_path: Path) -> str:

--- a/tests/models/lvae/test_noise_model.py
+++ b/tests/models/lvae/test_noise_model.py
@@ -11,6 +11,8 @@ from careamics.models.lvae.noise_models import (
     noise_model_factory,
 )
 
+pytestmark = pytest.mark.lvae
+
 
 def test_factory_no_noise_model():
     noise_model = noise_model_factory(None)


### PR DESCRIPTION
### Description

Currently the CI is extremely slow (https://github.com/CAREamics/careamics/issues/244), to a point where it requires 30 mins between pushing a fix and seeing whether all tests pass... It is in particular due to the addition of numerous LVAE tests.

Until we go over all the tests and sanitize them a bit, this should allow faster execution.

This PR is a temporary solution to make it easier to work:
- Split the CI between the "officially supported" algorithms and the LVAE. 
- Make LVAE CI run on a single python version and two runners (ubuntu and windows, macos being super slow)
- Add codecov CI to have the code coverage computed from running all tests (single runner, single python version)
- Add codecov threshold to not fail if there difference in coverage is less than 2%
- Reduce `n_images` from `100` to `10` in welford tests

Summary:
- **What**: Make CI run faster.
- **Why**: Currently, CI is excruciatingly slow. 
- **How**: Split slow LVAE tests into their own CI running on fewer runners.

### Changes Made

- **Added**: 
    - `lvae.yml` CI
    - `codecov.yml` CI
    - `codecov.yml` configuration file (in root)
- **Modified**:
    - all LVAE test files with the marker `lvae`
    - `pyproject.toml` to register the `lvae` marker
    - welford tests to reduce their length

### Related Issues

https://github.com/CAREamics/careamics/issues/244