### PR TITLE
Feature: Update BMZ export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     'numpy<2.0.0',
     'torch>=2.0.0',
     'torchvision',
-    'bioimageio.core>=0.6.0',
+    'bioimageio.core>=0.6.9',
     'tifffile',
     'psutil',
     'pydantic>=2.5,<2.9',

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -183,7 +183,7 @@ def export_to_bmz(
         )
 
         # test model description
-        summary: ValidationSummary = test_model(model_description, decimal=1)
+        summary: ValidationSummary = test_model(model_description)
         if summary.status == "failed":
             raise ValueError(f"Model description test failed: {summary}")
 


### PR DESCRIPTION
### Description

- **What**: Following the core-bioimage-io-python release [0.6.9](https://github.com/bioimage-io/core-bioimage-io-python/releases/tag/v0.6.9), models are validated using absolute and relative tolerances instead of decimal precision to validate a model's output. This PR updates the `export_to_bmz` function so that this new behaviour can be taken advantage of.
- **Why**: This allows some models, in the [careamics-examples](https://github.com/CAREamics/careamics-examples) repo, that could not previously be exported due to them failing the validation, to now be exported.
- **How**: Removed the argument `decimal` from the function call of `test_model` (imported from `bioimage.core`). (The `decimal` argument was kept for back compatibility, and its use causes the code to revert to the previous behaviour).

### Changes Made

- **Modified**: 
  - `export_to_bmz` function.
  - pyproject.toml: set `'bioimageio.core>=0.6.9'`

### Additional Notes and Examples

PR to [careamics-examples](https://github.com/CAREamics/careamics-examples) coming soon.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)