### PR TITLE
Feature: Predict to disk (outerloop implementation)

### DIFF
--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -682,9 +682,7 @@ class CAREamist:
         tile_size: Optional[tuple[int, ...]] = None,
         tile_overlap: Optional[tuple[int, ...]] = (48, 48),
         axes: Optional[str] = None,
-        data_type: Optional[
-            Union[Literal["array", "tiff", "custom"], SupportedData]
-        ] = None,
+        data_type: Optional[Literal["array", "tiff", "custom"]] = None,
         tta_transforms: bool = True,
         dataloader_params: Optional[dict] = None,
         read_source_func: Optional[Callable] = None,
@@ -772,9 +770,9 @@ class CAREamist:
         if write_func_kwargs is None:
             write_func_kwargs = {}
 
-        data_type = SupportedData(data_type)
-        # TODO: make configurable?
+        # write_type = SupportedData(write_type)
 
+        # TODO: make configurable?
         write_dir = self.work_dir / "predictions"
 
         # guards for custom types
@@ -794,12 +792,14 @@ class CAREamist:
         # extract file names
         if isinstance(source, PredictDataModule):
             # assert not isinstance(source.pred_data, )
-            data_type = SupportedData(source.data_type)
+            data_type = source.data_type
             extension_filter = source.extension_filter
             source_file_paths = list_files(
                 source.pred_data, data_type, extension_filter
             )
         elif isinstance(source, (str, Path)):
+            data_type = data_type or self.cfg.data_config.data_type
+            extension_filter = SupportedData.get_extension_pattern(data_type)
             source_file_paths = list_files(source, data_type, extension_filter)
         else:
             raise ValueError(f"Unsupported source type: '{type(source)}'.")
@@ -825,7 +825,7 @@ class CAREamist:
             write_data = np.concatenate(prediction)
 
             # create directory structure and write path
-            file_write_dir = write_dir / source_path.parent
+            file_write_dir = write_dir / source_path.parent.name
             file_write_dir.mkdir(parents=True, exist_ok=True)
             write_path = (file_write_dir / source_path.name).with_suffix(
                 write_extension

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -568,7 +568,7 @@ class CAREamist:
         configuration parameters will be used, with the `patch_size` instead of
         `tile_size`.
 
-        Test-time augmentation (TTA) can be switched off using the `tta_transforms`
+        Test-time augmentation (TTA) can be switched on using the `tta_transforms`
         parameter. The TTA augmentation applies all possible flip and 90 degrees
         rotations to the prediction input and averages the predictions. TTA augmentation
         should not be used if you did not train with these augmentations.
@@ -686,6 +686,7 @@ class CAREamist:
         write_extension: Optional[str] = None,
         write_func: Optional[WriteFunc] = None,
         write_func_kwargs: Optional[dict[str, Any]] = None,
+        prediction_dir: Union[Path, str] = "predictions",
         **kwargs,
     ) -> None:
         """
@@ -708,7 +709,7 @@ class CAREamist:
         configuration parameters will be used, with the `patch_size` instead of
         `tile_size`.
 
-        Test-time augmentation (TTA) can be switched off using the `tta_transforms`
+        Test-time augmentation (TTA) can be switched on using the `tta_transforms`
         parameter. The TTA augmentation applies all possible flip and 90 degrees
         rotations to the prediction input and averages the predictions. TTA augmentation
         should not be used if you did not train with these augmentations.
@@ -751,6 +752,10 @@ class CAREamist:
             `write_type` a function to save the data must be passed. See notes below.
         write_func_kwargs : dict of {str: any}, optional
             Additional keyword arguments to be passed to the save function.
+        prediction_dir : Path | str, default="predictions"
+            The path to save the prediction results to. If `prediction_dir` is not
+            absolute, the directory will be assumed to be relative to the pre-set
+            `work_dir`. If the directory does not exist it will be created.
         **kwargs : Any
             Unused.
 
@@ -766,10 +771,11 @@ class CAREamist:
         if write_func_kwargs is None:
             write_func_kwargs = {}
 
-        # write_type = SupportedData(write_type)
-
-        # TODO: make configurable?
-        write_dir = self.work_dir / "predictions"
+        if Path(prediction_dir).is_absolute():
+            write_dir = Path(prediction_dir)
+        else:
+            write_dir = self.work_dir / prediction_dir
+        write_dir.mkdir(exist_ok=True, parents=True)
 
         # guards for custom types
         if write_type == SupportedData.CUSTOM:


### PR DESCRIPTION
### Description

- **What**: Add a `predict_to_disk` function to the `CAREamist` class.
- **Why**: So users can save predictions without having to write the saving process themselves.
- **How**: This implementation loops through the files, predicts the result and saves each one in turn. N.b. this will eventually be replaced with the `PredictionWriterCallback` version.

### Changes Made

- **Added**: 
  - `predict_to_disk` function to `CAREamist` class.
  - tests
- **Modified**:
  - Some type hints.

### Additional Notes and Examples

Currently the results are saved to a directory called "predictions" but maybe it should be configurable by the user?

This function can only be called on source data from a path because the prediction files are saved with the same name as the source files.

Not the neatest as I expect this to be replaced soon.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)