### PR TITLE
Fix(BMZ export): torchvision version; model validation 

### DIFF
--- a/src/careamics/model_io/bioimage/bioimage_utils.py
+++ b/src/careamics/model_io/bioimage/bioimage_utils.py
@@ -22,7 +22,7 @@ def get_unzip_path(zip_path: Union[Path, str]) -> Path:
     return zip_path.parent / (str(zip_path.name) + ".unzip")
 
 
-def create_env_text(pytorch_version: str) -> str:
+def create_env_text(pytorch_version: str, torchvision_version: str) -> str:
     """Create environment yaml content for the bioimage model.
 
     This installs an environment with the specified pytorch version and the latest
@@ -32,6 +32,8 @@ def create_env_text(pytorch_version: str) -> str:
     ----------
     pytorch_version : str
         Pytorch version.
+    torchvision_version : str
+        Torchvision version.
 
     Returns
     -------
@@ -43,7 +45,7 @@ def create_env_text(pytorch_version: str) -> str:
         f"dependencies:\n"
         f"  - python=3.10\n"
         f"  - pytorch={pytorch_version}\n"
-        f"  - torchvision={pytorch_version}\n"
+        f"  - torchvision={torchvision_version}\n"
         f"  - pip\n"
         f"  - pip:\n"
         f"    - git+https://github.com/CAREamics/careamics.git\n"

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -284,15 +284,6 @@ def create_model_description(
         weights=weights_descr,
         attachments=[FileDescr(source=config_path)],
         cite=config.get_algorithm_citations(),
-        config={  # conversion from float32 to float64 creates small differences...
-            "bioimageio": {
-                "test_kwargs": {
-                    "pytorch_state_dict": {
-                        "decimals": 0,  # ...so we relax the constraints on the decimals
-                    }
-                }
-            }
-        },
     )
 
     return model

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -8,7 +8,9 @@ import numpy as np
 import pkg_resources
 from bioimageio.core import load_description, test_model
 from bioimageio.spec import ValidationSummary, save_bioimageio_package
-from torch import __version__, load, save
+from torch import __version__ as PYTORCH_VERSION
+from torch import load, save
+from torchvision import __version__ as TORCHVISION_VERSION
 
 from careamics.config import Configuration, load_configuration, save_configuration
 from careamics.config.support import SupportedArchitecture
@@ -141,7 +143,6 @@ def export_to_bmz(
         path_to_archive.parent.mkdir(parents=True, exist_ok=True)
 
     # versions
-    pytorch_version = __version__
     careamics_version = pkg_resources.get_distribution("careamics").version
 
     # save files in temporary folder
@@ -151,7 +152,7 @@ def export_to_bmz(
         # create environment file
         # TODO move in bioimage module
         env_path = temp_path / "environment.yml"
-        env_path.write_text(create_env_text(pytorch_version))
+        env_path.write_text(create_env_text(PYTORCH_VERSION, TORCHVISION_VERSION))
 
         # export input and ouputs
         inputs = temp_path / "inputs.npy"
@@ -174,7 +175,7 @@ def export_to_bmz(
             inputs=inputs,
             outputs=outputs,
             weights_path=weight_path,
-            torch_version=pytorch_version,
+            torch_version=PYTORCH_VERSION,
             careamics_version=careamics_version,
             config_path=config_path,
             env_path=env_path,


### PR DESCRIPTION
### Description

- **What**: Two fixes to the bmz export: The torchvision version in the environment.yaml file was incorrectly set to be the torch version; and bmz `ModelDescription` configuration had the incorrect parameter `decimals` (it was meant to be `decimal` without the 's').
- **Why**: The incorrect env file meant the CI couldn't environment could be created and the incorrect parameter meant the model validation could not be run in the CI.
- **How**: Set the correct torchvision version in the env file. Removed the configuration from the `ModelDesc`, following https://github.com/bioimage-io/core-bioimage-io-python/pull/418 the decimal parameter is deprecated.

### Changes Made

- **Modified**: 
  - func `create_env_text` in `src/careamics/model_io/bioimage/bioimage_utils.py`
  - src/careamics/model_io/bmz_io.py
  - func `create_model_description` in `src/careamics/model_io/bioimage/model_description.py`

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)