### PR TITLE
Fix: Enforce dataloader params to have shuffle=True

### DIFF
--- a/src/careamics/lightning/train_data_module.py
+++ b/src/careamics/lightning/train_data_module.py
@@ -447,6 +447,7 @@ class TrainDataModule(L.LightningDataModule):
         Any
             Training dataloader.
         """
+        # check because iterable dataset cannot be shuffled
         if not isinstance(self.train_dataset, IterableDataset):
             if ("shuffle" in self.dataloader_params) and (
                 not self.dataloader_params["shuffle"]

--- a/src/careamics/lightning/train_data_module.py
+++ b/src/careamics/lightning/train_data_module.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from typing import Any, Callable, Literal, Optional, Union
+from warnings import warn
 
 import numpy as np
 import pytorch_lightning as L
@@ -264,6 +265,16 @@ class TrainDataModule(L.LightningDataModule):
         self.dataloader_params: dict[str, Any] = (
             data_config.dataloader_params if data_config.dataloader_params else {}
         )
+        if ("shuffle" in self.dataloader_params) and (
+            not self.dataloader_params["shuffle"]
+        ):
+            warn(
+                "Dataloader parameters include `shuffle=False`, this will be passed to "
+                "the training dataloader and may result in bad results.",
+                stacklevel=1,
+            )
+        else:
+            self.dataloader_params["shuffle"] = True
 
     def prepare_data(self) -> None:
         """

--- a/src/careamics/lightning/train_data_module.py
+++ b/src/careamics/lightning/train_data_module.py
@@ -7,7 +7,7 @@ from warnings import warn
 import numpy as np
 import pytorch_lightning as L
 from numpy.typing import NDArray
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, IterableDataset
 
 from careamics.config import DataConfig
 from careamics.config.support import SupportedData
@@ -265,16 +265,6 @@ class TrainDataModule(L.LightningDataModule):
         self.dataloader_params: dict[str, Any] = (
             data_config.dataloader_params if data_config.dataloader_params else {}
         )
-        if ("shuffle" in self.dataloader_params) and (
-            not self.dataloader_params["shuffle"]
-        ):
-            warn(
-                "Dataloader parameters include `shuffle=False`, this will be passed to "
-                "the training dataloader and may result in bad results.",
-                stacklevel=1,
-            )
-        else:
-            self.dataloader_params["shuffle"] = True
 
     def prepare_data(self) -> None:
         """
@@ -457,6 +447,18 @@ class TrainDataModule(L.LightningDataModule):
         Any
             Training dataloader.
         """
+        if not isinstance(self.train_dataset, IterableDataset):
+            if ("shuffle" in self.dataloader_params) and (
+                not self.dataloader_params["shuffle"]
+            ):
+                warn(
+                    "Dataloader parameters include `shuffle=False`, this will be "
+                    "passed to the training dataloader and may result in bad results.",
+                    stacklevel=1,
+                )
+            else:
+                self.dataloader_params["shuffle"] = True
+
         return DataLoader(
             self.train_dataset, batch_size=self.batch_size, **self.dataloader_params
         )


### PR DESCRIPTION
### Description

- **What**: It seems that in the `CAREamics` `TrainDataModule` the dataloader does not have shuffle set to `True`. 
- **Why**: Not shuffling the data during training can result in worse training, e.g. overfitting.
- **How**: Allow users to explicitly pass shuffle=False with a warning, otherwise `{"shuffle": True}` is added to the param dictionary, if the dataset is not a subclass of `IterableDataset`.`

### Changes Made

- **Modified**: `TrainDataModule.train_dataloader`

### Additional Notes and Examples

See the discussion in #258 for details.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)