### PR TITLE
refac: made some attributes of `VAEAlgorithmConfig` optional

### DIFF
--- a/src/careamics/config/vae_algorithm_model.py
+++ b/src/careamics/config/vae_algorithm_model.py
@@ -40,18 +40,18 @@ class VAEAlgorithmConfig(BaseModel):
     #   - values can still be passed as strings and they will be cast to Enum
     algorithm: Literal["musplit", "denoisplit"]
 
-    # NOTE: these are all configs (pydantic models)
-    loss: LVAELossConfig
+    # NOTE: these are all configs (pydantic models)s
     model: Union[LVAEModel, CustomModel] = Field(discriminator="architecture")
+    loss: Optional[LVAELossConfig]
     noise_model: Optional[MultiChannelNMConfig] = None
     noise_model_likelihood: Optional[NMLikelihoodConfig] = None
     gaussian_likelihood: Optional[GaussianLikelihoodConfig] = None
 
     # Optional fields
-    optimizer: OptimizerModel = OptimizerModel()
+    optimizer: Optional[OptimizerModel] = OptimizerModel()
     """Optimizer to use, defined in SupportedOptimizer."""
 
-    lr_scheduler: LrSchedulerModel = LrSchedulerModel()
+    lr_scheduler: Optional[LrSchedulerModel] = LrSchedulerModel()
 
     @model_validator(mode="after")
     def algorithm_cross_validation(self: Self) -> Self:

--- a/src/careamics/config/vae_algorithm_model.py
+++ b/src/careamics/config/vae_algorithm_model.py
@@ -40,9 +40,9 @@ class VAEAlgorithmConfig(BaseModel):
     #   - values can still be passed as strings and they will be cast to Enum
     algorithm: Literal["musplit", "denoisplit"]
 
-    # NOTE: these are all configs (pydantic models)s
+    # NOTE: these are all configs (pydantic models)
     model: Union[LVAEModel, CustomModel] = Field(discriminator="architecture")
-    loss: Optional[LVAELossConfig]
+    loss: Optional[LVAELossConfig] = None
     noise_model: Optional[MultiChannelNMConfig] = None
     noise_model_likelihood: Optional[NMLikelihoodConfig] = None
     gaussian_likelihood: Optional[GaussianLikelihoodConfig] = None


### PR DESCRIPTION
### Description

- **What**: Made all attributes, except `model`, `Optional` in `VAEAlgortihmConfig`.
- **Why**: At inference time the only the `model` attribute is needed. This allows to simplify model initialization for evaluation.
- **How**: Simply marked attributes as `Optional`, added `None` default if needed.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)