### PR TITLE
fix: Allow singleton channel in convenience functions

### DIFF
--- a/src/careamics/cli/conf.py
+++ b/src/careamics/cli/conf.py
@@ -3,7 +3,7 @@
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 import click
 import typer
@@ -154,8 +154,12 @@ def care(  # numpydoc ignore=PR01
             help="Loss function to use.",
         ),
     ] = "mae",
-    n_channels_in: Annotated[int, typer.Option(help="Number of channels in")] = 1,
-    n_channels_out: Annotated[int, typer.Option(help="Number of channels out")] = -1,
+    n_channels_in: Annotated[
+        Optional[int], typer.Option(help="Number of channels in")
+    ] = None,
+    n_channels_out: Annotated[
+        Optional[int], typer.Option(help="Number of channels out")
+    ] = None,
     logger: Annotated[
         click.Choice,
         typer.Option(
@@ -237,8 +241,12 @@ def n2n(  # numpydoc ignore=PR01
             help="Loss function to use.",
         ),
     ] = "mae",
-    n_channels_in: Annotated[int, typer.Option(help="Number of channels in")] = 1,
-    n_channels_out: Annotated[int, typer.Option(help="Number of channels out")] = -1,
+    n_channels_in: Annotated[
+        Optional[int], typer.Option(help="Number of channels in")
+    ] = None,
+    n_channels_out: Annotated[
+        Optional[int], typer.Option(help="Number of channels out")
+    ] = None,
     logger: Annotated[
         click.Choice,
         typer.Option(
@@ -312,8 +320,8 @@ def n2v(  # numpydoc ignore=PR01
     ] = True,
     use_n2v2: Annotated[bool, typer.Option(help="Whether to use N2V2")] = False,
     n_channels: Annotated[
-        int, typer.Option(help="Number of channels (in and out)")
-    ] = 1,
+        Optional[int], typer.Option(help="Number of channels (in and out)")
+    ] = None,
     roi_size: Annotated[int, typer.Option(help="N2V pixel manipulation area.")] = 11,
     masked_pixel_percentage: Annotated[
         float, typer.Option(help="Percentage of pixels masked in each patch.")

--- a/tests/cli/test_conf.py
+++ b/tests/cli/test_conf.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -33,5 +32,5 @@ def test_conf(tmp_path: Path, algorithm: str):
             "1",
         ],
     )
-    assert os.path.isfile(config_path)
+    assert config_path.is_file()
     assert result.exit_code == 0

--- a/tests/config/test_configuration_factory.py
+++ b/tests/config/test_configuration_factory.py
@@ -194,6 +194,19 @@ def test_supervised_configuration_singleton_channel():
     )
 
 
+def test_supervised_configuration_no_channel():
+    """Test that no error is raised without channel and number of inputs."""
+    _create_supervised_configuration(
+        algorithm="n2n",
+        experiment_name="test",
+        data_type="tiff",
+        axes="YX",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+    )
+
+
 def test_supervised_configuration_error_without_channel_axes():
     """Test that an error is raised if channels are not in axes, but the input channel
     number is specified and greater than 1."""

--- a/tests/config/test_configuration_factory.py
+++ b/tests/config/test_configuration_factory.py
@@ -179,6 +179,21 @@ def test_supervised_configuration_error_with_channel_axes():
         )
 
 
+def test_supervised_configuration_singleton_channel():
+    """Test that no error is raised if channels are in axes, and the input channel is
+    1."""
+    _create_supervised_configuration(
+        algorithm="n2n",
+        experiment_name="test",
+        data_type="tiff",
+        axes="CYX",
+        patch_size=[64, 64],
+        batch_size=8,
+        num_epochs=100,
+        n_channels_in=1,
+    )
+
+
 def test_supervised_configuration_error_without_channel_axes():
     """Test that an error is raised if channels are not in axes, but the input channel
     number is specified and greater than 1."""


### PR DESCRIPTION
### Description

Following https://github.com/CAREamics/careamics/issues/159, this PR allows creating a configuration with a singleton channel via the configuration convenience functions.

- **What**: Allow singleton channel in convenience functions.
- **Why**: In some rare cases, a singleton channel might be present in the data.
- **How**: Change the `if` statements and error raising conditions of the convenience functions.

### Changes Made


- **Modified**: `configuration_factory.py`.

### Related Issues

- Fixes [Allow singleton channel in convenience functions](https://github.com/CAREamics/careamics/issues/159)

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [x] PR to the documentation exists (for bug fixes / features)