### PR TITLE
feat: Enable prediction step during training

### DIFF
--- a/src/careamics/lightning/lightning_module.py
+++ b/src/careamics/lightning/lightning_module.py
@@ -14,6 +14,7 @@ from careamics.config.support import (
     SupportedOptimizer,
     SupportedScheduler,
 )
+from careamics.config.tile_information import TileInformation
 from careamics.losses import loss_factory
 from careamics.models.lvae.likelihoods import (
     GaussianLikelihood,
@@ -163,11 +164,17 @@ class FCNModule(L.LightningModule):
         Any
             Model output.
         """
+        # TODO refactor when redoing datasets
         # hacky way to determine if it is PredictDataModule, otherwise there is a
-        # circular import to solve (isinstance)
-        is_prediction = hasattr(self._trainer.datamodule, "tiled")
+        # circular import to solve with isinstance
+        from_prediction = hasattr(self._trainer.datamodule, "tiled")
+        is_tiled = (
+            len(batch) > 1
+            and isinstance(batch[1], list)
+            and isinstance(batch[1][0], TileInformation)
+        )
 
-        if is_prediction and self._trainer.datamodule.tiled:
+        if is_tiled:
             x, *aux = batch
         else:
             x = batch
@@ -175,7 +182,10 @@ class FCNModule(L.LightningModule):
 
         # apply test-time augmentation if available
         # TODO: probably wont work with batch size > 1
-        if is_prediction and self._trainer.datamodule.prediction_config.tta_transforms:
+        if (
+            from_prediction
+            and self._trainer.datamodule.prediction_config.tta_transforms
+        ):
             tta = ImageRestorationTTA()
             augmented_batch = tta.forward(x)  # list of augmented tensors
             augmented_output = []
@@ -191,12 +201,12 @@ class FCNModule(L.LightningModule):
         denorm = Denormalize(
             image_means=(
                 self._trainer.datamodule.predict_dataset.image_means
-                if is_prediction
+                if from_prediction
                 else self._trainer.datamodule.train_dataset.image_stats.means
             ),
             image_stds=(
                 self._trainer.datamodule.predict_dataset.image_stds
-                if is_prediction
+                if from_prediction
                 else self._trainer.datamodule.train_dataset.image_stats.stds
             ),
         )

--- a/tests/lightning/test_lightning_module.py
+++ b/tests/lightning/test_lightning_module.py
@@ -310,7 +310,8 @@ def test_fcn_module_unet_depth_3_channels_3D(n_channels):
     assert y.shape == x.shape
 
 
-def test_prediction_callback_during_training(minimum_configuration):
+@pytest.mark.parametrize("tiled", [False, True])
+def test_prediction_callback_during_training(minimum_configuration, tiled):
     import numpy as np
     from pytorch_lightning import Callback, Trainer
 
@@ -352,13 +353,16 @@ def test_prediction_callback_during_training(minimum_configuration):
 
             self.data = convert_outputs(outputs, self.pred_datamodule.tiled)
 
-    array = np.arange(32 * 32).reshape((32, 32))
+    array = np.arange(64 * 64).reshape((64, 64))
     pred_datamodule = create_predict_datamodule(
         pred_data=array,
         data_type=config.data_config.data_type,
         axes=config.data_config.axes,
         image_means=[11.8],  # random placeholder
         image_stds=[3.14],
+        tile_size=(16, 16) if tiled else None,
+        tile_overlap=(8, 8) if tiled else None,
+        batch_size=2,
     )
 
     predict_after_val_callback = CustomPredictAfterValidationCallback(

--- a/tests/lightning/test_lightning_module.py
+++ b/tests/lightning/test_lightning_module.py
@@ -308,3 +308,54 @@ def test_fcn_module_unet_depth_3_channels_3D(n_channels):
     x = torch.rand((1, n_channels, 16, 64, 64))
     y: torch.Tensor = model.forward(x)
     assert y.shape == x.shape
+
+
+def test_prediction_callback_during_training(minimum_configuration):
+    import numpy as np
+    from pytorch_lightning import Callback
+
+    from careamics import CAREamist, Configuration
+    from careamics.lightning import PredictDataModule, create_predict_datamodule
+    from careamics.prediction_utils import convert_outputs
+
+    config = Configuration(**minimum_configuration)
+
+    class CustomPredictAfterValidationCallback(Callback):
+        def __init__(self, pred_datamodule: PredictDataModule):
+            self.pred_datamodule = pred_datamodule
+
+            # prepare data and setup
+            self.pred_datamodule.prepare_data()
+            self.pred_datamodule.setup()
+            self.pred_dataloader = pred_datamodule.predict_dataloader()
+
+        def setup(self, trainer, pl_module, stage):
+            if stage in ("fit", "validate"):
+                self.pred_datamodule.prepare_data()
+                self.pred_datamodule.setup("predict")
+
+        def on_validation_epoch_end(self, trainer, pl_module):
+            if trainer.sanity_checking:  # optional skip
+                return
+
+            outputs = []
+            for idx, batch in enumerate(self.pred_dataloader):
+                batch = pl_module.transfer_batch_to_device(batch, pl_module.device, 0)
+                outputs.append(pl_module.predict_step(batch, batch_idx=idx))
+
+            return convert_outputs(outputs, self.pred_datamodule.tiled)
+
+    array = np.arange(32 * 32).reshape((32, 32))
+    pred_datamodule = create_predict_datamodule(
+        pred_data=array,
+        data_type=config.data_config.data_type,
+        axes=config.data_config.axes,
+        image_means=[11.8],
+        image_stds=[3.14],
+    )
+
+    predict_after_val_callback = CustomPredictAfterValidationCallback(
+        pred_datamodule=pred_datamodule
+    )
+    engine = CAREamist(config, callbacks=[predict_after_val_callback])
+    engine.train(train_source=array)


### PR DESCRIPTION
### Description

Following https://github.com/CAREamics/careamics/issues/148, I have been exploring how to predict during training. This PR would allow adding `Callback` that use `predict_step` during Training.

- **What**: Allow callbacks to call `predict_step` during training.
- **Why**: Some applications might require predicting consistently on full images to assess training performances throughout training. 
- **How**: Modified `FCNModule.predict_step` to make it compatible with a `TrainDataModule` (all calls to `trainer.datamodule` were written with the expectation that it returns a `PredictDataModule`.

### Changes Made

- **Modified**: `lightning_module.py`, `test_lightning_module.py`

### Related Issues

- Resolves https://github.com/CAREamics/careamics/issues/148

### Additional Notes and Examples

```python
    import numpy as np
    from pytorch_lightning import Callback, Trainer

    from careamics import CAREamist, Configuration
    from careamics.lightning import PredictDataModule, create_predict_datamodule
    from careamics.prediction_utils import convert_outputs

    config = Configuration(**minimum_configuration)

    class CustomPredictAfterValidationCallback(Callback):
        def __init__(self, pred_datamodule: PredictDataModule):
            self.pred_datamodule = pred_datamodule

            # prepare data and setup
            self.pred_datamodule.prepare_data()
            self.pred_datamodule.setup()
            self.pred_dataloader = pred_datamodule.predict_dataloader()

        def on_validation_epoch_end(self, trainer: Trainer, pl_module):
            if trainer.sanity_checking:  # optional skip
                return

            # update statistics in the prediction dataset for coherence
            # (they can computed on-line by the training dataset)
            self.pred_datamodule.predict_dataset.image_means = (
                trainer.datamodule.train_dataset.image_stats.means
            )
            self.pred_datamodule.predict_dataset.image_stds = (
                trainer.datamodule.train_dataset.image_stats.stds
            )

            # predict on the dataset
            outputs = []
            for idx, batch in enumerate(self.pred_dataloader):
                batch = pl_module.transfer_batch_to_device(batch, pl_module.device, 0)
                outputs.append(pl_module.predict_step(batch, batch_idx=idx))

           data = convert_outputs(outputs, self.pred_datamodule.tiled)
           # can save data here

    array = np.arange(32 * 32).reshape((32, 32))
    pred_datamodule = create_predict_datamodule(
        pred_data=array,
        data_type=config.data_config.data_type,
        axes=config.data_config.axes,
        image_means=[11.8], # random placeholder
        image_stds=[3.14],
        # can do tiling here
    )

    predict_after_val_callback = CustomPredictAfterValidationCallback(
        pred_datamodule=pred_datamodule
    )
    engine = CAREamist(config, callbacks=[predict_after_val_callback])
    engine.train(train_source=array)
```



Currently, this current implementation is not fully satisfactory and here are a few important points:

- For this PR to work we need to discriminate between `TrainDataModule` and `PredictDataModule` in `predict_step`, which is a bit of a hack as it currently check `hasattr(..., "tiled")`. The reason is to avoid a circular import of `PredictDataModule`. We should revisit that.
- `TrainDataModule` and `PredictDataModule` have incompatible members: `PredictDataModule` has `.tiled`, and the two have different naming conventions for the statistics (`PredictDataModule` has `image_means` and `image_stds`, while `TrainDataModule` has them wrapped in a `stats` dataclass). These statistics are retrieved either through `_trainer.datamodule.predict_dataset` or `_trainer.datamodule.train_dataset`.
- We do not provide the `Callable` that would allow to use such feature. We might want to some heavy lifting here as well (see example).
- Probably the most serious issue, normalization is done in the datasets but denormalization is performed in the `predict_step`. In our case, that means that normalization could be applied by a `PredictDataModule` (in the `Callback` and the denormalization by the `TrainDataModule` (in `predict_step`). That is incoherent and due to the way we wrote CAREamics.

All in all, this draft exemplifies two problems with CAREamics:
- `TrainDataModule` and `PredictDataModule` have different members
- Normalization is done by the `DataModule` but denormalization by `LightningModule`

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [x] PR to the documentation exists (for bug fixes / features)