### PR TITLE
Refac: Rename config file to careamics.yaml in BMZ export

### DIFF
--- a/src/careamics/config/configuration_model.py
+++ b/src/careamics/config/configuration_model.py
@@ -565,8 +565,8 @@ def save_configuration(config: Configuration, path: Union[str, Path]) -> Path:
     config : Configuration
         Configuration to save.
     path : str or Path
-        Path to a existing folder in which to save the configuration or to an existing
-        configuration file.
+        Path to a existing folder in which to save the configuration, or to a valid
+        configuration file path (uses a .yml or .yaml extension).
 
     Returns
     -------

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -305,7 +305,7 @@ def extract_model_path(model_desc: ModelDescr) -> tuple[Path, Path]:
     weights_path = model_desc.weights.pytorch_state_dict.source.path
 
     for file in model_desc.attachments:
-        if file.source.path.name == "careamics.yml":
+        if file.source.path.name == "careamics.yaml":
             config_path = file.source.path
             break
     else:

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -289,7 +289,7 @@ def create_model_description(
     return model
 
 
-def extract_model_path(model_desc: ModelDescr) -> Tuple[Path, Path]:
+def extract_model_path(model_desc: ModelDescr) -> tuple[Path, Path]:
     """Return the relative path to the weights and configuration files.
 
     Parameters
@@ -299,20 +299,16 @@ def extract_model_path(model_desc: ModelDescr) -> Tuple[Path, Path]:
 
     Returns
     -------
-    Tuple[Path, Path]
+    tuple of (path, path)
         Weights and configuration paths.
     """
     weights_path = model_desc.weights.pytorch_state_dict.source.path
 
-    if len(model_desc.attachments) == 1:
-        config_path = model_desc.attachments[0].source.path
+    for file in model_desc.attachments:
+        if file.source.path.name == "careamics.yml":
+            config_path = file.source.path
+            break
     else:
-        for file in model_desc.attachments:
-            if file.source.path.suffix == ".yml":
-                config_path = file.source.path
-                break
-
-        if config_path is None:
-            raise ValueError("Configuration file not found.")
+        raise ValueError("Configuration file not found.")
 
     return weights_path, config_path

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -161,7 +161,7 @@ def export_to_bmz(
         np.save(outputs, output_array)
 
         # export configuration
-        config_path = save_configuration(config, temp_path)
+        config_path = save_configuration(config, temp_path / "careamics.yml")
 
         # export model state dictionary
         weight_path = _export_state_dict(model, temp_path / "weights.pth")

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -161,7 +161,7 @@ def export_to_bmz(
         np.save(outputs, output_array)
 
         # export configuration
-        config_path = save_configuration(config, temp_path / "careamics.yml")
+        config_path = save_configuration(config, temp_path / "careamics.yaml")
 
         # export model state dictionary
         weight_path = _export_state_dict(model, temp_path / "weights.pth")


### PR DESCRIPTION
### Description

- **What**: When exporting to bmz the config file is now called `careamics.yaml`. Searching for the config file during loading has also been made more restrictive: previously the function searched for any `.yml` file in the attachments and now it searches specifically for `careamics.yaml`. 
- **Why**: Renaming the file makes it clearer to users it relates to CAREamics' functionality and should prevent any future name clashes with other tools. The config file loading was made more restrictive because it was not very robust to possible cases where additional attachments are used, and using the `export_to_bmz` function doesn't allow any choice in the name of the config file.
- **How**: Modified config path in `export_to_bmz` and modified config path search in `extract_model_path`.

### Changes Made

- **Modified**: 
  - `export_to_bmz`
  - `extract_model_path`
  - `save_configuration` docs

### Related Issues

- Resolves #269 

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)