### PR TITLE
Feature: Load model from BMZ using URL

### DIFF
--- a/src/careamics/config/configuration_model.py
+++ b/src/careamics/config/configuration_model.py
@@ -565,8 +565,8 @@ def save_configuration(config: Configuration, path: Union[str, Path]) -> Path:
     config : Configuration
         Configuration to save.
     path : str or Path
-        Path to a existing folder in which to save the configuration or to an existing
-        configuration file.
+        Path to a existing folder in which to save the configuration, or to a valid
+        configuration file path (uses a .yml or .yaml extension).
 
     Returns
     -------

--- a/src/careamics/config/configuration_model.py
+++ b/src/careamics/config/configuration_model.py
@@ -565,8 +565,8 @@ def save_configuration(config: Configuration, path: Union[str, Path]) -> Path:
     config : Configuration
         Configuration to save.
     path : str or Path
-        Path to a existing folder in which to save the configuration, or to a valid
-        configuration file path (uses a .yml or .yaml extension).
+        Path to a existing folder in which to save the configuration or to an existing
+        configuration file.
 
     Returns
     -------

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -305,8 +305,8 @@ def extract_model_path(model_desc: ModelDescr) -> tuple[Path, Path]:
     weights_path = model_desc.weights.pytorch_state_dict.download().path
 
     for file in model_desc.attachments:
-        if file.download().path.name == "careamics.yaml":
-            config_path = file.source.path
+        if file.source.path.name == "careamics.yaml":
+            config_path = file.download().path
             break
     else:
         raise ValueError("Configuration file not found.")

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -289,7 +289,7 @@ def create_model_description(
     return model
 
 
-def extract_model_path(model_desc: ModelDescr) -> tuple[Path, Path]:
+def extract_model_path(model_desc: ModelDescr) -> Tuple[Path, Path]:
     """Return the relative path to the weights and configuration files.
 
     Parameters
@@ -299,16 +299,20 @@ def extract_model_path(model_desc: ModelDescr) -> tuple[Path, Path]:
 
     Returns
     -------
-    tuple of (path, path)
+    Tuple[Path, Path]
         Weights and configuration paths.
     """
     weights_path = model_desc.weights.pytorch_state_dict.source.path
 
-    for file in model_desc.attachments:
-        if file.source.path.name == "careamics.yaml":
-            config_path = file.source.path
-            break
+    if len(model_desc.attachments) == 1:
+        config_path = model_desc.attachments[0].source.path
     else:
-        raise ValueError("Configuration file not found.")
+        for file in model_desc.attachments:
+            if file.source.path.suffix == ".yml":
+                config_path = file.source.path
+                break
+
+        if config_path is None:
+            raise ValueError("Configuration file not found.")
 
     return weights_path, config_path

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -305,7 +305,7 @@ def extract_model_path(model_desc: ModelDescr) -> tuple[Path, Path]:
     weights_path = model_desc.weights.pytorch_state_dict.source.path
 
     for file in model_desc.attachments:
-        if file.source.path.name == "careamics.yml":
+        if file.source.path.name == "careamics.yaml":
             config_path = file.source.path
             break
     else:

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -302,14 +302,14 @@ def extract_model_path(model_desc: ModelDescr) -> Tuple[Path, Path]:
     Tuple[Path, Path]
         Weights and configuration paths.
     """
-    weights_path = model_desc.weights.pytorch_state_dict.source.path
+    weights_path = model_desc.weights.pytorch_state_dict.download().path
 
     if len(model_desc.attachments) == 1:
-        config_path = model_desc.attachments[0].source.path
+        config_path = model_desc.attachments[0].download().path
     else:
         for file in model_desc.attachments:
             if file.source.path.suffix == ".yml":
-                config_path = file.source.path
+                config_path = file.download().path
                 break
 
         if config_path is None:

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -289,7 +289,7 @@ def create_model_description(
     return model
 
 
-def extract_model_path(model_desc: ModelDescr) -> Tuple[Path, Path]:
+def extract_model_path(model_desc: ModelDescr) -> tuple[Path, Path]:
     """Return the relative path to the weights and configuration files.
 
     Parameters
@@ -299,20 +299,16 @@ def extract_model_path(model_desc: ModelDescr) -> Tuple[Path, Path]:
 
     Returns
     -------
-    Tuple[Path, Path]
+    tuple of (path, path)
         Weights and configuration paths.
     """
     weights_path = model_desc.weights.pytorch_state_dict.source.path
 
-    if len(model_desc.attachments) == 1:
-        config_path = model_desc.attachments[0].source.path
+    for file in model_desc.attachments:
+        if file.source.path.name == "careamics.yml":
+            config_path = file.source.path
+            break
     else:
-        for file in model_desc.attachments:
-            if file.source.path.suffix == ".yml":
-                config_path = file.source.path
-                break
-
-        if config_path is None:
-            raise ValueError("Configuration file not found.")
+        raise ValueError("Configuration file not found.")
 
     return weights_path, config_path

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -302,10 +302,16 @@ def extract_model_path(model_desc: ModelDescr) -> tuple[Path, Path]:
     tuple of (path, path)
         Weights and configuration paths.
     """
+    if model_desc.weights.pytorch_state_dict is None:
+        raise ValueError("No model weights found in model description.")
     weights_path = model_desc.weights.pytorch_state_dict.download().path
 
     for file in model_desc.attachments:
-        if file.source.path.name == "careamics.yaml":
+        file_path = file.source if isinstance(file.source, Path) else file.source.path
+        if file_path is None:
+            continue
+        file_path = Path(file_path)
+        if file_path.name == "careamics.yaml":
             config_path = file.download().path
             break
     else:

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -161,7 +161,7 @@ def export_to_bmz(
         np.save(outputs, output_array)
 
         # export configuration
-        config_path = save_configuration(config, temp_path)
+        config_path = save_configuration(config, temp_path / "careamics.yml")
 
         # export model state dictionary
         weight_path = _export_state_dict(model, temp_path / "weights.pth")

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -162,7 +162,7 @@ def export_to_bmz(
         np.save(outputs, output_array)
 
         # export configuration
-        config_path = save_configuration(config, temp_path / "careamics.yaml")
+        config_path = save_configuration(config, temp_path)
 
         # export model state dictionary
         weight_path = _export_state_dict(model, temp_path / "weights.pth")

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -161,7 +161,7 @@ def export_to_bmz(
         np.save(outputs, output_array)
 
         # export configuration
-        config_path = save_configuration(config, temp_path / "careamics.yml")
+        config_path = save_configuration(config, temp_path / "careamics.yaml")
 
         # export model state dictionary
         weight_path = _export_state_dict(model, temp_path / "weights.pth")

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -6,8 +6,9 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import pkg_resources
-from bioimageio.core import load_description, test_model
+from bioimageio.core import load_model_description, test_model
 from bioimageio.spec import ValidationSummary, save_bioimageio_package
+from pydantic import HttpUrl
 from torch import __version__ as PYTORCH_VERSION
 from torch import load, save
 from torchvision import __version__ as TORCHVISION_VERSION
@@ -193,32 +194,30 @@ def export_to_bmz(
 
 
 def load_from_bmz(
-    path: Union[Path, str]
+    path: Union[Path, str, HttpUrl]
 ) -> Tuple[Union[FCNModule, VAEModule], Configuration]:
     """Load a model from a BioImage Model Zoo archive.
 
     Parameters
     ----------
-    path : Union[Path, str]
-        Path to the BioImage Model Zoo archive.
+    path : Path, str or HttpUrl
+        Path to the BioImage Model Zoo archive. A Http URL must point to a downloadable
+        location.
 
     Returns
     -------
-    Tuple[CAREamicsKiln, Configuration]
-        CAREamics model and configuration.
+    FCNModel or VAEModel
+        The loaded CAREamics model.
+    Configuration
+        The loaded CAREamics configuration.
 
     Raises
     ------
     ValueError
         If the path is not a zip file.
     """
-    path = Path(path)
-
-    if path.suffix != ".zip":
-        raise ValueError(f"Path must be a bioimage.io zip file, got {path}.")
-
     # load description, this creates an unzipped folder next to the archive
-    model_desc = load_description(path)
+    model_desc = load_model_description(path)
 
     # extract relative paths
     weights_path, config_path = extract_model_path(model_desc)


### PR DESCRIPTION
### Description

- **What**: Now it is possible to pass a URL to the `load_from_bmz` function to download and load BMZ files.
- **Why**: Not many users will have access to the model resource URLs, but this functionality is useful for developing the CAREamics BMZ compatibility script.
- **How**: 
  - Type hint `path` as also `pydantic.HttpUrl` in `load_from_bmz` (as in `bioimage.core`); 
  - Remove `path` validation checks from `load_from_bmz` and allow it to be handled in `load_model_description`
  - Call `download` on the file resources to download and get the correct path.

### Changes Made

- **Modified**: 
  - `load_from_bmz`
  - `extract_model_path`

### Additional Notes and Examples

This will have merge conflicts with #271.

There are currently no official tests (it does work), we can discuss using the URL of one of the existing CAREamics models uploaded to the BMZ or create a Mock.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)