### PR TITLE
Fix(dependencies): Set bioimageio-core version greater than 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     'numpy<2.0.0',
     'torch>=2.0.0',
     'torchvision',
-    'bioimageio.core>=0.6.9',
+    'bioimageio.core>=0.7.0',
     'tifffile',
     'psutil',
     'pydantic>=2.5,<2.9',


### PR DESCRIPTION
### Description

- **What**: Set bioimageio-core version greater than 0.7.0
- **Why**: Following the new `bioimage-core` release (0.7.0), we needed to make some fixes (part of PR #279). The most convenient function to solve this problem, `resolve_and_extract` only exists since 0.7.0.
- **How**: In pyproject.toml

### Changes Made

- **Modified**: pyproject.toml

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)