### PR TITLE
Update BMZ README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v0.7.2
     hooks:
       - id: ruff
-        exclude: "^src/careamics/lvae_training/.*|^src/careamics/models/lvae/.*"
+        exclude: "^src/careamics/lvae_training/.*|^src/careamics/models/lvae/.*|^scripts/.*"
         args: [--fix, --target-version, py38]
 
   - repo: https://github.com/psf/black
@@ -31,7 +31,7 @@ repos:
       - id: mypy
         files: "^src/"
         exclude: "^src/careamics/lvae_training/.*|^src/careamics/models/lvae/.*|^src/careamics/config/likelihood_model.py|^src/careamics/losses/loss_factory.py|^src/careamics/losses/lvae/losses.py"
-        args: ['--config-file', 'mypy.ini']
+        args: ["--config-file", "mypy.ini"]
         additional_dependencies:
           - numpy
           - types-PyYAML
@@ -42,7 +42,7 @@ repos:
     rev: v1.8.0
     hooks:
       - id: numpydoc-validation
-        exclude: "^src/careamics/lvae_training/.*|^src/careamics/models/lvae/.*|^src/careamics/losses/lvae/.*"      
+        exclude: "^src/careamics/lvae_training/.*|^src/careamics/models/lvae/.*|^src/careamics/losses/lvae/.*|^scripts/.*"
 
   # # jupyter linting and formatting
   # - repo: https://github.com/nbQA-dev/nbQA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     'typer==0.12.3',
     'scikit-image<=0.23.2',
     'zarr<3.0.0',
+    'pillow<=10.3.0',
 ]
 
 [project.optional-dependencies]

--- a/scripts/export_bmz_readme.py
+++ b/scripts/export_bmz_readme.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+from pathlib import Path
+
+from careamics.config import create_n2v_configuration
+from careamics.model_io.bioimage._readme_factory import readme_factory
+
+
+def main():
+    # create configuration
+    config = create_n2v_configuration(
+        experiment_name="export_bmz_readme",
+        data_type="array",
+        axes="YX",
+        patch_size=(64, 64),
+        batch_size=2,
+        num_epochs=10,
+    )
+    # export README
+    readme_path = readme_factory(
+        config=config,
+        careamics_version="0.1.0",
+    )
+
+    # copy file to __file__
+    readme_path.rename(Path(__file__).parent / "README.md")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_bmz_readme.py
+++ b/scripts/export_bmz_readme.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+"""Export a README file for the bioimage model zoo."""
 from pathlib import Path
 
 from careamics.config import create_n2v_configuration
@@ -17,8 +18,7 @@ def main():
     )
     # export README
     readme_path = readme_factory(
-        config=config,
-        careamics_version="0.1.0",
+        config=config, careamics_version="0.1.0", data_description="Mydata"
     )
 
     # copy file to __file__

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -866,9 +866,9 @@ class CAREamist:
         friendly_model_name: str,
         input_array: NDArray,
         authors: list[dict],
-        general_description: str = "",
+        general_description: str,
+        data_description: str,
         channel_names: Optional[list[str]] = None,
-        data_description: Optional[str] = None,
     ) -> None:
         """Export the model to the BioImage Model Zoo format.
 
@@ -898,11 +898,11 @@ class CAREamist:
         authors : list of dict
             List of authors of the model.
         general_description : str
-            General description of the model, used in the metadata of the BMZ archive.
+            General description of the model used in the BMZ metadata.
+        data_description : str
+            Description of the data the model was trained on.
         channel_names : list of str, optional
             Channel names, by default None.
-        data_description : str, optional
-            Description of the data, by default None.
         """
         # TODO: add in docs that it is expected that input_array dimensions match
         # those in data_config
@@ -921,11 +921,11 @@ class CAREamist:
             path_to_archive=path_to_archive,
             model_name=friendly_model_name,
             general_description=general_description,
+            data_description=data_description,
             authors=authors,
             input_array=input_array,
             output_array=output,
             channel_names=channel_names,
-            data_description=data_description,
         )
 
     def get_losses(self) -> dict[str, list]:

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -869,6 +869,7 @@ class CAREamist:
         general_description: str,
         data_description: str,
         channel_names: Optional[list[str]] = None,
+        model_version: str = "0.1.0",
     ) -> None:
         """Export the model to the BioImage Model Zoo format.
 
@@ -903,6 +904,8 @@ class CAREamist:
             Description of the data the model was trained on.
         channel_names : list of str, optional
             Channel names, by default None.
+        model_version : str, default="0.1.0"
+            Version of the model.
         """
         # TODO: add in docs that it is expected that input_array dimensions match
         # those in data_config
@@ -926,6 +929,7 @@ class CAREamist:
             input_array=input_array,
             output_array=output,
             channel_names=channel_names,
+            model_version=model_version,
         )
 
     def get_losses(self) -> dict[str, list]:

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -868,6 +868,7 @@ class CAREamist:
         authors: list[dict],
         general_description: str,
         data_description: str,
+        covers: Optional[list[Union[Path, str]]] = None,
         channel_names: Optional[list[str]] = None,
         model_version: str = "0.1.0",
     ) -> None:
@@ -902,8 +903,10 @@ class CAREamist:
             General description of the model used in the BMZ metadata.
         data_description : str
             Description of the data the model was trained on.
-        channel_names : list of str, optional
-            Channel names, by default None.
+        covers : list of pathlib.Path or str, default=None
+            Paths to the cover images.
+        channel_names : list of str, default=None
+            Channel names.
         model_version : str, default="0.1.0"
             Version of the model.
         """
@@ -928,6 +931,7 @@ class CAREamist:
             authors=authors,
             input_array=input_array,
             output_array=output,
+            covers=covers,
             channel_names=channel_names,
             model_version=model_version,
         )

--- a/src/careamics/model_io/bioimage/_readme_factory.py
+++ b/src/careamics/model_io/bioimage/_readme_factory.py
@@ -70,7 +70,7 @@ def readme_factory(
         description.append(config.get_algorithm_description())
         description.append("\n\n")
 
-        # training description
+        # configuration description
         description.append("## Configuration\n\n")
 
         description.append(
@@ -80,6 +80,18 @@ def readme_factory(
 
         description.append(_yaml_block(yaml.dump(config.model_dump(exclude_none=True))))
         description.append("\n\n")
+
+        # validation
+        description.append("## Validation\n\n")
+
+        description.append(
+            "In order to validate the model, we encourage users to acquire a "
+            "test dataset with ground-truth data. Comparing the ground-truth data "
+            "with the prediction allows unbiased evaluation of the model performances. "
+            "In the absence of ground-truth, inspecting the residual image (difference "
+            "between input and predicted image) can be helpful to identify "
+            "whether real signal is removed from the input image.\n\n"
+        )
 
         # references
         reference = config.get_algorithm_references()

--- a/src/careamics/model_io/bioimage/_readme_factory.py
+++ b/src/careamics/model_io/bioimage/_readme_factory.py
@@ -1,7 +1,6 @@
 """Functions used to create a README.md file for BMZ export."""
 
 from pathlib import Path
-from typing import Optional
 
 import yaml
 
@@ -28,7 +27,7 @@ def _yaml_block(yaml_str: str) -> str:
 def readme_factory(
     config: Configuration,
     careamics_version: str,
-    data_description: Optional[str] = None,
+    data_description: str,
 ) -> Path:
     """Create a README file for the model.
 
@@ -41,18 +40,14 @@ def readme_factory(
         CAREamics configuration.
     careamics_version : str
         CAREamics version.
-    data_description : Optional[str], optional
-        Description of the data, by default None.
+    data_description : str
+        Description of the data.
 
     Returns
     -------
     Path
         Path to the README file.
     """
-    algorithm = config.algorithm_config
-    training = config.training_config
-    data = config.data_config
-
     # create file
     # TODO use tempfile as in the bmz_io module
     with cwd(get_careamics_home()):
@@ -65,41 +60,25 @@ def readme_factory(
 
         description = [f"# {algorithm_pretty_name}\n\n"]
 
+        # data description
+        description.append("## Data description\n\n")
+        description.append(data_description)
+        description.append("\n\n")
+
         # algorithm description
-        description.append("Algorithm description:\n\n")
+        description.append("## Algorithm description:\n\n")
         description.append(config.get_algorithm_description())
         description.append("\n\n")
 
-        # algorithm details
+        # training description
+        description.append("## Configuration\n\n")
+
         description.append(
             f"{algorithm_flavour} was trained using CAREamics (version "
-            f"{careamics_version}) with the following algorithm "
-            f"parameters:\n\n"
+            f"{careamics_version}) using the following configuration:\n\n"
         )
-        description.append(
-            _yaml_block(yaml.dump(algorithm.model_dump(exclude_none=True)))
-        )
-        description.append("\n\n")
 
-        # data description
-        description.append("## Data description\n\n")
-        if data_description is not None:
-            description.append(data_description)
-            description.append("\n\n")
-
-        description.append("The data was processed using the following parameters:\n\n")
-
-        description.append(_yaml_block(yaml.dump(data.model_dump(exclude_none=True))))
-        description.append("\n\n")
-
-        # training description
-        description.append("## Training description\n\n")
-
-        description.append("The model was trained using the following parameters:\n\n")
-
-        description.append(
-            _yaml_block(yaml.dump(training.model_dump(exclude_none=True)))
-        )
+        description.append(_yaml_block(yaml.dump(config.model_dump(exclude_none=True))))
         description.append("\n\n")
 
         # references
@@ -113,7 +92,7 @@ def readme_factory(
         description.append(
             "## Links\n\n"
             "- [CAREamics repository](https://github.com/CAREamics/careamics)\n"
-            "- [CAREamics documentation](https://careamics.github.io/latest/)\n"
+            "- [CAREamics documentation](https://careamics.github.io/)\n"
         )
 
         readme.write_text("".join(description))

--- a/src/careamics/model_io/bioimage/_readme_factory.py
+++ b/src/careamics/model_io/bioimage/_readme_factory.py
@@ -82,14 +82,15 @@ def readme_factory(
         description.append("\n\n")
 
         # validation
-        description.append("## Validation\n\n")
+        description.append("# Validation\n\n")
 
         description.append(
             "In order to validate the model, we encourage users to acquire a "
             "test dataset with ground-truth data. Comparing the ground-truth data "
             "with the prediction allows unbiased evaluation of the model performances. "
-            "In the absence of ground-truth, inspecting the residual image (difference "
-            "between input and predicted image) can be helpful to identify "
+            "This can be done for instance by using metrics such as PSNR, SSIM, or"
+            "MicroSSIM. In the absence of ground-truth, inspecting the residual image "
+            "(difference between input and predicted image) can be helpful to identify "
             "whether real signal is removed from the input image.\n\n"
         )
 
@@ -102,7 +103,7 @@ def readme_factory(
 
         # links
         description.append(
-            "## Links\n\n"
+            "# Links\n\n"
             "- [CAREamics repository](https://github.com/CAREamics/careamics)\n"
             "- [CAREamics documentation](https://careamics.github.io/)\n"
         )

--- a/src/careamics/model_io/bioimage/cover_factory.py
+++ b/src/careamics/model_io/bioimage/cover_factory.py
@@ -98,7 +98,7 @@ def _convert_to_image(original_shape: tuple[int, ...], array: NDArray) -> Image:
             return Image.fromarray(array).convert("RGB")
         elif n_channels == 2:
             # add an empty channel to the numpy array
-            array = np.concatenate([array, np.zeros_like(array[..., 0:1])], axis=-1)
+            array = np.concatenate([np.zeros_like(array[..., 0:1]), array], axis=-1)
 
             return Image.fromarray(array).convert("RGB")
         else:  # more than 4

--- a/src/careamics/model_io/bioimage/cover_factory.py
+++ b/src/careamics/model_io/bioimage/cover_factory.py
@@ -1,0 +1,171 @@
+"""Convenience function to create covers for the BMZ."""
+
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+from PIL import Image
+
+color_palette = np.array(
+    [
+        np.array([255, 195, 0]),  # grey
+        np.array([189, 226, 240]),
+        np.array([96, 60, 76]),
+        np.array([193, 225, 193]),
+    ]
+)
+
+
+def _get_norm_slice(array: NDArray) -> NDArray:
+    """Get the normalized middle slice of a 4D or 5D array (SC(Z)YX).
+
+    Parameters
+    ----------
+    array : NDArray
+        Array from which to get the middle slice.
+
+    Returns
+    -------
+    NDArray
+        Normalized middle slice of the input array.
+    """
+    if array.ndim not in (4, 5):
+        raise ValueError("Array must be 4D or 5D.")
+
+    channels = array.shape[1] > 1
+    z_stack = array.ndim == 5
+
+    # get slice
+    if z_stack:
+        array_slice = array[0, :, array.shape[2] // 2, ...]
+    else:
+        array_slice = array[0, ...]
+
+    # channels
+    if channels:
+        array_slice = np.moveaxis(array_slice, 0, -1)
+    else:
+        array_slice = array_slice[0, ...]
+
+    # normalize
+    array_slice = (
+        255
+        * (array_slice - array_slice.min())
+        / (array_slice.max() - array_slice.min())
+    )
+
+    return array_slice.astype(np.uint8)
+
+
+def _four_channel_image(array: NDArray) -> Image:
+    """Convert 4-channel array to Image.
+
+    Parameters
+    ----------
+    array : NDArray
+        Normalized array to convert.
+
+    Returns
+    -------
+    Image
+        Converted array.
+    """
+    colors = color_palette[np.newaxis, np.newaxis, :, :]
+    four_c_array = np.sum(array[..., :4, np.newaxis] * colors, axis=-2).astype(np.uint8)
+
+    return Image.fromarray(four_c_array).convert("RGB")
+
+
+def _convert_to_image(original_shape: tuple[int, ...], array: NDArray) -> Image:
+    """Convert to Image.
+
+    Parameters
+    ----------
+    original_shape : tuple
+        Original shape of the array.
+    array : NDArray
+        Normalized array to convert.
+
+    Returns
+    -------
+    Image
+        Converted array.
+    """
+    n_channels = original_shape[1]
+
+    if n_channels > 1:
+        if n_channels == 3:
+            return Image.fromarray(array).convert("RGB")
+        elif n_channels == 2:
+            # add an empty channel to the numpy array
+            array = np.concatenate([array, np.zeros_like(array[..., 0:1])], axis=-1)
+
+            return Image.fromarray(array).convert("RGB")
+        else:  # more than 4
+            return _four_channel_image(array[..., :4])
+    else:
+        return Image.fromarray(array).convert("L").convert("RGB")
+
+
+def create_cover(directory: Path, array_in: NDArray, array_out: NDArray) -> Path:
+    """Create a cover image from input and output arrays.
+
+    Input and output arrays are expected to be SC(Z)YX. For images with a Z
+    dimension, the middle slice is taken.
+
+    Parameters
+    ----------
+    directory : Path
+        Directory in which to save the cover.
+    array_in : numpy.ndarray
+        Array from which to create the cover image.
+    array_out : numpy.ndarray
+        Array from which to create the cover image.
+
+    Returns
+    -------
+    Path
+        Path to the saved cover image.
+    """
+    # extract slice and normalize arrays
+    slice_in = _get_norm_slice(array_in)
+    slice_out = _get_norm_slice(array_out)
+
+    horizontal_split = slice_in.shape[-1] == slice_out.shape[-1]
+    if not horizontal_split:
+        if slice_in.shape[-2] != slice_out.shape[-2]:
+            raise ValueError("Input and output arrays have different shapes.")
+
+    # convert to Image
+    image_in = _convert_to_image(array_in.shape, slice_in)
+    image_out = _convert_to_image(array_out.shape, slice_out)
+
+    # split horizontally or vertically
+    if horizontal_split:
+        width = image_in.width // 2
+
+        cover = Image.new("RGB", (image_in.width, image_in.height))
+        cover.paste(image_in.crop((0, 0, width, image_in.height)), (0, 0))
+        cover.paste(
+            image_out.crop(
+                (image_in.width - width, 0, image_in.width, image_in.height)
+            ),
+            (width, 0),
+        )
+    else:
+        height = image_in.height // 2
+
+        cover = Image.new("RGB", (image_in.width, image_in.height))
+        cover.paste(image_in.crop((0, 0, image_in.width, height)), (0, 0))
+        cover.paste(
+            image_out.crop(
+                (0, image_in.height - height, image_in.width, image_in.height)
+            ),
+            (0, height),
+        )
+
+    # save
+    cover_path = directory / "cover.png"
+    cover.save(cover_path)
+
+    return cover_path

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -197,6 +197,7 @@ def create_model_description(
     config_path: Union[Path, str],
     env_path: Union[Path, str],
     channel_names: Optional[List[str]] = None,
+    model_version: str = "0.1.0",
 ) -> ModelDescr:
     """Create model description.
 
@@ -228,6 +229,8 @@ def create_model_description(
         Path to environment file.
     channel_names : Optional[List[str]], optional
         Channel names, by default None.
+    model_version : str, default "0.1.0"
+        Model version.
 
     Returns
     -------

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -196,6 +196,7 @@ def create_model_description(
     careamics_version: str,
     config_path: Union[Path, str],
     env_path: Union[Path, str],
+    covers: list[Union[Path, str]],
     channel_names: Optional[List[str]] = None,
     model_version: str = "0.1.0",
 ) -> ModelDescr:
@@ -227,6 +228,8 @@ def create_model_description(
         Path to model configuration.
     env_path : Union[Path, str]
         Path to environment file.
+    covers : list of pathlib.Path or str
+        Paths to cover images.
     channel_names : Optional[List[str]], optional
         Channel names, by default None.
     model_version : str, default "0.1.0"
@@ -298,6 +301,7 @@ def create_model_description(
         weights=weights_descr,
         attachments=[FileDescr(source=config_path)],
         cite=config.get_algorithm_citations(),
+        covers=covers,
     )
 
     return model

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -187,6 +187,7 @@ def create_model_description(
     config: Configuration,
     name: str,
     general_description: str,
+    data_description: str,
     authors: List[Author],
     inputs: Union[Path, str],
     outputs: Union[Path, str],
@@ -196,7 +197,6 @@ def create_model_description(
     config_path: Union[Path, str],
     env_path: Union[Path, str],
     channel_names: Optional[List[str]] = None,
-    data_description: Optional[str] = None,
 ) -> ModelDescr:
     """Create model description.
 
@@ -208,6 +208,8 @@ def create_model_description(
         Name of the model.
     general_description : str
         General description of the model.
+    data_description : str
+        Description of the data the model was trained on.
     authors : List[Author]
         Authors of the model.
     inputs : Union[Path, str]
@@ -226,8 +228,6 @@ def create_model_description(
         Path to environment file.
     channel_names : Optional[List[str]], optional
         Channel names, by default None.
-    data_description : Optional[str], optional
-        Description of the data, by default None.
 
     Returns
     -------

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -294,7 +294,7 @@ def create_model_description(
                 }
             }
         },
-        version="0.1.0",
+        version=model_version,
         weights=weights_descr,
         attachments=[FileDescr(source=config_path)],
         cite=config.get_algorithm_citations(),

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -22,6 +22,7 @@ from .bioimage import (
     create_model_description,
     extract_model_path,
 )
+from .bioimage.cover_factory import create_cover
 
 
 def _export_state_dict(
@@ -89,6 +90,7 @@ def export_to_bmz(
     authors: List[dict],
     input_array: np.ndarray,
     output_array: np.ndarray,
+    covers: Optional[list[Union[Path, str]]] = None,
     channel_names: Optional[List[str]] = None,
     model_version: str = "0.1.0",
 ) -> None:
@@ -119,6 +121,8 @@ def export_to_bmz(
         Input array, should not have been normalized.
     output_array : np.ndarray
         Output array, should have been denormalized.
+    covers : list of pathlib.Path or str, default=None
+        Paths to the cover images.
     channel_names : Optional[List[str]], optional
         Channel names, by default None.
     model_version : str, default="0.1.0"
@@ -169,6 +173,10 @@ def export_to_bmz(
         # export model state dictionary
         weight_path = _export_state_dict(model, temp_path / "weights.pth")
 
+        # export cover if necesary
+        if covers is None:
+            covers = [create_cover(temp_path, input_array, output_array)]
+
         # create model description
         model_description = create_model_description(
             config=config,
@@ -183,6 +191,7 @@ def export_to_bmz(
             careamics_version=careamics_version,
             config_path=config_path,
             env_path=env_path,
+            covers=covers,
             channel_names=channel_names,
             model_version=model_version,
         )

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -90,6 +90,7 @@ def export_to_bmz(
     input_array: np.ndarray,
     output_array: np.ndarray,
     channel_names: Optional[List[str]] = None,
+    model_version: str = "0.1.0",
 ) -> None:
     """Export the model to BioImage Model Zoo format.
 
@@ -120,6 +121,8 @@ def export_to_bmz(
         Output array, should have been denormalized.
     channel_names : Optional[List[str]], optional
         Channel names, by default None.
+    model_version : str, default="0.1.0"
+        Model version.
 
     Raises
     ------
@@ -181,6 +184,7 @@ def export_to_bmz(
             config_path=config_path,
             env_path=env_path,
             channel_names=channel_names,
+            model_version=model_version,
         )
 
         # test model description

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -85,11 +85,11 @@ def export_to_bmz(
     path_to_archive: Union[Path, str],
     model_name: str,
     general_description: str,
+    data_description: str,
     authors: List[dict],
     input_array: np.ndarray,
     output_array: np.ndarray,
     channel_names: Optional[List[str]] = None,
-    data_description: Optional[str] = None,
 ) -> None:
     """Export the model to BioImage Model Zoo format.
 
@@ -110,6 +110,8 @@ def export_to_bmz(
         Model name.
     general_description : str
         General description of the model.
+    data_description : str
+        Description of the data the model was trained on.
     authors : List[dict]
         Authors of the model.
     input_array : np.ndarray
@@ -118,8 +120,6 @@ def export_to_bmz(
         Output array, should have been denormalized.
     channel_names : Optional[List[str]], optional
         Channel names, by default None.
-    data_description : Optional[str], optional
-        Description of the data, by default None.
 
     Raises
     ------
@@ -171,6 +171,7 @@ def export_to_bmz(
             config=config,
             name=model_name,
             general_description=general_description,
+            data_description=data_description,
             authors=authors,
             inputs=inputs,
             outputs=outputs,
@@ -180,7 +181,6 @@ def export_to_bmz(
             config_path=config_path,
             env_path=env_path,
             channel_names=channel_names,
-            data_description=data_description,
         )
 
         # test model description

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -374,6 +374,7 @@ def pre_trained_bmz(tmp_path, pre_trained) -> Path:
         path_to_archive=path,
         model_name="TopModel",
         general_description="A model that just walked in.",
+        data_description="My data.",
         authors=[{"name": "Amod", "affiliation": "El"}],
         input_array=train_array[np.newaxis, np.newaxis, ...],
         output_array=predicted,

--- a/tests/model_io/test_bmz_io.py
+++ b/tests/model_io/test_bmz_io.py
@@ -51,6 +51,7 @@ def test_bmz_io(tmp_path, ordered_array, pre_trained):
         path_to_archive=path,
         model_name="TopModel",
         general_description="A model that just walked in.",
+        data_description="My data.",
         authors=[{"name": "Amod", "affiliation": "El"}],
         input_array=train_array[np.newaxis, np.newaxis, ...],
         output_array=predicted,

--- a/tests/model_io/test_bmz_io.py
+++ b/tests/model_io/test_bmz_io.py
@@ -1,4 +1,5 @@
 import numpy as np
+from bioimageio.spec import load_description
 from torch import Tensor
 
 from careamics import CAREamist
@@ -55,8 +56,13 @@ def test_bmz_io(tmp_path, ordered_array, pre_trained):
         authors=[{"name": "Amod", "affiliation": "El"}],
         input_array=train_array[np.newaxis, np.newaxis, ...],
         output_array=predicted,
+        model_version="0.0.15",
     )
     assert path.exists()
+
+    # load description
+    description = load_description(path)
+    assert str(description.version) == "0.0.15"
 
     # load model
     model, config = load_pretrained(path)

--- a/tests/test_careamist.py
+++ b/tests/test_careamist.py
@@ -113,6 +113,7 @@ def test_train_single_array_no_val(tmp_path: Path, minimum_configuration: dict):
         input_array=train_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
 
@@ -148,6 +149,7 @@ def test_train_array(tmp_path: Path, minimum_configuration: dict):
         input_array=train_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
 
@@ -189,6 +191,7 @@ def test_train_array_channel(
         input_array=train_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
         channel_names=["red", "green", "blue"],
     )
     assert (tmp_path / "model.zip").exists()
@@ -225,6 +228,7 @@ def test_train_array_3d(tmp_path: Path, minimum_configuration: dict):
         input_array=train_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
 
@@ -263,6 +267,7 @@ def test_train_tiff_files_in_memory_no_val(tmp_path: Path, minimum_configuration
         input_array=train_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
 
@@ -305,6 +310,7 @@ def test_train_tiff_files_in_memory(tmp_path: Path, minimum_configuration: dict)
         input_array=train_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
 
@@ -348,6 +354,7 @@ def test_train_tiff_files(tmp_path: Path, minimum_configuration: dict):
         input_array=train_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
 
@@ -390,6 +397,7 @@ def test_train_array_supervised(tmp_path: Path, supervised_configuration: dict):
         input_array=train_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
 
@@ -451,6 +459,7 @@ def test_train_tiff_files_in_memory_supervised(
         input_array=train_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
 
@@ -512,6 +521,7 @@ def test_train_tiff_files_supervised(tmp_path: Path, supervised_configuration: d
         input_array=train_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
 
@@ -557,6 +567,7 @@ def test_predict_on_array_tiled(
         input_array=train_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
 
@@ -600,6 +611,7 @@ def test_predict_arrays_no_tiling(
         input_array=train_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
 
@@ -742,6 +754,7 @@ def test_predict_path(
         input_array=train_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
 
@@ -807,6 +820,7 @@ def test_export_bmz_pretrained_prediction(tmp_path: Path, pre_trained: Path):
         input_array=source_array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
 
@@ -828,6 +842,7 @@ def test_export_bmz_pretrained_with_array(tmp_path: Path, pre_trained: Path):
         input_array=array,
         authors=[{"name": "Amod", "affiliation": "El"}],
         general_description="A model that just walked in.",
+        data_description="A random array.",
     )
     assert (tmp_path / "model2.zip").exists()
 


### PR DESCRIPTION
### Description

Following https://github.com/CAREamics/careamics/issues/278, this PR reorganizes the exported BMZ README:

- Put all configuration to the end
- Fix title level of algorithm
- Put data description first
- Remove training section
- Add a validation section
- Fix link to documentation

In addition, the API for the BMZ export has changed:
- `data_description` is now mandatory
- `model_version` is an optional parameter allowing to version models
- `cover` is an optional parameter

Users can now provide a path to a cover, no validation is done of that path. If no cover is provided, then we do something that is probably not optimized for multichannels:
- For 2D images, the images (input and output) are split horizontally, or vertically if they have different height. If they have different width as well, then an error is raised.
- For Z stack, the middle slice is selected.
- For images with 2 channels, the channels are used as `blue` and `green`
- For images with 3 channels, they are interpreted as RGB
- For images with 4 or more channels, the first 4 channels are used. The pixel value are normalised and multiplied with the RGB vectors of 4 pre-defined colors, and all channels are summed into an RGB image.

Note that that this is not a great way to represent scientific data, we should apply LUT to the grey scale channels and recompose overlays. Look up tables have been worked out for scientific figures and we could use those.

If that is acceptable for now, it will be easy to replace it.

### Changes Made

- **Added**:
    - `cover_factory.py`
    - helper scripts to inspect BMZ README and covers.
- **Modified**: all BMZ related modules.


### Related Issues

https://github.com/CAREamics/careamics/issues/278
https://github.com/CAREamics/careamics/issues/176

### Breaking changes

Any call to `careamist.export_bmz`.

### Additional Notes and Examples

The results README looks like this:

```markdown
# Noise2Void - CAREamics

## Data description

Mydata

## Algorithm description:

Noise2Void is a UNet-based self-supervised algorithm that uses blind-spot training to denoise images. In short, in every patches during training, random pixels are selected and their value replaced by a neighboring pixel value. The network is then trained to predict the original pixel value. The algorithm relies on the continuity of the signal (neighboring pixels have similar values) and the pixel-wise independence of the noise (the noise in a pixel is not correlated with the noise in neighboring pixels).

## Configuration

Noise2Void was trained using CAREamics (version 0.1.0) using the following configuration:


algorithm_config:
  algorithm: n2v
  loss: n2v
  lr_scheduler:
    name: ReduceLROnPlateau
    parameters: {}
  model:
    architecture: UNet
    conv_dims: 2
    depth: 2
    final_activation: None
    in_channels: 1
    independent_channels: true
    n2v2: false
    num_channels_init: 32
    num_classes: 1
  optimizer:
    name: Adam
    parameters:
      lr: 0.0001
data_config:
  axes: YX
  batch_size: 2
  data_type: array
  patch_size:
  - 64
  - 64
  transforms:
  - flip_x: true
    flip_y: true
    name: XYFlip
    p: 0.5
  - name: XYRandomRotate90
    p: 0.5
  - masked_pixel_percentage: 0.2
    name: N2VManipulate
    roi_size: 11
    strategy: uniform
    struct_mask_axis: none
    struct_mask_span: 5
experiment_name: export_bmz_readme
training_config:
  accumulate_grad_batches: 1
  check_val_every_n_epoch: 1
  checkpoint_callback:
    auto_insert_metric_name: false
    mode: min
    monitor: val_loss
    save_last: true
    save_top_k: 3
    save_weights_only: false
    verbose: false
  enable_progress_bar: true
  gradient_clip_algorithm: norm
  max_steps: -1
  num_epochs: 10
  precision: '32'
version: 0.1.0


## Validation

In order to validate the model, we encourage users to acquire a test dataset with ground-truth data. Additionally, inspecting the residual image (difference between input and predicted image) can be helpful to identify whether real signal is removed from the input image.

## References

Krull, A., Buchholz, T.O. and Jug, F., 2019. "Noise2Void - Learning denoising from single noisy images". In Proceedings of the IEEE/CVF conference on computer vision and pattern recognition (pp. 2129-2137). doi: 10.1109/cvpr.2019.00223

## Links

- [CAREamics repository](https://github.com/CAREamics/careamics)
- [CAREamics documentation](https://careamics.github.io/)
```

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)