### PR TITLE
chore: Set `ruff` compatibility check to `py39`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: ruff
         exclude: "^src/careamics/lvae_training/.*|^src/careamics/models/lvae/.*|^scripts/.*"
-        args: [--fix, --target-version, py38]
+        args: [--fix, --target-version, py39]
 
   - repo: https://github.com/psf/black
     rev: 24.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,7 @@ checks = [
     "GL02", # Closing quotes should be placed in the line after the last text 
     # in the docstring
     "GL03", # Double line break found
+    "RT04", # Return value description should start with a capital letter
 ]
 exclude = [ # don't report on objects that match any of these regex
     "test_*",

--- a/src/careamics/cli/conf.py
+++ b/src/careamics/cli/conf.py
@@ -3,12 +3,11 @@
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Annotated, Optional
 
 import click
 import typer
 import yaml
-from typing_extensions import Annotated
 
 from ..config import (
     Configuration,

--- a/src/careamics/cli/main.py
+++ b/src/careamics/cli/main.py
@@ -7,11 +7,10 @@ its implementation is contained in the conf.py file.
 """
 
 from pathlib import Path
-from typing import Optional
+from typing import Annotated, Optional
 
 import click
 import typer
-from typing_extensions import Annotated
 
 from ..careamist import CAREamist
 from . import conf

--- a/src/careamics/cli/utils.py
+++ b/src/careamics/cli/utils.py
@@ -1,11 +1,11 @@
 """Utility functions for the CAREamics CLI."""
 
-from typing import Optional, Tuple
+from typing import Optional
 
 
 def handle_2D_3D_callback(
-    value: Optional[Tuple[int, int, int]]
-) -> Optional[Tuple[int, ...]]:
+    value: Optional[tuple[int, int, int]]
+) -> Optional[tuple[int, ...]]:
     """
     Callback for options that require 2D or 3D inputs.
 

--- a/src/careamics/config/architectures/architecture_model.py
+++ b/src/careamics/config/architectures/architecture_model.py
@@ -1,6 +1,6 @@
 """Base model for the various CAREamics architectures."""
 
-from typing import Any, Dict
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -15,7 +15,7 @@ class ArchitectureModel(BaseModel):
     architecture: str
     """Name of the architecture."""
 
-    def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
         """
         Dump the model as a dictionary, ignoring the architecture keyword.
 
@@ -26,7 +26,7 @@ class ArchitectureModel(BaseModel):
 
         Returns
         -------
-        dict[str, Any]
+        {str: Any}
             Model as a dictionary.
         """
         model_dict = super().model_dump(**kwargs)

--- a/src/careamics/config/data_model.py
+++ b/src/careamics/config/data_model.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pprint import pformat
-from typing import Any, Literal, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -15,7 +15,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from typing_extensions import Annotated, Self
+from typing_extensions import Self
 
 from .support import SupportedTransform
 from .transformations import TRANSFORMS_UNION, N2VManipulateModel

--- a/src/careamics/config/likelihood_model.py
+++ b/src/careamics/config/likelihood_model.py
@@ -1,11 +1,10 @@
 """Likelihood model."""
 
-from typing import Literal, Optional, Union
+from typing import Annotated, Literal, Optional, Union
 
 import numpy as np
 import torch
 from pydantic import BaseModel, ConfigDict, PlainSerializer, PlainValidator
-from typing_extensions import Annotated
 
 from careamics.models.lvae.noise_models import (
     GaussianMixtureNoiseModel,

--- a/src/careamics/config/nm_model.py
+++ b/src/careamics/config/nm_model.py
@@ -1,7 +1,7 @@
 """Noise models config."""
 
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Annotated, Literal, Optional, Union
 
 import numpy as np
 import torch
@@ -12,7 +12,6 @@ from pydantic import (
     PlainSerializer,
     PlainValidator,
 )
-from typing_extensions import Annotated
 
 from careamics.utils.serializers import _array_to_json, _to_numpy
 

--- a/src/careamics/config/transformations/transform_model.py
+++ b/src/careamics/config/transformations/transform_model.py
@@ -1,6 +1,6 @@
 """Parent model for the transforms."""
 
-from typing import Any, Dict
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -23,7 +23,7 @@ class TransformModel(BaseModel):
 
     name: str
 
-    def model_dump(self, **kwargs) -> Dict[str, Any]:
+    def model_dump(self, **kwargs) -> dict[str, Any]:
         """
         Return the model as a dictionary.
 
@@ -34,7 +34,7 @@ class TransformModel(BaseModel):
 
         Returns
         -------
-        Dict[str, Any]
+        {str: Any}
             Dictionary representation of the model.
         """
         model_dict = super().model_dump(**kwargs)

--- a/src/careamics/config/transformations/transform_union.py
+++ b/src/careamics/config/transformations/transform_union.py
@@ -1,9 +1,8 @@
 """Type used to represent all transformations users can create."""
 
-from typing import Union
+from typing import Annotated, Union
 
 from pydantic import Discriminator
-from typing_extensions import Annotated
 
 from .n2v_manipulate_model import N2VManipulateModel
 from .xy_flip_model import XYFlipModel

--- a/src/careamics/config/validators/validator_utils.py
+++ b/src/careamics/config/validators/validator_utils.py
@@ -4,7 +4,7 @@ Validator functions.
 These functions are used to validate dimensions and axes of inputs.
 """
 
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 _AXES = "STCZYX"
 
@@ -79,14 +79,14 @@ def value_ge_than_8_power_of_2(
 
 
 def patch_size_ge_than_8_power_of_2(
-    patch_list: Optional[Union[List[int], Union[Tuple[int, ...]]]],
+    patch_list: Optional[Union[list[int], Union[tuple[int, ...]]]],
 ) -> None:
     """
     Validate that each entry is greater or equal than 8 and a power of 2.
 
     Parameters
     ----------
-    patch_list : Optional[Union[List[int]]]
+    patch_list : list or typle of int, or None
         Patch size.
 
     Raises

--- a/src/careamics/dataset/dataset_utils/dataset_utils.py
+++ b/src/careamics/dataset/dataset_utils/dataset_utils.py
@@ -1,7 +1,5 @@
 """Dataset utilities."""
 
-from typing import List, Tuple
-
 import numpy as np
 
 from careamics.utils.logging import get_logger
@@ -10,14 +8,14 @@ logger = get_logger(__name__)
 
 
 def _get_shape_order(
-    shape_in: Tuple[int, ...], axes_in: str, ref_axes: str = "STCZYX"
-) -> Tuple[Tuple[int, ...], str, List[int]]:
+    shape_in: tuple[int, ...], axes_in: str, ref_axes: str = "STCZYX"
+) -> tuple[tuple[int, ...], str, list[int]]:
     """
     Compute a new shape for the array based on the reference axes.
 
     Parameters
     ----------
-    shape_in : Tuple[int, ...]
+    shape_in : tuple[int, ...]
         Input shape.
     axes_in : str
         Input axes.
@@ -26,7 +24,7 @@ def _get_shape_order(
 
     Returns
     -------
-    Tuple[Tuple[int, ...], str, List[int]]
+    tuple[tuple[int, ...], str, list[int]]
         New shape, new axes, indices of axes in the new axes order.
     """
     indices = [axes_in.find(k) for k in ref_axes]

--- a/src/careamics/dataset/dataset_utils/file_utils.py
+++ b/src/careamics/dataset/dataset_utils/file_utils.py
@@ -2,7 +2,7 @@
 
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 
 import numpy as np
 
@@ -12,12 +12,12 @@ from careamics.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-def get_files_size(files: List[Path]) -> float:
+def get_files_size(files: list[Path]) -> float:
     """Get files size in MB.
 
     Parameters
     ----------
-    files : List[Path]
+    files : list of pathlib.Path
         List of files.
 
     Returns
@@ -32,7 +32,7 @@ def list_files(
     data_path: Union[str, Path],
     data_type: Union[str, SupportedData],
     extension_filter: str = "",
-) -> List[Path]:
+) -> list[Path]:
     """List recursively files in `data_path` and return a sorted list.
 
     If `data_path` is a file, its name is validated against the `data_type` using
@@ -55,8 +55,8 @@ def list_files(
 
     Returns
     -------
-    List[Path]
-        List of pathlib.Path objects.
+    list[Path]
+        list of pathlib.Path objects.
 
     Raises
     ------
@@ -105,7 +105,7 @@ def list_files(
     return files
 
 
-def validate_source_target_files(src_files: List[Path], tar_files: List[Path]) -> None:
+def validate_source_target_files(src_files: list[Path], tar_files: list[Path]) -> None:
     """
     Validate source and target path lists.
 
@@ -113,9 +113,9 @@ def validate_source_target_files(src_files: List[Path], tar_files: List[Path]) -
 
     Parameters
     ----------
-    src_files : List[Path]
+    src_files : list of pathlib.Path
         List of source files.
-    tar_files : List[Path]
+    tar_files : list of pathlib.Path
         List of target files.
 
     Raises

--- a/src/careamics/dataset/dataset_utils/iterate_over_files.py
+++ b/src/careamics/dataset/dataset_utils/iterate_over_files.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
-from typing import Callable, Generator, Optional, Union
+from typing import Callable, Optional, Union
 
 from numpy.typing import NDArray
 from torch.utils.data import get_worker_info

--- a/src/careamics/dataset/iterable_pred_dataset.py
+++ b/src/careamics/dataset/iterable_pred_dataset.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Callable, Generator
+from typing import Any, Callable
 
 from numpy.typing import NDArray
 from torch.utils.data import IterableDataset

--- a/src/careamics/dataset/iterable_tiled_pred_dataset.py
+++ b/src/careamics/dataset/iterable_tiled_pred_dataset.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Callable, Generator
+from typing import Any, Callable
 
 from numpy.typing import NDArray
 from torch.utils.data import IterableDataset

--- a/src/careamics/dataset/patching/random_patching.py
+++ b/src/careamics/dataset/patching/random_patching.py
@@ -1,6 +1,7 @@
 """Random patching utilities."""
 
-from typing import Generator, List, Optional, Tuple, Union
+from collections.abc import Generator
+from typing import Optional, Union
 
 import numpy as np
 import zarr
@@ -11,10 +12,10 @@ from .validate_patch_dimension import validate_patch_dimensions
 # TOOD split in testable functions
 def extract_patches_random(
     arr: np.ndarray,
-    patch_size: Union[List[int], Tuple[int, ...]],
+    patch_size: Union[list[int], tuple[int, ...]],
     target: Optional[np.ndarray] = None,
     seed: Optional[int] = None,
-) -> Generator[Tuple[np.ndarray, Optional[np.ndarray]], None, None]:
+) -> Generator[tuple[np.ndarray, Optional[np.ndarray]], None, None]:
     """
     Generate patches from an array in a random manner.
 
@@ -31,12 +32,12 @@ def extract_patches_random(
     ----------
     arr : np.ndarray
         Input image array.
-    patch_size : Tuple[int]
+    patch_size : tuple of int
         Patch sizes in each dimension.
     target : Optional[np.ndarray], optional
         Target array, by default None.
-    seed : Optional[int], optional
-        Random seed, by default None.
+    seed : int or None, default=None
+        Random seed.
 
     Yields
     ------
@@ -112,8 +113,8 @@ def extract_patches_random(
 
 def extract_patches_random_from_chunks(
     arr: zarr.Array,
-    patch_size: Union[List[int], Tuple[int, ...]],
-    chunk_size: Union[List[int], Tuple[int, ...]],
+    patch_size: Union[list[int], tuple[int, ...]],
+    chunk_size: Union[list[int], tuple[int, ...]],
     chunk_limit: Optional[int] = None,
     seed: Optional[int] = None,
 ) -> Generator[np.ndarray, None, None]:
@@ -127,9 +128,9 @@ def extract_patches_random_from_chunks(
     ----------
     arr : np.ndarray
         Input image array.
-    patch_size : Union[List[int], Tuple[int, ...]]
+    patch_size : Union[list[int], tuple[int, ...]]
         Patch sizes in each dimension.
-    chunk_size : Union[List[int], Tuple[int, ...]]
+    chunk_size : Union[list[int], tuple[int, ...]]
         Chunk sizes to load from the.
     chunk_limit : Optional[int], optional
         Number of chunks to load, by default None.

--- a/src/careamics/dataset/patching/sequential_patching.py
+++ b/src/careamics/dataset/patching/sequential_patching.py
@@ -1,6 +1,6 @@
 """Sequential patching functions."""
 
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 from skimage.util import view_as_windows
@@ -9,21 +9,21 @@ from .validate_patch_dimension import validate_patch_dimensions
 
 
 def _compute_number_of_patches(
-    arr_shape: Tuple[int, ...], patch_sizes: Union[List[int], Tuple[int, ...]]
-) -> Tuple[int, ...]:
+    arr_shape: tuple[int, ...], patch_sizes: Union[list[int], tuple[int, ...]]
+) -> tuple[int, ...]:
     """
     Compute the number of patches that fit in each dimension.
 
     Parameters
     ----------
-    arr_shape : Tuple[int, ...]
+    arr_shape : tuple[int, ...]
         Shape of the input array.
-    patch_sizes : Union[List[int], Tuple[int, ...]
+    patch_sizes : Union[list[int], tuple[int, ...]
         Shape of the patches.
 
     Returns
     -------
-    Tuple[int, ...]
+    tuple[int, ...]
         Number of patches in each dimension.
     """
     if len(arr_shape) != len(patch_sizes):
@@ -47,8 +47,8 @@ def _compute_number_of_patches(
 
 
 def _compute_overlap(
-    arr_shape: Tuple[int, ...], patch_sizes: Union[List[int], Tuple[int, ...]]
-) -> Tuple[int, ...]:
+    arr_shape: tuple[int, ...], patch_sizes: Union[list[int], tuple[int, ...]]
+) -> tuple[int, ...]:
     """
     Compute the overlap between patches in each dimension.
 
@@ -57,14 +57,14 @@ def _compute_overlap(
 
     Parameters
     ----------
-    arr_shape : Tuple[int, ...]
+    arr_shape : tuple[int, ...]
         Input array shape.
-    patch_sizes : Union[List[int], Tuple[int, ...]]
+    patch_sizes : Union[list[int], tuple[int, ...]]
         Size of the patches.
 
     Returns
     -------
-    Tuple[int, ...]
+    tuple[int, ...]
         Overlap between patches in each dimension.
     """
     n_patches = _compute_number_of_patches(arr_shape, patch_sizes)
@@ -80,21 +80,21 @@ def _compute_overlap(
 
 
 def _compute_patch_steps(
-    patch_sizes: Union[List[int], Tuple[int, ...]], overlaps: Tuple[int, ...]
-) -> Tuple[int, ...]:
+    patch_sizes: Union[list[int], tuple[int, ...]], overlaps: tuple[int, ...]
+) -> tuple[int, ...]:
     """
     Compute steps between patches.
 
     Parameters
     ----------
-    patch_sizes : Tuple[int]
+    patch_sizes : tuple[int]
         Size of the patches.
-    overlaps : Tuple[int]
+    overlaps : tuple[int]
         Overlap between patches.
 
     Returns
     -------
-    Tuple[int]
+    tuple[int]
         Steps between patches.
     """
     steps = [
@@ -107,9 +107,9 @@ def _compute_patch_steps(
 # TODO why stack the target here and not on a different dimension before this function?
 def _compute_patch_views(
     arr: np.ndarray,
-    window_shape: List[int],
-    step: Tuple[int, ...],
-    output_shape: List[int],
+    window_shape: list[int],
+    step: tuple[int, ...],
+    output_shape: list[int],
     target: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """
@@ -119,11 +119,11 @@ def _compute_patch_views(
     ----------
     arr : np.ndarray
         Array from which the views are extracted.
-    window_shape : Tuple[int]
+    window_shape : tuple[int]
         Shape of the views.
-    step : Tuple[int]
+    step : tuple[int]
         Steps between views.
-    output_shape : Tuple[int]
+    output_shape : tuple[int]
         Shape of the output array.
     target : Optional[np.ndarray], optional
         Target array, by default None.
@@ -150,9 +150,9 @@ def _compute_patch_views(
 
 def extract_patches_sequential(
     arr: np.ndarray,
-    patch_size: Union[List[int], Tuple[int, ...]],
+    patch_size: Union[list[int], tuple[int, ...]],
     target: Optional[np.ndarray] = None,
-) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+) -> tuple[np.ndarray, Optional[np.ndarray]]:
     """
     Generate patches from an array in a sequential manner.
 
@@ -163,14 +163,14 @@ def extract_patches_sequential(
     ----------
     arr : np.ndarray
         Input image array.
-    patch_size : Tuple[int]
+    patch_size : tuple[int]
         Patch sizes in each dimension.
     target : Optional[np.ndarray], optional
         Target array, by default None.
 
     Returns
     -------
-    Tuple[np.ndarray, Optional[np.ndarray]]
+    tuple[np.ndarray, Optional[np.ndarray]]
         Patches.
     """
     is_3d_patch = len(patch_size) == 3

--- a/src/careamics/dataset/patching/validate_patch_dimension.py
+++ b/src/careamics/dataset/patching/validate_patch_dimension.py
@@ -1,13 +1,13 @@
 """Patch validation functions."""
 
-from typing import List, Tuple, Union
+from typing import Union
 
 import numpy as np
 
 
 def validate_patch_dimensions(
     arr: np.ndarray,
-    patch_size: Union[List[int], Tuple[int, ...]],
+    patch_size: Union[list[int], tuple[int, ...]],
     is_3d_patch: bool,
 ) -> None:
     """
@@ -26,7 +26,7 @@ def validate_patch_dimensions(
     ----------
     arr : np.ndarray
         Input array.
-    patch_size : Union[List[int], Tuple[int, ...]]
+    patch_size : Union[list[int], tuple[int, ...]]
         Size of the patches along each dimension of the array, except the first.
     is_3d_patch : bool
         Whether the patch is 3D or not.

--- a/src/careamics/dataset/tiling/collate_tiles.py
+++ b/src/careamics/dataset/tiling/collate_tiles.py
@@ -1,6 +1,6 @@
 """Collate function for tiling."""
 
-from typing import Any, List, Tuple
+from typing import Any
 
 import numpy as np
 from torch.utils.data.dataloader import default_collate
@@ -8,7 +8,7 @@ from torch.utils.data.dataloader import default_collate
 from careamics.config.tile_information import TileInformation
 
 
-def collate_tiles(batch: List[Tuple[np.ndarray, TileInformation]]) -> Any:
+def collate_tiles(batch: list[tuple[np.ndarray, TileInformation]]) -> Any:
     """
     Collate tiles received from CAREamics prediction dataloader.
 
@@ -19,7 +19,7 @@ def collate_tiles(batch: List[Tuple[np.ndarray, TileInformation]]) -> Any:
 
     Parameters
     ----------
-    batch : List[Tuple[np.ndarray, TileInformation], ...]
+    batch : list[tuple[np.ndarray, TileInformation], ...]
         Batch of tiles.
 
     Returns

--- a/src/careamics/dataset/tiling/lvae_tiled_patching.py
+++ b/src/careamics/dataset/tiling/lvae_tiled_patching.py
@@ -2,7 +2,8 @@
 
 import builtins
 import itertools
-from typing import Any, Generator, Optional, Union
+from collections.abc import Generator
+from typing import Any, Optional, Union
 
 import numpy as np
 from numpy.typing import NDArray

--- a/src/careamics/dataset/tiling/tiled_patching.py
+++ b/src/careamics/dataset/tiling/tiled_patching.py
@@ -1,7 +1,8 @@
 """Tiled patching utilities."""
 
 import itertools
-from typing import Generator, List, Tuple, Union
+from collections.abc import Generator
+from typing import Union
 
 import numpy as np
 
@@ -10,7 +11,7 @@ from careamics.config.tile_information import TileInformation
 
 def _compute_crop_and_stitch_coords_1d(
     axis_size: int, tile_size: int, overlap: int
-) -> Tuple[List[Tuple[int, int]], List[Tuple[int, int]], List[Tuple[int, int]]]:
+) -> tuple[list[tuple[int, int]], list[tuple[int, int]], list[tuple[int, int]]]:
     """
     Compute the coordinates of each tile along an axis, given the overlap.
 
@@ -25,8 +26,8 @@ def _compute_crop_and_stitch_coords_1d(
 
     Returns
     -------
-    Tuple[Tuple[int, ...], ...]
-        Tuple of all coordinates for given axis.
+    tuple[tuple[int, ...], ...]
+        tuple of all coordinates for given axis.
     """
     # Compute the step between tiles
     step = tile_size - overlap
@@ -81,9 +82,9 @@ def _compute_crop_and_stitch_coords_1d(
 
 def extract_tiles(
     arr: np.ndarray,
-    tile_size: Union[List[int], Tuple[int, ...]],
-    overlaps: Union[List[int], Tuple[int, ...]],
-) -> Generator[Tuple[np.ndarray, TileInformation], None, None]:
+    tile_size: Union[list[int], tuple[int, ...]],
+    overlaps: Union[list[int], tuple[int, ...]],
+) -> Generator[tuple[np.ndarray, TileInformation], None, None]:
     """Generate tiles from the input array with specified overlap.
 
     The tiles cover the whole array. The method returns a generator that yields
@@ -98,14 +99,14 @@ def extract_tiles(
     ----------
     arr : np.ndarray
         Array of shape (S, C, (Z), Y, X).
-    tile_size : Union[List[int], Tuple[int]]
+    tile_size : Union[list[int], tuple[int]]
         Tile sizes in each dimension, of length 2 or 3.
-    overlaps : Union[List[int], Tuple[int]]
+    overlaps : Union[list[int], tuple[int]]
         Overlap values in each dimension, of length 2 or 3.
 
     Yields
     ------
-    Generator[Tuple[np.ndarray, TileInformation], None, None]
+    Generator[tuple[np.ndarray, TileInformation], None, None]
         Tile generator, yields the tile and additional information.
     """
     # Iterate over num samples (S)

--- a/src/careamics/file_io/read/get_func.py
+++ b/src/careamics/file_io/read/get_func.py
@@ -1,7 +1,7 @@
 """Module to get read functions."""
 
 from pathlib import Path
-from typing import Callable, Dict, Protocol, Union
+from typing import Callable, Protocol, Union
 
 from numpy.typing import NDArray
 
@@ -30,7 +30,7 @@ class ReadFunc(Protocol):
         """
 
 
-READ_FUNCS: Dict[SupportedData, ReadFunc] = {
+READ_FUNCS: dict[SupportedData, ReadFunc] = {
     SupportedData.TIFF: read_tiff,
 }
 

--- a/src/careamics/lightning/callbacks/prediction_writer_callback/prediction_writer_callback.py
+++ b/src/careamics/lightning/callbacks/prediction_writer_callback/prediction_writer_callback.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Optional, Union
 
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import BasePredictionWriter

--- a/src/careamics/lightning/callbacks/prediction_writer_callback/write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction_writer_callback/write_strategy.py
@@ -1,7 +1,8 @@
 """Module containing different strategies for writing predictions."""
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Optional, Protocol, Sequence, Union
+from typing import Any, Optional, Protocol, Union
 
 import numpy as np
 from numpy.typing import NDArray

--- a/src/careamics/lightning/callbacks/progress_bar_callback.py
+++ b/src/careamics/lightning/callbacks/progress_bar_callback.py
@@ -1,7 +1,7 @@
 """Progressbar callback."""
 
 import sys
-from typing import Dict, Union
+from typing import Union
 
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import TQDMProgressBar
@@ -71,7 +71,7 @@ class ProgressBarCallback(TQDMProgressBar):
 
     def get_metrics(
         self, trainer: Trainer, pl_module: LightningModule
-    ) -> Dict[str, Union[int, str, float, Dict[str, float]]]:
+    ) -> dict[str, Union[int, str, float, dict[str, float]]]:
         """Override this to customize the metrics displayed in the progress bar.
 
         Parameters

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -1,7 +1,7 @@
 """Module use to build BMZ model description."""
 
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 from bioimageio.spec._internal.io import resolve_and_extract
@@ -36,9 +36,9 @@ from ._readme_factory import readme_factory
 def _create_axes(
     array: np.ndarray,
     data_config: DataConfig,
-    channel_names: Optional[List[str]] = None,
+    channel_names: Optional[list[str]] = None,
     is_input: bool = True,
-) -> List[AxisBase]:
+) -> list[AxisBase]:
     """Create axes description.
 
     Array shape is expected to be SC(Z)YX.
@@ -49,15 +49,15 @@ def _create_axes(
         Array.
     data_config : DataModel
         CAREamics data configuration.
-    channel_names : Optional[List[str]], optional
+    channel_names : Optional[list[str]], optional
         Channel names, by default None.
     is_input : bool, optional
         Whether the axes are input axes, by default True.
 
     Returns
     -------
-    List[AxisBase]
-        List of axes description.
+    list[AxisBase]
+        list of axes description.
 
     Raises
     ------
@@ -105,8 +105,8 @@ def _create_inputs_ouputs(
     data_config: DataConfig,
     input_path: Union[Path, str],
     output_path: Union[Path, str],
-    channel_names: Optional[List[str]] = None,
-) -> Tuple[InputTensorDescr, OutputTensorDescr]:
+    channel_names: Optional[list[str]] = None,
+) -> tuple[InputTensorDescr, OutputTensorDescr]:
     """Create input and output tensor description.
 
     Input and output paths must point to a `.npy` file.
@@ -123,12 +123,12 @@ def _create_inputs_ouputs(
         Path to input .npy file.
     output_path : Union[Path, str]
         Path to output .npy file.
-    channel_names : Optional[List[str]], optional
+    channel_names : Optional[list[str]], optional
         Channel names, by default None.
 
     Returns
     -------
-    Tuple[InputTensorDescr, OutputTensorDescr]
+    tuple[InputTensorDescr, OutputTensorDescr]
         Input and output tensor descriptions.
     """
     input_axes = _create_axes(input_array, data_config, channel_names)
@@ -188,7 +188,7 @@ def create_model_description(
     name: str,
     general_description: str,
     data_description: str,
-    authors: List[Author],
+    authors: list[Author],
     inputs: Union[Path, str],
     outputs: Union[Path, str],
     weights_path: Union[Path, str],
@@ -197,7 +197,7 @@ def create_model_description(
     config_path: Union[Path, str],
     env_path: Union[Path, str],
     covers: list[Union[Path, str]],
-    channel_names: Optional[List[str]] = None,
+    channel_names: Optional[list[str]] = None,
     model_version: str = "0.1.0",
 ) -> ModelDescr:
     """Create model description.
@@ -212,7 +212,7 @@ def create_model_description(
         General description of the model.
     data_description : str
         Description of the data the model was trained on.
-    authors : List[Author]
+    authors : list[Author]
         Authors of the model.
     inputs : Union[Path, str]
         Path to input .npy file.
@@ -230,7 +230,7 @@ def create_model_description(
         Path to environment file.
     covers : list of pathlib.Path or str
         Paths to cover images.
-    channel_names : Optional[List[str]], optional
+    channel_names : Optional[list[str]], optional
         Channel names, by default None.
     model_version : str, default "0.1.0"
         Model version.

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -2,7 +2,7 @@
 
 import tempfile
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import pkg_resources
@@ -87,11 +87,11 @@ def export_to_bmz(
     model_name: str,
     general_description: str,
     data_description: str,
-    authors: List[dict],
+    authors: list[dict],
     input_array: np.ndarray,
     output_array: np.ndarray,
     covers: Optional[list[Union[Path, str]]] = None,
-    channel_names: Optional[List[str]] = None,
+    channel_names: Optional[list[str]] = None,
     model_version: str = "0.1.0",
 ) -> None:
     """Export the model to BioImage Model Zoo format.
@@ -115,7 +115,7 @@ def export_to_bmz(
         General description of the model.
     data_description : str
         Description of the data the model was trained on.
-    authors : List[dict]
+    authors : list[dict]
         Authors of the model.
     input_array : np.ndarray
         Input array, should not have been normalized.
@@ -123,7 +123,7 @@ def export_to_bmz(
         Output array, should have been denormalized.
     covers : list of pathlib.Path or str, default=None
         Paths to the cover images.
-    channel_names : Optional[List[str]], optional
+    channel_names : Optional[list[str]], optional
         Channel names, by default None.
     model_version : str, default="0.1.0"
         Model version.
@@ -212,7 +212,7 @@ def export_to_bmz(
 
 def load_from_bmz(
     path: Union[Path, str, HttpUrl]
-) -> Tuple[Union[FCNModule, VAEModule], Configuration]:
+) -> tuple[Union[FCNModule, VAEModule], Configuration]:
     """Load a model from a BioImage Model Zoo archive.
 
     Parameters

--- a/src/careamics/model_io/model_io_utils.py
+++ b/src/careamics/model_io/model_io_utils.py
@@ -1,7 +1,7 @@
 """Utility functions to load pretrained models."""
 
 from pathlib import Path
-from typing import Tuple, Union
+from typing import Union
 
 import torch
 
@@ -13,7 +13,7 @@ from careamics.utils import check_path_exists
 
 def load_pretrained(
     path: Union[Path, str]
-) -> Tuple[Union[FCNModule, VAEModule], Configuration]:
+) -> tuple[Union[FCNModule, VAEModule], Configuration]:
     """
     Load a pretrained model from a checkpoint or a BioImage Model Zoo model.
 
@@ -26,8 +26,8 @@ def load_pretrained(
 
     Returns
     -------
-    Tuple[CAREamicsKiln, Configuration]
-        Tuple of CAREamics model and its configuration.
+    tuple[CAREamicsKiln, Configuration]
+        tuple of CAREamics model and its configuration.
 
     Raises
     ------
@@ -48,7 +48,7 @@ def load_pretrained(
 
 def _load_checkpoint(
     path: Union[Path, str]
-) -> Tuple[Union[FCNModule, VAEModule], Configuration]:
+) -> tuple[Union[FCNModule, VAEModule], Configuration]:
     """
     Load a model from a checkpoint and return both model and configuration.
 
@@ -59,8 +59,8 @@ def _load_checkpoint(
 
     Returns
     -------
-    Tuple[CAREamicsKiln, Configuration]
-        Tuple of CAREamics model and its configuration.
+    tuple[CAREamicsKiln, Configuration]
+        tuple of CAREamics model and its configuration.
 
     Raises
     ------

--- a/src/careamics/models/layers.py
+++ b/src/careamics/models/layers.py
@@ -4,7 +4,7 @@ Layer module.
 This submodule contains layers used in the CAREamics models.
 """
 
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -157,22 +157,22 @@ class Conv_Block(nn.Module):
 
 
 def _unpack_kernel_size(
-    kernel_size: Union[Tuple[int, ...], int], dim: int
-) -> Tuple[int, ...]:
+    kernel_size: Union[tuple[int, ...], int], dim: int
+) -> tuple[int, ...]:
     """Unpack kernel_size to a tuple of ints.
 
     Inspired by Kornia implementation. TODO: link
 
     Parameters
     ----------
-    kernel_size : Union[Tuple[int, ...], int]
+    kernel_size : Union[tuple[int, ...], int]
         Kernel size.
     dim : int
         Number of dimensions.
 
     Returns
     -------
-    Tuple[int, ...]
+    tuple[int, ...]
         Kernel size tuple.
     """
     if isinstance(kernel_size, int):
@@ -183,20 +183,20 @@ def _unpack_kernel_size(
 
 
 def _compute_zero_padding(
-    kernel_size: Union[Tuple[int, ...], int], dim: int
-) -> Tuple[int, ...]:
+    kernel_size: Union[tuple[int, ...], int], dim: int
+) -> tuple[int, ...]:
     """Utility function that computes zero padding tuple.
 
     Parameters
     ----------
-    kernel_size : Union[Tuple[int, ...], int]
+    kernel_size : Union[tuple[int, ...], int]
         Kernel size.
     dim : int
         Number of dimensions.
 
     Returns
     -------
-    Tuple[int, ...]
+    tuple[int, ...]
         Zero padding tuple.
     """
     kernel_dims = _unpack_kernel_size(kernel_size, dim)
@@ -245,8 +245,8 @@ def get_pascal_kernel_1d(
     >>> get_pascal_kernel_1d(6)
     tensor([ 1.,  5., 10., 10.,  5.,  1.])
     """
-    pre: List[float] = []
-    cur: List[float] = []
+    pre: list[float] = []
+    cur: list[float] = []
     for i in range(kernel_size):
         cur = [1.0] * (i + 1)
 
@@ -266,7 +266,7 @@ def get_pascal_kernel_1d(
 
 
 def _get_pascal_kernel_nd(
-    kernel_size: Union[Tuple[int, int], int],
+    kernel_size: Union[tuple[int, int], int],
     norm: bool = True,
     dim: int = 2,
     *,
@@ -282,7 +282,7 @@ def _get_pascal_kernel_nd(
 
     Parameters
     ----------
-    kernel_size : Union[Tuple[int, int], int]
+    kernel_size : Union[tuple[int, int], int]
         Kernel size for the pascal kernel.
     norm : bool
         Normalize the kernel, by default True.
@@ -420,7 +420,7 @@ class MaxBlurPool(nn.Module):
     ----------
     dim : int
         Toggles between 2D and 3D.
-    kernel_size : Union[Tuple[int, int], int]
+    kernel_size : Union[tuple[int, int], int]
         Kernel size for max pooling.
     stride : int
         Stride for pooling.
@@ -433,7 +433,7 @@ class MaxBlurPool(nn.Module):
     def __init__(
         self,
         dim: int,
-        kernel_size: Union[Tuple[int, int], int],
+        kernel_size: Union[tuple[int, int], int],
         stride: int = 2,
         max_pool_size: int = 2,
         ceil_mode: bool = False,
@@ -444,7 +444,7 @@ class MaxBlurPool(nn.Module):
         ----------
         dim : int
             Dimension of the convolution.
-        kernel_size : Union[Tuple[int, int], int]
+        kernel_size : Union[tuple[int, int], int]
             Kernel size for max pooling.
         stride : int, optional
             Stride, by default 2.

--- a/src/careamics/models/unet.py
+++ b/src/careamics/models/unet.py
@@ -4,7 +4,7 @@ UNet model.
 A UNet encoder, decoder and complete model.
 """
 
-from typing import Any, List, Tuple, Union
+from typing import Any, Union
 
 import torch
 import torch.nn as nn
@@ -102,9 +102,9 @@ class UnetEncoder(nn.Module):
                 )
             )
             encoder_blocks.append(self.pooling)
-        self.encoder_blocks = nn.ModuleList(encoder_blocks)
+        self.encoder_blocks = nn.Modulelist(encoder_blocks)
 
-    def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
+    def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
         """
         Forward pass.
 
@@ -115,7 +115,7 @@ class UnetEncoder(nn.Module):
 
         Returns
         -------
-        List[torch.Tensor]
+        list[torch.Tensor]
             Output of each encoder block (skip connections) and final output of the
             encoder.
         """
@@ -202,7 +202,7 @@ class UnetDecoder(nn.Module):
             groups=self.groups,
         )
 
-        decoder_blocks: List[nn.Module] = []
+        decoder_blocks: list[nn.Module] = []
         for n in range(depth):
             decoder_blocks.append(upsampling)
             in_channels = (num_channels_init * 2 ** (depth - n)) * groups
@@ -222,7 +222,7 @@ class UnetDecoder(nn.Module):
                 )
             )
 
-        self.decoder_blocks = nn.ModuleList(decoder_blocks)
+        self.decoder_blocks = nn.Modulelist(decoder_blocks)
 
     def forward(self, *features: torch.Tensor) -> torch.Tensor:
         """
@@ -230,7 +230,7 @@ class UnetDecoder(nn.Module):
 
         Parameters
         ----------
-        *features :  List[torch.Tensor]
+        *features :  list[torch.Tensor]
             List containing the output of each encoder block(skip connections) and final
             output of the encoder.
 
@@ -240,7 +240,7 @@ class UnetDecoder(nn.Module):
             Output of the decoder.
         """
         x: torch.Tensor = features[0]
-        skip_connections: Tuple[torch.Tensor, ...] = features[-1:0:-1]
+        skip_connections: tuple[torch.Tensor, ...] = features[-1:0:-1]
 
         x = self.bottleneck(x)
 
@@ -289,10 +289,10 @@ class UnetDecoder(nn.Module):
         m = A.shape[1] // groups
         n = B.shape[1] // groups
 
-        A_groups: List[torch.Tensor] = [
+        A_groups: list[torch.Tensor] = [
             A[:, i * m : (i + 1) * m] for i in range(groups)
         ]
-        B_groups: List[torch.Tensor] = [
+        B_groups: list[torch.Tensor] = [
             B[:, i * n : (i + 1) * n] for i in range(groups)
         ]
 

--- a/src/careamics/models/unet.py
+++ b/src/careamics/models/unet.py
@@ -102,7 +102,7 @@ class UnetEncoder(nn.Module):
                 )
             )
             encoder_blocks.append(self.pooling)
-        self.encoder_blocks = nn.Modulelist(encoder_blocks)
+        self.encoder_blocks = nn.ModuleList(encoder_blocks)
 
     def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
         """
@@ -222,7 +222,7 @@ class UnetDecoder(nn.Module):
                 )
             )
 
-        self.decoder_blocks = nn.Modulelist(decoder_blocks)
+        self.decoder_blocks = nn.ModuleList(decoder_blocks)
 
     def forward(self, *features: torch.Tensor) -> torch.Tensor:
         """

--- a/src/careamics/prediction_utils/prediction_outputs.py
+++ b/src/careamics/prediction_utils/prediction_outputs.py
@@ -1,6 +1,6 @@
 """Module containing functions to convert prediction outputs to desired form."""
 
-from typing import Any, List, Literal, Tuple, Union, overload
+from typing import Any, Literal, Union, overload
 
 import numpy as np
 from numpy.typing import NDArray
@@ -9,7 +9,7 @@ from ..config.tile_information import TileInformation
 from .stitch_prediction import stitch_prediction
 
 
-def convert_outputs(predictions: List[Any], tiled: bool) -> list[NDArray]:
+def convert_outputs(predictions: list[Any], tiled: bool) -> list[NDArray]:
     """
     Convert the Lightning trainer outputs to the desired form.
 
@@ -25,7 +25,7 @@ def convert_outputs(predictions: List[Any], tiled: bool) -> list[NDArray]:
     Returns
     -------
     list of numpy.ndarray or numpy.ndarray
-        List of arrays with the axes SC(Z)YX. If there is only 1 output it will not
+        list of arrays with the axes SC(Z)YX. If there is only 1 output it will not
         be in a list.
     """
     if len(predictions) == 0:
@@ -44,27 +44,27 @@ def convert_outputs(predictions: List[Any], tiled: bool) -> list[NDArray]:
 # for mypy
 @overload
 def combine_batches(  # numpydoc ignore=GL08
-    predictions: List[Any], tiled: Literal[True]
-) -> Tuple[List[NDArray], List[TileInformation]]: ...
+    predictions: list[Any], tiled: Literal[True]
+) -> tuple[list[NDArray], list[TileInformation]]: ...
 
 
 # for mypy
 @overload
 def combine_batches(  # numpydoc ignore=GL08
-    predictions: List[Any], tiled: Literal[False]
-) -> List[NDArray]: ...
+    predictions: list[Any], tiled: Literal[False]
+) -> list[NDArray]: ...
 
 
 # for mypy
 @overload
 def combine_batches(  # numpydoc ignore=GL08
-    predictions: List[Any], tiled: Union[bool, Literal[True], Literal[False]]
-) -> Union[List[NDArray], Tuple[List[NDArray], List[TileInformation]]]: ...
+    predictions: list[Any], tiled: Union[bool, Literal[True], Literal[False]]
+) -> Union[list[NDArray], tuple[list[NDArray], list[TileInformation]]]: ...
 
 
 def combine_batches(
-    predictions: List[Any], tiled: bool
-) -> Union[List[NDArray], Tuple[List[NDArray], List[TileInformation]]]:
+    predictions: list[Any], tiled: bool
+) -> Union[list[NDArray], tuple[list[NDArray], list[TileInformation]]]:
     """
     If predictions are in batches, they will be combined.
 
@@ -87,8 +87,8 @@ def combine_batches(
 
 
 def _combine_tiled_batches(
-    predictions: List[Tuple[NDArray, List[TileInformation]]]
-) -> Tuple[List[NDArray], List[TileInformation]]:
+    predictions: list[tuple[NDArray, list[TileInformation]]]
+) -> tuple[list[NDArray], list[TileInformation]]:
     """
     Combine batches from tiled output.
 
@@ -109,13 +109,13 @@ def _combine_tiled_batches(
     tile_infos = [
         tile_info for _, tile_info_list in predictions for tile_info in tile_info_list
     ]
-    prediction_tiles: List[NDArray] = _combine_array_batches(
+    prediction_tiles: list[NDArray] = _combine_array_batches(
         [preds for preds, _ in predictions]
     )
     return prediction_tiles, tile_infos
 
 
-def _combine_array_batches(predictions: List[NDArray]) -> List[NDArray]:
+def _combine_array_batches(predictions: list[NDArray]) -> list[NDArray]:
     """
     Combine batches of arrays.
 

--- a/src/careamics/prediction_utils/stitch_prediction.py
+++ b/src/careamics/prediction_utils/stitch_prediction.py
@@ -1,7 +1,7 @@
 """Prediction utility functions."""
 
 import builtins
-from typing import List, Union
+from typing import Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -11,9 +11,9 @@ from careamics.config.tile_information import TileInformation
 
 # TODO: why not allow input and output of torch.tensor ?
 def stitch_prediction(
-    tiles: List[np.ndarray],
-    tile_infos: List[TileInformation],
-) -> List[np.ndarray]:
+    tiles: list[np.ndarray],
+    tile_infos: list[TileInformation],
+) -> list[np.ndarray]:
     """
     Stitch tiles back together to form a full image(s).
 
@@ -54,8 +54,8 @@ def stitch_prediction(
 
 
 def stitch_prediction_single(
-    tiles: List[NDArray],
-    tile_infos: List[TileInformation],
+    tiles: list[NDArray],
+    tile_infos: list[TileInformation],
 ) -> NDArray:
     """
     Stitch tiles back together to form a full image.

--- a/src/careamics/transforms/compose.py
+++ b/src/careamics/transforms/compose.py
@@ -1,6 +1,6 @@
 """A class chaining transforms together."""
 
-from typing import Dict, List, Optional, Tuple, Union, cast
+from typing import Optional, Union, cast
 
 from numpy.typing import NDArray
 
@@ -20,7 +20,7 @@ ALL_TRANSFORMS = {
 }
 
 
-def get_all_transforms() -> Dict[str, type]:
+def get_all_transforms() -> dict[str, type]:
     """Return all the transforms accepted by CAREamics.
 
     Returns
@@ -37,7 +37,7 @@ class Compose:
 
     Parameters
     ----------
-    transform_list : List[TransformModel]
+    transform_list : list[TransformModel]
         A list of dictionaries where each dictionary contains the name of a
         transform and its parameters.
 
@@ -47,12 +47,12 @@ class Compose:
         A callable that applies the transforms to the input data.
     """
 
-    def __init__(self, transform_list: List[TransformModel]) -> None:
+    def __init__(self, transform_list: list[TransformModel]) -> None:
         """Instantiate a Compose object.
 
         Parameters
         ----------
-        transform_list : List[TransformModel]
+        transform_list : list[TransformModel]
             A list of dictionaries where each dictionary contains the name of a
             transform and its parameters.
         """
@@ -67,7 +67,7 @@ class Compose:
 
     def _chain_transforms(
         self, patch: NDArray, target: Optional[NDArray]
-    ) -> Tuple[Optional[NDArray], ...]:
+    ) -> tuple[Optional[NDArray], ...]:
         """Chain transforms on the input data.
 
         Parameters
@@ -79,7 +79,7 @@ class Compose:
 
         Returns
         -------
-        Tuple[np.ndarray, Optional[np.ndarray]]
+        tuple[np.ndarray, Optional[np.ndarray]]
             The output of the transformations.
         """
         params: Union[
@@ -103,7 +103,7 @@ class Compose:
         patch: NDArray,
         target: Optional[NDArray],
         **additional_arrays: NDArray,
-    ) -> Tuple[NDArray, Optional[NDArray], dict[str, NDArray]]:
+    ) -> tuple[NDArray, Optional[NDArray], dict[str, NDArray]]:
         """Chain transforms on the input data, with additional arrays.
 
         Parameters
@@ -118,7 +118,7 @@ class Compose:
 
         Returns
         -------
-        Tuple[np.ndarray, Optional[np.ndarray]]
+        tuple[np.ndarray, Optional[np.ndarray]]
             The output of the transformations.
         """
         params = {"patch": patch, "target": target, **additional_arrays}
@@ -131,7 +131,7 @@ class Compose:
 
     def __call__(
         self, patch: NDArray, target: Optional[NDArray] = None
-    ) -> Tuple[NDArray, ...]:
+    ) -> tuple[NDArray, ...]:
         """Apply the transforms to the input data.
 
         Parameters
@@ -143,11 +143,11 @@ class Compose:
 
         Returns
         -------
-        Tuple[np.ndarray, ...]
+        tuple[np.ndarray, ...]
             The output of the transformations.
         """
         # TODO: solve casting Compose.__call__ ouput
-        return cast(Tuple[NDArray, ...], self._chain_transforms(patch, target))
+        return cast(tuple[NDArray, ...], self._chain_transforms(patch, target))
 
     def transform_with_additional_arrays(
         self,

--- a/src/careamics/transforms/n2v_manipulate.py
+++ b/src/careamics/transforms/n2v_manipulate.py
@@ -1,6 +1,6 @@
 """N2V manipulation transform."""
 
-from typing import Any, Literal, Optional, Tuple
+from typing import Any, Literal, Optional
 
 import numpy as np
 from numpy.typing import NDArray
@@ -100,7 +100,7 @@ class N2VManipulate(Transform):
 
     def __call__(
         self, patch: NDArray, *args: Any, **kwargs: Any
-    ) -> Tuple[NDArray, NDArray, NDArray]:
+    ) -> tuple[NDArray, NDArray, NDArray]:
         """Apply the transform to the image.
 
         Parameters
@@ -114,7 +114,7 @@ class N2VManipulate(Transform):
 
         Returns
         -------
-        Tuple[np.ndarray, np.ndarray, np.ndarray]
+        tuple[np.ndarray, np.ndarray, np.ndarray]
             Masked patch, original patch, and mask.
         """
         masked = np.zeros_like(patch)

--- a/src/careamics/transforms/pixel_manipulation.py
+++ b/src/careamics/transforms/pixel_manipulation.py
@@ -5,7 +5,7 @@ Pixel manipulation is used in N2V and similar algorithm to replace the value of
 masked pixels.
 """
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import numpy as np
 
@@ -107,7 +107,7 @@ def _odd_jitter_func(step: float, rng: np.random.Generator) -> np.ndarray:
 
 def _get_stratified_coords(
     mask_pixel_perc: float,
-    shape: Tuple[int, ...],
+    shape: tuple[int, ...],
     rng: Optional[np.random.Generator] = None,
 ) -> np.ndarray:
     """
@@ -121,7 +121,7 @@ def _get_stratified_coords(
     mask_pixel_perc : float
         Actual (quasi) percentage of masked pixels across the whole image. Used in
         calculating the distance between masked pixels across each axis.
-    shape : Tuple[int, ...]
+    shape : tuple[int, ...]
         Shape of the input patch.
     rng : np.random.Generator or None
         Random number generator.
@@ -242,7 +242,7 @@ def uniform_manipulate(
     remove_center: bool = True,
     struct_params: Optional[StructMaskParameters] = None,
     rng: Optional[np.random.Generator] = None,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Manipulate pixels by replacing them with a neighbor values.
 
@@ -269,8 +269,8 @@ def uniform_manipulate(
 
     Returns
     -------
-    Tuple[np.ndarray]
-        Tuple containing the manipulated patch and the corresponding mask.
+    tuple[np.ndarray]
+        tuple containing the manipulated patch and the corresponding mask.
     """
     if rng is None:
         rng = np.random.default_rng()
@@ -322,7 +322,7 @@ def median_manipulate(
     subpatch_size: int = 11,
     struct_params: Optional[StructMaskParameters] = None,
     rng: Optional[np.random.Generator] = None,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Manipulate pixels by replacing them with the median of their surrounding subpatch.
 
@@ -348,8 +348,8 @@ def median_manipulate(
 
     Returns
     -------
-    Tuple[np.ndarray]
-           Tuple containing the manipulated patch, the original patch and the mask.
+    tuple[np.ndarray]
+           tuple containing the manipulated patch, the original patch and the mask.
     """
     if rng is None:
         rng = np.random.default_rng()

--- a/src/careamics/transforms/xy_random_rotate90.py
+++ b/src/careamics/transforms/xy_random_rotate90.py
@@ -1,6 +1,6 @@
 """Patch transform applying XY random 90 degrees rotations."""
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import numpy as np
 from numpy.typing import NDArray
@@ -69,7 +69,7 @@ class XYRandomRotate90(Transform):
 
         Returns
         -------
-        Tuple[np.ndarray, Optional[np.ndarray]]
+        tuple[np.ndarray, Optional[np.ndarray]]
             Transformed patch and target.
         """
         if self.rng.random() > self.p:
@@ -90,7 +90,7 @@ class XYRandomRotate90(Transform):
 
         return patch_transformed, target_transformed, additional_transformed
 
-    def _apply(self, patch: NDArray, n_rot: int, axes: Tuple[int, int]) -> NDArray:
+    def _apply(self, patch: NDArray, n_rot: int, axes: tuple[int, int]) -> NDArray:
         """Apply the transform to the image.
 
         Parameters
@@ -99,7 +99,7 @@ class XYRandomRotate90(Transform):
             Image or image patch, 2D or 3D, shape C(Z)YX.
         n_rot : int
             Number of 90 degree rotations.
-        axes : Tuple[int, int]
+        axes : tuple[int, int]
             Axes along which to rotate the patch.
 
         Returns

--- a/src/careamics/utils/context.py
+++ b/src/careamics/utils/context.py
@@ -5,9 +5,10 @@ A convenience function to change the working directory in order to save data.
 """
 
 import os
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, Union
+from typing import Union
 
 
 def get_careamics_home() -> Path:

--- a/src/careamics/utils/logging.py
+++ b/src/careamics/utils/logging.py
@@ -7,8 +7,9 @@ The methods are responsible for the in-console logger.
 import logging
 import sys
 import time
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Optional, Union
+from typing import Any, Optional, Union
 
 LOGGERS: dict = {}
 
@@ -84,7 +85,7 @@ class ProgressBar:
         Zero-indexed current epoch, by default None.
     num_epochs : Optional[int], optional
         Total number of epochs, by default None.
-    stateful_metrics : Optional[List], optional
+    stateful_metrics : Optional[list], optional
         Iterable of string names of metrics that should *not* be averaged over time.
         Metrics in this list will be displayed as-is. All others will be averaged by
         the progress bar before display, by default None.
@@ -99,7 +100,7 @@ class ProgressBar:
         max_value: Optional[int] = None,
         epoch: Optional[int] = None,
         num_epochs: Optional[int] = None,
-        stateful_metrics: Optional[List] = None,
+        stateful_metrics: Optional[list] = None,
         always_stateful: bool = False,
         mode: str = "train",
     ) -> None:
@@ -114,7 +115,7 @@ class ProgressBar:
             Zero-indexed current epoch, by default None.
         num_epochs : Optional[int], optional
             Total number of epochs, by default None.
-        stateful_metrics : Optional[List], optional
+        stateful_metrics : Optional[list], optional
             Iterable of string names of metrics that should *not* be averaged over time.
             Metrics in this list will be displayed as-is. All others will be averaged by
             the progress bar before display, by default None.
@@ -145,8 +146,8 @@ class ProgressBar:
         self._seen_so_far = 0
         # We use a dict + list to avoid garbage collection
         # issues found in OrderedDict
-        self._values: Dict[Any, Any] = {}
-        self._values_order: List[Any] = []
+        self._values: dict[Any, Any] = {}
+        self._values_order: list[Any] = []
         self._start = time.time()
         self._last_update = 0.0
         self.spin = self.spinning_cursor() if self.max_value is None else None
@@ -158,7 +159,7 @@ class ProgressBar:
             self.message = "Denoising"
 
     def update(
-        self, current_step: int, batch_size: int = 1, values: Optional[List] = None
+        self, current_step: int, batch_size: int = 1, values: Optional[list] = None
     ) -> None:
         """
         Update the progress bar.
@@ -169,7 +170,7 @@ class ProgressBar:
             Index of the current step.
         batch_size : int, optional
             Batch size, by default 1.
-        values : Optional[List], optional
+        values : Optional[list], optional
             Updated metrics values, by default None.
         """
         values = values or []
@@ -263,7 +264,7 @@ class ProgressBar:
 
         self._last_update = now
 
-    def add(self, n: int, values: Optional[List] = None) -> None:
+    def add(self, n: int, values: Optional[list] = None) -> None:
         """
         Update the progress bar by n steps.
 
@@ -271,7 +272,7 @@ class ProgressBar:
         ----------
         n : int
             Number of steps to increase the progress bar with.
-        values : Optional[List], optional
+        values : Optional[list], optional
             Updated metrics values, by default None.
         """
         self.update(self._seen_so_far + n, 1, values=values)

--- a/src/careamics/utils/torch_utils.py
+++ b/src/careamics/utils/torch_utils.py
@@ -5,7 +5,7 @@ These functions are used to control certain aspects and behaviours of PyTorch.
 """
 
 import inspect
-from typing import Dict, Union
+from typing import Union
 
 import torch
 
@@ -27,12 +27,12 @@ def filter_parameters(
     ----------
     func : type
         Class object.
-    user_params : Dict
+    user_params : dict
         User provided parameters.
 
     Returns
     -------
-    Dict
+    dict
         Parameters matching `func`'s signature.
     """
     # Get the list of all default parameters
@@ -64,13 +64,13 @@ def get_optimizer(name: str) -> torch.optim.Optimizer:
     return getattr(torch.optim, name)
 
 
-def get_optimizers() -> Dict[str, str]:
+def get_optimizers() -> dict[str, str]:
     """
     Return the list of all optimizers available in torch.optim.
 
     Returns
     -------
-    Dict
+    dict
         Optimizers available in torch.optim.
     """
     optims = {}
@@ -106,13 +106,13 @@ def get_scheduler(
     return getattr(torch.optim.lr_scheduler, name)
 
 
-def get_schedulers() -> Dict[str, str]:
+def get_schedulers() -> dict[str, str]:
     """
     Return the list of all schedulers available in torch.optim.lr_scheduler.
 
     Returns
     -------
-    Dict
+    dict
         Schedulers available in torch.optim.lr_scheduler.
     """
     schedulers = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable, Tuple
+from typing import Callable
 
 import numpy as np
 import pytest
@@ -317,12 +317,12 @@ def array_3D() -> np.ndarray:
 
 
 @pytest.fixture
-def patch_size() -> Tuple[int, int]:
+def patch_size() -> tuple[int, int]:
     return (64, 64)
 
 
 @pytest.fixture
-def overlaps() -> Tuple[int, int]:
+def overlaps() -> tuple[int, int]:
     return (32, 32)
 
 

--- a/tests/test_careamist.py
+++ b/tests/test_careamist.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from threading import Thread
-from typing import Tuple
 
 import numpy as np
 import pytest
@@ -16,7 +15,7 @@ from careamics.lightning.callbacks import HyperParametersCallback, ProgressBarCa
 from careamics.lightning.predict_data_module import create_predict_datamodule
 
 
-def random_array(shape: Tuple[int, ...], seed: int = 42):
+def random_array(shape: tuple[int, ...], seed: int = 42):
     """Return a random array with values between 0 and 255."""
     rng = np.random.default_rng(seed)
     return (rng.integers(0, 255, shape)).astype(np.float32)


### PR DESCRIPTION
### Description

`ruff` was enforcing compatibility with `py38`, which we don't support anymore. Updating the `pre-commit` env to `py39` caused all the `from typing import Dict, List, Tuple` to cause errors.

This PR removes all such imports and replace them with the annotation `dict`, `tuple` or `list`. 

### Changes Made


- **Modified**: Almost all files.


### Related Issues

- Resolves https://github.com/CAREamics/careamics/issues/301

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)