### PR TITLE
chore: Better constraints for typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     'pydantic>=2.5,<2.11',
     'pytorch_lightning>=2.2,<=2.4',
     'pyyaml<=6.0.2,!=6.0.0',
-    'typer==0.15.1',
+    'typer>=0.12.3,<=0.15.1',
     'scikit-image<=0.25.0',
     'zarr<3.0.0',
     'pillow<=11.0.0',


### PR DESCRIPTION
### Description

The latest `dependabot` updated dependencies to `typer==0.15`. Better use a `min` and `max` versions, as we actually don't need a particular one.

This PR does just that.