### PR TITLE
Fix: Mismatch between NumPy version used in mypy pre-commit and package dependencies.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         exclude: "^src/careamics/lvae_training/.*|^src/careamics/models/lvae/.*|^src/careamics/config/likelihood_model.py|^src/careamics/losses/loss_factory.py|^src/careamics/losses/lvae/losses.py"
         args: ["--config-file", "mypy.ini"]
         additional_dependencies:
-          - numpy
+          - numpy<2.0.0
           - types-PyYAML
           - types-setuptools
 


### PR DESCRIPTION
### Description

- **What**: MyPy in the pre-commit was using a different version of NumPy, for type checking, than the version of NumPy that is used in CAREamics. This PR fixes this mismatch.
- **Why**: Pre-commit was failing, likely due to the new [2.2 NumPy release](https://numpy.org/doc/stable/release/2.2.0-notes.html) where they claim to have added "Many improved annotations".
- **How**: Made numpy version in `.pre-commit-config.yaml` match that in `pyproject.toml`.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)