### PR TITLE
CZI Dataset support for training

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     'typer>=0.12.3,<=0.15.1',
     'scikit-image<=0.25.0',
     'zarr<3.0.0',
+    'pylibczirw==4.1.0',
     'pillow<=11.1.0',
 ]
 

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -564,7 +564,7 @@ class CAREamist:
         tile_size: Optional[tuple[int, ...]] = None,
         tile_overlap: Optional[tuple[int, ...]] = (48, 48),
         axes: Optional[str] = None,
-        data_type: Optional[Literal["array", "tiff", "custom"]] = None,
+        data_type: Optional[Literal["array", "tiff", "czi", "custom"]] = None,
         tta_transforms: bool = False,
         dataloader_params: Optional[dict] = None,
         read_source_func: Optional[Callable] = None,
@@ -806,7 +806,7 @@ class CAREamist:
 
         # extract file names
         source_path: Union[Path, str, NDArray]
-        source_data_type: Literal["array", "tiff", "custom"]
+        source_data_type: Literal["array", "tiff", "czi", "custom"]
         if isinstance(source, PredictDataModule):
             source_path = source.pred_data
             source_data_type = source.data_type

--- a/src/careamics/config/data_model.py
+++ b/src/careamics/config/data_model.py
@@ -93,7 +93,7 @@ class DataConfig(BaseModel):
     )
 
     # Dataset configuration
-    data_type: Literal["array", "tiff", "custom"]
+    data_type: Literal["array", "tiff", "czi", "custom"]
     """Type of input data, numpy.ndarray (array) or paths (tiff and custom), as defined
     in SupportedData."""
 

--- a/src/careamics/config/support/supported_data.py
+++ b/src/careamics/config/support/supported_data.py
@@ -16,12 +16,15 @@ class SupportedData(str, BaseEnum):
         Array data.
     TIFF : str
         TIFF image data.
+    CZI : str
+        czi image data.
     CUSTOM : str
         Custom data.
     """
 
     ARRAY = "array"
     TIFF = "tiff"
+    CZI = "czi"
     CUSTOM = "custom"
     # ZARR = "zarr"
 
@@ -78,6 +81,8 @@ class SupportedData(str, BaseEnum):
             raise NotImplementedError(f"Data '{data_type}' is not loaded from a file.")
         elif data_type == cls.TIFF:
             return "*.tif*"
+        elif data_type == cls.CZI:
+            return "*.czi*"
         elif data_type == cls.CUSTOM:
             return "*.*"
         else:
@@ -102,6 +107,8 @@ class SupportedData(str, BaseEnum):
             raise NotImplementedError(f"Data '{data_type}' is not loaded from a file.")
         elif data_type == cls.TIFF:
             return ".tiff"
+        elif data_type == cls.CZI:
+            return ".czi"
         elif data_type == cls.CUSTOM:
             # TODO: improve this message
             raise NotImplementedError("Custom extensions have to be passed elsewhere.")

--- a/src/careamics/dataset/__init__.py
+++ b/src/careamics/dataset/__init__.py
@@ -1,6 +1,7 @@
 """Dataset module."""
 
 __all__ = [
+    "CZIDataset",
     "InMemoryDataset",
     "InMemoryPredDataset",
     "InMemoryTiledPredDataset",
@@ -9,6 +10,7 @@ __all__ = [
     "PathIterableDataset",
 ]
 
+from .czi_dataset import CZIDataset
 from .in_memory_dataset import InMemoryDataset
 from .in_memory_pred_dataset import InMemoryPredDataset
 from .in_memory_tiled_pred_dataset import InMemoryTiledPredDataset

--- a/src/careamics/dataset/czi_dataset.py
+++ b/src/careamics/dataset/czi_dataset.py
@@ -1,0 +1,310 @@
+"""Iterable dataset used to load data file by file."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Generator
+from pathlib import Path
+from typing import Callable, Optional
+
+import numpy as np
+from torch.utils.data import IterableDataset
+
+from careamics.config import DataConfig
+from careamics.config.transformations import NormalizeModel
+from careamics.dataset.czi_dataset_utils import (
+    extract_random_czi_patches,
+    extract_sequential_czi_patches,
+    iterate_file_names,
+)
+from careamics.file_io.read import read_czi_roi
+from careamics.transforms import Compose
+
+from ..utils.logging import get_logger
+from .dataset_utils.running_stats import WelfordStatistics
+from .patching.patching import Stats
+
+logger = get_logger(__name__)
+
+
+class CZIDataset(IterableDataset):
+    """
+    Dataset allowing extracting patches w/o loading whole data into memory.
+
+    Parameters
+    ----------
+    data_config : DataConfig
+        Data configuration.
+    src_files : list of pathlib.Path
+        List of data files.
+    target_files : list of pathlib.Path, optional
+        Optional list of target files, by default None.
+    read_source_func : Callable, optional
+        Read source function for custom types, by default read_czi_roi.
+
+    Attributes
+    ----------
+    data_path : list of pathlib.Path
+        Path to the data, must be a directory.
+    axes : str
+        Description of axes in format STCZYX.
+    """
+
+    def __init__(
+        self,
+        data_config: DataConfig,
+        src_files: list[Path],
+        target_files: Optional[list[Path]] = None,
+        read_source_func: Callable = read_czi_roi,
+    ) -> None:
+        """Constructors.
+
+        Parameters
+        ----------
+        data_config : DataConfig
+            Data configuration.
+        src_files : list[Path]
+            List of data files.
+        target_files : list[Path] or None, optional
+            Optional list of target files, by default None.
+        read_source_func : Callable, optional
+            Read source function for custom types, by default read_czi_roi.
+        """
+        self.data_config = data_config
+        self.data_files = src_files
+        self.target_files = target_files
+        self.read_source_func = read_source_func
+
+        # compute mean and std over the dataset
+        # only checking the image_mean because the DataConfig class ensures that
+        # if image_mean is provided, image_std is also provided
+        if not self.data_config.image_means:
+            self.image_stats, self.target_stats = self._calculate_mean_and_std()
+            logger.info(
+                f"Computed dataset mean: {self.image_stats.means},"
+                f"std: {self.image_stats.stds}"
+            )
+
+            # update the mean in the config
+            self.data_config.set_means_and_stds(
+                image_means=self.image_stats.means,
+                image_stds=self.image_stats.stds,
+                target_means=(
+                    list(self.target_stats.means)
+                    if self.target_stats.means is not None
+                    else None
+                ),
+                target_stds=(
+                    list(self.target_stats.stds)
+                    if self.target_stats.stds is not None
+                    else None
+                ),
+            )
+
+        else:
+            # if mean and std are provided in the config, use them
+            self.image_stats, self.target_stats = (
+                Stats(self.data_config.image_means, self.data_config.image_stds),
+                Stats(self.data_config.target_means, self.data_config.target_stds),
+            )
+
+        # create transform composed of normalization and other transforms
+        self.patch_transform = Compose(
+            transform_list=[
+                NormalizeModel(
+                    image_means=self.image_stats.means,
+                    image_stds=self.image_stats.stds,
+                    target_means=self.target_stats.means,
+                    target_stds=self.target_stats.stds,
+                )
+            ]
+            + data_config.transforms
+        )
+
+    def _calculate_mean_and_std(self) -> tuple[Stats, Stats]:
+        """
+        Calculate mean and std of the dataset.
+
+        Returns
+        -------
+        tuple of Stats and optional Stats
+            Data classes containing the image and target statistics.
+        """
+        num_samples = 0
+        num_targets = 0
+        image_stats = WelfordStatistics()
+        if self.target_files is not None:
+            target_stats = WelfordStatistics()
+
+        for sample_file, target_file in iterate_file_names(
+            self.data_files, self.target_files
+        ):
+            sample_patches = extract_sequential_czi_patches(
+                self.read_source_func, sample_file
+            )
+
+            for patch in sample_patches:
+                # update the image statistics
+                image_stats.update(np.expand_dims(patch, axis=0), num_samples)
+                num_samples += 1
+
+            # update the target statistics if target is available
+            if target_file is not None:
+                target_patches = extract_sequential_czi_patches(
+                    self.read_source_func, target_file
+                )
+                for patch in target_patches:
+                    target_stats.update(np.expand_dims(patch[0], axis=1), num_targets)
+                    num_targets += 1
+
+        if num_samples == 0:
+            raise ValueError("No samples found in the dataset.")
+
+        # Average the means and stds per sample
+        image_means, image_stds = image_stats.finalize()
+
+        if target_file is not None:
+            target_means, target_stds = target_stats.finalize()
+
+            return (
+                Stats(image_means, image_stds),
+                Stats(np.array(target_means), np.array(target_stds)),
+            )
+        else:
+            return Stats(image_means, image_stds), Stats(None, None)
+
+    def __iter__(
+        self,
+    ) -> Generator[tuple[np.ndarray, ...], None, None]:
+        """
+        Iterate over data source and yield single patch.
+
+        Yields
+        ------
+        np.ndarray
+            Single patch.
+        """
+        assert (
+            self.image_stats.means is not None and self.image_stats.stds is not None
+        ), "Mean and std must be provided"
+
+        # iterate over files
+        for sample_input_file, sample_target_file in iterate_file_names(
+            self.data_files, self.target_files
+        ):
+
+            patches = extract_random_czi_patches(
+                sample_file_path=sample_input_file,
+                patch_size=self.data_config.patch_size,
+                target_file_path=sample_target_file,
+                read_source_func=self.read_source_func,
+            )
+
+            # iterate over patches
+            # patches are tuples of (patch, target) if target is available
+            # or (patch, None) only if no target is available
+            # patch is of dimensions (C)ZYX
+            for patch_data in patches:
+                yield self.patch_transform(
+                    patch=patch_data[0],
+                    target=patch_data[1],
+                )
+
+    def get_data_statistics(self) -> tuple[list[float], list[float]]:
+        """Return training data statistics.
+
+        Returns
+        -------
+        tuple of list of floats
+            Means and standard deviations across channels of the training data.
+        """
+        return self.image_stats.get_statistics()
+
+    def get_number_of_files(self) -> int:
+        """
+        Return the number of files in the dataset.
+
+        Returns
+        -------
+        int
+            Number of files in the dataset.
+        """
+        return len(self.data_files)
+
+    def split_dataset(
+        self,
+        percentage: float = 0.1,
+        minimum_number: int = 5,
+    ) -> CZIDataset:
+        """Split up dataset in two.
+
+        Splits the datest sing a percentage of the data (files) to extract, or the
+        minimum number of the percentage is less than the minimum number.
+
+        Parameters
+        ----------
+        percentage : float, optional
+            Percentage of files to split up, by default 0.1.
+        minimum_number : int, optional
+            Minimum number of files to split up, by default 5.
+
+        Returns
+        -------
+        IterableDataset
+            Dataset containing the split data.
+
+        Raises
+        ------
+        ValueError
+            If the percentage is smaller than 0 or larger than 1.
+        ValueError
+            If the minimum number is smaller than 1 or larger than the number of files.
+        """
+        if percentage < 0 or percentage > 1:
+            raise ValueError(f"Percentage must be between 0 and 1, got {percentage}.")
+
+        if minimum_number < 1 or minimum_number > self.get_number_of_files():
+            raise ValueError(
+                f"Minimum number of files must be between 1 and "
+                f"{self.get_number_of_files()} (number of files), got "
+                f"{minimum_number}."
+            )
+
+        # compute number of files
+        total_files = self.get_number_of_files()
+        n_files = max(round(percentage * total_files), minimum_number)
+
+        # get random indices
+        indices = np.random.choice(total_files, n_files, replace=False)
+
+        # extract files
+        val_files = [self.data_files[i] for i in indices]
+
+        # remove patches from self.patch
+        data_files = []
+        for i, file in enumerate(self.data_files):
+            if i not in indices:
+                data_files.append(file)
+        self.data_files = data_files
+
+        # same for targets
+        if self.target_files is not None:
+            val_target_files = [self.target_files[i] for i in indices]
+
+            data_target_files = []
+            for i, file in enumerate(self.target_files):
+                if i not in indices:
+                    data_target_files.append(file)
+            self.target_files = data_target_files
+
+        # clone the dataset
+        dataset = copy.deepcopy(self)
+
+        # reassign patches
+        dataset.data_files = val_files
+
+        # reassign targets
+        if self.target_files is not None:
+            dataset.target_files = val_target_files
+
+        return dataset

--- a/src/careamics/dataset/czi_dataset_utils.py
+++ b/src/careamics/dataset/czi_dataset_utils.py
@@ -1,0 +1,437 @@
+"""CZI dataset  utilities."""
+
+from collections.abc import Generator, Iterator
+from pathlib import Path
+from typing import Callable, NamedTuple, Optional, Union
+
+import numpy as np
+from pylibCZIrw import czi as pyczi
+from torch.utils.data import get_worker_info
+
+from careamics.file_io.read import read_czi_roi
+
+
+class Rectangle(NamedTuple):
+    """Rectangle object."""
+
+    x: int
+    y: int
+    w: int
+    h: int
+
+
+def iterate_file_names(
+    data_files: list[Path],
+    target_files: Optional[list[Path]] = None,
+) -> Generator[tuple[Path, Optional[Path]], None, None]:
+    """Iterate over the filenames.
+
+    This function yields the filenames from the provided list of data files.
+
+    Parameters
+    ----------
+    data_files : list of pathlib.Path
+        List of data files.
+    target_files : Optional[list[Path]], optional
+        List of target data files, by default None.
+
+    Yields
+    ------
+    Generator[tuple[str, Optional[str]], None, None]
+        The filename as a string
+
+    """
+    # iterate over the files
+    for i, filename in enumerate(data_files):
+        if target_files is not None:
+            if filename.name != target_files[i].name:
+                raise ValueError(
+                    f"File {filename} does not match target file " f"{target_files[i]}."
+                )
+
+            yield filename, target_files[i]
+        else:
+            yield filename, None
+
+
+def get_czi_shape(
+    czi_reader: pyczi.CziReader,
+) -> list[int]:
+    """Return the dimesion of the CZI object (Z,X,Y).
+
+       We explicitly check CZTXY dimensions
+       Rest of the dimensions are considered as samples (planes) to extract the data
+       The depth of the the data is decided by Z or T which ever is highest
+
+    Parameters
+    ----------
+    czi_reader : pyczi.CziReader
+       The czi reader object.
+
+    Returns
+    -------
+    List[int]
+        The (Z),X,Y dimension of the czi file.
+    """
+    total_dim = czi_reader.total_bounding_box
+    if "Z" in total_dim and "T" in total_dim:
+        Z_shape = total_dim["Z"][1] - total_dim["Z"][0]
+        T_shape = total_dim["T"][1] - total_dim["T"][0]
+
+        return [
+            Z_shape if Z_shape > T_shape else T_shape,
+            total_dim["X"][1] - total_dim["X"][0],
+            total_dim["Y"][1] - total_dim["Y"][0],
+        ]
+
+    elif "Z" in total_dim and "T" not in total_dim:
+        Z_shape = total_dim["Z"][1] - total_dim["Z"][0]
+        return [
+            Z_shape,
+            total_dim["X"][1] - total_dim["X"][0],
+            total_dim["Y"][1] - total_dim["Y"][0],
+        ]
+
+    elif "Z" not in total_dim and "T" in total_dim:
+        T_shape = total_dim["T"][1] - total_dim["T"][0]
+        return [
+            T_shape,
+            total_dim["X"][1] - total_dim["X"][0],
+            total_dim["Y"][1] - total_dim["Y"][0],
+        ]
+    return [
+        total_dim["X"][1] - total_dim["X"][0],
+        total_dim["Y"][1] - total_dim["Y"][0],
+    ]
+
+
+def check_for_scenes(czi_reader: pyczi.CziReader) -> dict[int, Rectangle]:
+    """Check for existence of scenes in a czi file.
+
+    Parameters
+    ----------
+    czi_reader : pyczi.CziReader
+        CZI reader object of the file.
+
+    Returns
+    -------
+    dict[int,Rectangle]
+        The scene information in the czi file.
+    """
+    total_dim = czi_reader.total_bounding_box
+    scene_info = czi_reader.scenes_bounding_rectangle
+    if len(scene_info) >= 1:
+        return scene_info
+    else:
+        return {
+            0: Rectangle(
+                x=total_dim["X"][0],
+                y=total_dim["Y"][0],
+                w=total_dim["X"][1] - total_dim["X"][0],
+                h=total_dim["Y"][1] - total_dim["Y"][0],
+            )
+        }
+
+
+def get_number_patches(
+    czi_reader: pyczi.CziReader,
+    patch_size: Union[list[int], tuple[int, ...]],
+    scene_info: dict[int, Rectangle],
+    num_workers=int,
+) -> int:
+    """Calculate the number of patches that can be extracted from a czi file.
+
+    Parameters
+    ----------
+    czi_reader : pyczi.CziReader
+       The czi reader object of the file.
+    patch_size : Union[list[int], tuple[int, ...]]
+        Patch_size ((Z),X,Y).
+    scene_info : dict[int, Rectangle]
+        The scene information in the czi file.
+    num_workers : int
+        Number of workers to split the patches.
+
+    Returns
+    -------
+    int
+        Number of patches that can be extracted.
+    """
+    n_patches = 0
+    for _, scene in scene_info.items():
+        data_shape = list(get_czi_shape(czi_reader))
+        data_shape[-2:] = scene.w, scene.h
+        if len(patch_size) == 2 and len(data_shape) == 3:
+            # treat the "Z/Taxis" as 2D samples
+            n_patches += (np.prod(data_shape[1:]) / np.prod(patch_size)).astype(int)
+        else:
+            n_patches += (np.prod(data_shape) / np.prod(patch_size)).astype(int)
+    return np.ceil(n_patches / num_workers).astype(int)
+
+
+def plane_iterator(
+    czi_reader: pyczi.CziReader, patch_size: Union[list[int], tuple[int, ...]]
+) -> tuple[Iterator[tuple[int, ...]], list[str], Union[list[int], tuple[int, ...]]]:
+    """Update patch_size (C,Z,X,Y) and get iterator over the planes of the CZI file.
+
+    Parameters
+    ----------
+    czi_reader : pyczi.CziReader
+        The czi reader object of the file.
+    patch_size : Union[List[int], tuple[int, ...]]
+        Patch_size (X,Y) or (Z,X,Y).
+
+    Returns
+    -------
+    tuple[Iterator[tuple[int, ...]], List[str], Union[List[int], tuple[int, ...]]]
+        Iterator over the czi dimensions except C,(Z/T) depending of the patch_size.
+        The list of dimensions of the czi file.
+        The updated patch_size (C,Z,X,Y).
+    """
+    total_dim = czi_reader.total_bounding_box
+    # Remove C dimension from the plane_iterator
+    if "C" in total_dim:
+        patch_size = (total_dim["C"][1] - total_dim["C"][0], *patch_size)
+        total_dim.pop("C")
+    else:
+        # update the patch_size to C(Z)XY
+        patch_size = (1, *patch_size)
+
+    # Remove Z/T dimension from the plane_iterator if 3D model
+    if len(patch_size) == 4:
+        if "Z" in total_dim and "T" in total_dim:
+            Z_shape = total_dim["Z"][1] - total_dim["Z"][0]
+            T_shape = total_dim["T"][1] - total_dim["T"][0]
+            total_dim.pop("Z") if Z_shape > T_shape else total_dim.pop("T")
+        elif "Z" in total_dim and "T" not in total_dim:
+            total_dim.pop("Z")
+        else:
+            total_dim.pop("T")
+    else:
+        # update the patchsize to CZXY (Z=1 for 2D)
+        patch_size = (patch_size[0], 1, *patch_size[1:])
+
+    arrays = [
+        np.arange(total_dim[key][1] - total_dim[key][0]) for key in total_dim.keys()
+    ]
+    # updated key_list after removing C and/or Z dimensions
+    key_list = list(total_dim.keys())
+    shape = tuple(array.shape[0] for array in arrays)
+    plane_iter = iter(np.ndindex(shape[:-2]))
+    return plane_iter, key_list, patch_size
+
+
+def extract_random_czi_patches(
+    sample_file_path: Path,
+    patch_size: Union[list[int], tuple[int, ...]],
+    target_file_path: Optional[Path] = None,
+    read_source_func: Callable = read_czi_roi,
+) -> Generator[tuple[np.ndarray, Optional[np.ndarray]], None, None]:
+    """Generate random patches from CZI files.
+
+    The method calculates how many patches the image can be divided into and then
+    extracts an equal number of random patches.
+
+    It returns a generator that yields the following:
+
+    - patch: np.ndarray, dimension C(Z)YX.
+    - target_patch: np.ndarray, dimension C(Z)YX, if the target is present, None
+        otherwise.
+
+    Parameters
+    ----------
+    sample_file_path : Path
+        The czi filepath.
+    patch_size : tuple[int]
+        Patch sizes in each dimension.
+    target_file_path : Optional[Path], optional
+        Target filepath, by default None.
+    read_source_func : Callable
+        CZI reader function.
+
+    Yields
+    ------
+    Generator[np.ndarray, None, None]
+        Generator of patches.
+    """
+    worker_info = get_worker_info()
+    num_workers = worker_info.num_workers if worker_info is not None else 1
+    rng = np.random.default_rng(seed=None)
+    with pyczi.open_czi(str(sample_file_path)) as sample_reader:
+
+        scene_info = check_for_scenes(sample_reader)
+        data_shape = get_czi_shape(sample_reader)
+
+        # if Z not in the data and patch_size is 3D
+        if len(patch_size) == 3 and len(data_shape) < 3:
+            raise ValueError(
+                "Dimension in the data do not match for a 3D model."
+                " Data needs to have Z/T dimensions for 3D models."
+            )
+        elif (
+            len(patch_size) == 3
+            and len(data_shape) == 3
+            and patch_size[0] > data_shape[0]
+        ):
+            raise ValueError(
+                "Do not have enough data in the Z/T dimension to create 3D patches."
+                "Reduce the depth of the patch_size."
+            )
+        else:
+            n_patches = get_number_patches(
+                sample_reader, patch_size, scene_info, num_workers
+            )
+
+        data_shape = [1, *data_shape] if len(data_shape) == 2 else data_shape
+
+        if target_file_path is not None:
+            with pyczi.open_czi(str(target_file_path)) as target_reader:
+                plane_indices, key_list, updated_patch_size = plane_iterator(
+                    sample_reader, patch_size
+                )
+                list_plane_indices = list(plane_indices)
+                for _ in range(n_patches * len(list_plane_indices)):
+                    plane_key = rng.integers(0, len(list_plane_indices))
+                    scene_key = rng.integers(0, len(scene_info))
+                    scene_value = scene_info[scene_key]
+                    plane_indice = list_plane_indices[plane_key]
+                    # change the data chape according to the scene
+                    data_shape[-2:] = scene_value.w, scene_value.h
+                    # (Z,X,Y) coordinates
+                    coords: list[int] = [
+                        rng.integers(
+                            0,
+                            data_shape[i] - updated_patch_size[1:][i],
+                            endpoint=True,
+                        )
+                        for i in range(len(updated_patch_size[1:]))
+                    ]
+                    coords[1] = scene_value.x + coords[1]
+                    coords[2] = scene_value.y + coords[2]
+                    plane = {
+                        key: plane_indice[i] for i, key in enumerate(key_list[:-2])
+                    }
+                    patch = read_source_func(
+                        sample_file_path,
+                        sample_reader,
+                        updated_patch_size,
+                        coords,
+                        plane,
+                        scene_key,
+                    )
+                    target_patch = read_source_func(
+                        target_file_path,
+                        target_reader,
+                        updated_patch_size,
+                        coords,
+                        plane,
+                        scene_key,
+                    )
+                    yield patch, target_patch
+        else:
+            plane_indices, key_list, updated_patch_size = plane_iterator(
+                sample_reader, patch_size
+            )
+            list_plane_indices = list(plane_indices)
+            for _ in range(n_patches * len(list_plane_indices)):
+                plane_key = rng.integers(0, len(list_plane_indices))
+                scene_key = rng.integers(0, len(scene_info))
+                scene_value = scene_info[scene_key]
+                plane_indice = list_plane_indices[plane_key]
+                # change the data chape according to the scene
+                data_shape[-2:] = scene_value.w, scene_value.h
+                coords = [
+                    rng.integers(
+                        0, data_shape[i] - updated_patch_size[1:][i], endpoint=True
+                    )
+                    for i in range(len(updated_patch_size[1:]))
+                ]
+                coords[1] = scene_value.x + coords[1]
+                coords[2] = scene_value.y + coords[2]
+                plane = {key: plane_indice[i] for i, key in enumerate(key_list[:-2])}
+                patch = read_source_func(
+                    sample_file_path,
+                    sample_reader,
+                    updated_patch_size,
+                    coords,
+                    plane,
+                    scene_key,
+                )
+                yield patch, None
+
+
+def get_tiles(data_shape: list[int]) -> list[list[int]]:
+    """Non-overlapping patch locations along with patch shape from a given data_shape.
+
+    Parameters
+    ----------
+    data_shape : list[int]
+        Shape of the data (Z,X,Y).
+
+    Returns
+    -------
+    List[int]
+        A list of coordinates along with the size of the patch.
+    """
+    tile = []
+    for x in range(0, data_shape[1], 2048):
+        for y in range(0, data_shape[2], 2048):
+            tile.append(
+                [x, y, min(2048, data_shape[1] - x), min(2048, data_shape[2] - y)]
+            )
+    return tile
+
+
+def extract_sequential_czi_patches(
+    read_source_func: Callable,
+    czi_file_path: Path,
+) -> Generator[tuple[np.ndarray]]:
+    """Generate sequntial patches from CZI file covering the entre data.
+
+    Used to calculate data statistics without loading the entire data in memory
+
+    It returns a generator that yields the following:
+
+    - patch: np.ndarray, dimension C(Z)YX.
+
+    Parameters
+    ----------
+    read_source_func : Callable
+        CZI reader function.
+    czi_file_path : Path
+        CZI file path.
+
+    Yields
+    ------
+    Generator[np.ndarray, None, None]
+        Generator of patches.
+    """
+    with pyczi.open_czi(str(czi_file_path)) as czi_reader:
+        scene_info = check_for_scenes(czi_reader)
+        for scene_key, scene in scene_info.items():
+            data_shape = get_czi_shape(czi_reader)
+            data_shape[-2:] = scene.w, scene.h
+            # data shape= (Z)XY shape; for 2D make Z=1
+            data_shape = [1, *data_shape] if len(data_shape) == 2 else data_shape
+            tiles = get_tiles(data_shape)
+
+            for tile in tiles:
+                tile_size = [tile[2], tile[3]]
+                plane_indices, key_list, updated_patch_size = plane_iterator(
+                    czi_reader, tile_size
+                )
+                for plane_indice in plane_indices:
+                    # get crop coordinates
+                    crop_coords = [tile[0] + scene.x, tile[1] + scene.y]
+                    plane = {
+                        key: plane_indice[i] for i, key in enumerate(key_list[:-2])
+                    }
+                    patch = read_source_func(
+                        czi_file_path,
+                        czi_reader,
+                        updated_patch_size,
+                        (0, *crop_coords),
+                        plane,
+                        scene_key,
+                    )
+                    yield patch

--- a/src/careamics/file_io/read/__init__.py
+++ b/src/careamics/file_io/read/__init__.py
@@ -3,10 +3,12 @@
 __all__ = [
     "ReadFunc",
     "get_read_func",
+    "read_czi_roi",
     "read_tiff",
     "read_zarr",
 ]
 
+from .czi_read import read_czi_roi
 from .get_func import ReadFunc, get_read_func
 from .tiff import read_tiff
 from .zarr import read_zarr

--- a/src/careamics/file_io/read/czi_read.py
+++ b/src/careamics/file_io/read/czi_read.py
@@ -1,0 +1,112 @@
+"""Functions to read region of interest from CZI data."""
+
+import logging
+from pathlib import Path
+from typing import Optional, Union
+
+import numpy as np
+from pylibCZIrw import czi as pyczi
+
+from careamics.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def squeeze_possible(array: np.ndarray) -> np.ndarray:
+    """Dimension correction by squeezing.
+
+    Parameters
+    ----------
+    array : np.array
+        Input array of data.
+
+    Returns
+    -------
+    np.array
+        Output data with axis=1 squeezed.
+    """
+    if array.shape[1] == 1:
+        return array.squeeze(axis=1)
+    return array
+
+
+def read_czi_roi(
+    file_path: Path,  # Keep this to match protocol but don't use it
+    czi_reader: pyczi.CziReader,
+    patch_size: Union[list[int], tuple[int, ...]],
+    coords: Union[list[int], tuple[int, ...]],
+    plane: dict[str, int],
+    scene: Optional[int] = None,
+) -> np.ndarray:
+    """Read an ROI from a CZI.
+
+    Parameters
+    ----------
+    file_path : Path
+        CZI filepath (not used at the moment).
+    czi_reader : pyczi.CziReader
+        CZI reader object.
+    patch_size : Union[list[int], tuple[int, ...]]
+       Patch_size to extract from the data (it has to be 4 dimensional with CZXY).
+    coords : Union[list[int], tuple[int, ...]]
+        Coordinates of the roi in Z,X and Y dimensions.
+    plane : dict[str, int]
+        The plane where the data is extracted from.
+    scene : int
+        The scene point to extract the data from czi, default is None.
+
+    Returns
+    -------
+    np.array
+       The ROI region of data read from the CZI file of size (C(Z)XY).
+
+    Raises
+    ------
+    ValueError
+        When patchsize does not match 4
+    ValueError
+        when coords length does not match 3
+    ValueError
+        plane or coords is None
+    e
+        exception when the czi cannot be read
+    """
+    # Check if patch_size has 4 dimensions
+    if len(patch_size) != 4:
+        raise ValueError("patch_size must have 4 dimensions")
+
+    # Check if coords has length 3
+    if coords is not None and len(coords) != 3:
+        raise ValueError("coords must have length 3")
+
+    # Check if plane and roi are not None
+    if plane is None or coords is None:
+        raise ValueError("plane and coords cannot be None")
+
+    try:
+        roi = (coords[1], coords[2], *patch_size[2:])
+        # flip the XY to YX as the czi reader always reads to YX
+        patch_size = list(patch_size)
+        patch_size = patch_size[:-2] + [patch_size[-1], patch_size[-2]]
+        image = np.zeros(patch_size)
+        extract_plane = plane.copy()
+        for depth in range(patch_size[1]):
+            for channel in range(patch_size[0]):
+                extract_plane.update(
+                    {
+                        "Z": (
+                            coords[0] + depth if "Z" not in plane.keys() else plane["Z"]
+                        ),
+                        "C": channel,
+                        "T": (
+                            coords[0] + depth if "T" not in plane.keys() else plane["T"]
+                        ),
+                    }
+                )
+                image_roi = czi_reader.read(roi=roi, plane=extract_plane, scene=scene)
+                image[channel, depth] = image_roi[..., 0]
+        return squeeze_possible(image)
+
+    except (ValueError, OSError) as e:
+        logging.exception(f"Exception in file reader {czi_reader}: {e}, skipping it.")
+        raise e

--- a/src/careamics/file_io/read/get_func.py
+++ b/src/careamics/file_io/read/get_func.py
@@ -7,6 +7,7 @@ from numpy.typing import NDArray
 
 from careamics.config.support import SupportedData
 
+from .czi_read import read_czi_roi
 from .tiff import read_tiff
 
 
@@ -32,6 +33,7 @@ class ReadFunc(Protocol):
 
 READ_FUNCS: dict[SupportedData, ReadFunc] = {
     SupportedData.TIFF: read_tiff,
+    SupportedData.CZI: read_czi_roi,
 }
 
 

--- a/src/careamics/lightning/predict_data_module.py
+++ b/src/careamics/lightning/predict_data_module.py
@@ -226,7 +226,7 @@ class PredictDataModule(L.LightningDataModule):
 
 def create_predict_datamodule(
     pred_data: Union[str, Path, NDArray],
-    data_type: Union[Literal["array", "tiff", "custom"], SupportedData],
+    data_type: Union[Literal["array", "tiff", "czi", "custom"], SupportedData],
     axes: str,
     image_means: list[float],
     image_stds: list[float],
@@ -265,7 +265,7 @@ def create_predict_datamodule(
     ----------
     pred_data : str or pathlib.Path or numpy.ndarray
         Prediction data.
-    data_type : {"array", "tiff", "custom"}
+    data_type : {"array", "tiff", "czi", "custom"}
         Data type, see `SupportedData` for available options.
     axes : str
         Axes of the data, chosen among SCZYX.

--- a/tests/config/support/test_supported_data.py
+++ b/tests/config/support/test_supported_data.py
@@ -40,13 +40,24 @@ def test_extension_pattern_tiff_rglob(tmp_path: Path):
 
 def test_extension_pattern_custom_fnmatch(tmp_path: Path):
     """Test that the custom extension is compatible with fnmatch."""
-    path = tmp_path / "test.czi"
+    path = tmp_path / "test.txt"
 
     # test as str
     assert fnmatch(str(path), SupportedData.get_extension_pattern(SupportedData.CUSTOM))
 
     # test as Path
     assert fnmatch(path, SupportedData.get_extension_pattern(SupportedData.CUSTOM))
+
+
+def test_extension_pattern_czi_fnmatch(tmp_path: Path):
+    """Test that the CZI extension is compatible with fnmatch."""
+    path = tmp_path / "test.czi"
+
+    # test as str
+    assert fnmatch(str(path), SupportedData.get_extension_pattern(SupportedData.CZI))
+
+    # test as Path
+    assert fnmatch(path, SupportedData.get_extension_pattern(SupportedData.CZI))
 
 
 def test_extension_pattern_custom_rglob(tmp_path: Path):
@@ -89,6 +100,11 @@ def test_extension_array_error():
 def test_extension_tiff():
     """Test that the tiff extension is .tiff."""
     assert SupportedData.get_extension(SupportedData.TIFF) == ".tiff"
+
+
+def test_extension_czi():
+    """Test that the CZI extension is .czi."""
+    assert SupportedData.get_extension(SupportedData.CZI) == ".czi"
 
 
 def test_extension_custom_error():

--- a/tests/dataset/test_czi_dataset.py
+++ b/tests/dataset/test_czi_dataset.py
@@ -1,0 +1,91 @@
+import numpy as np
+import pytest
+from pylibCZIrw import czi as pyczi
+
+from careamics.config import DataConfig
+from careamics.dataset.czi_dataset import CZIDataset
+
+
+@pytest.fixture
+def dataset_czi(tmp_path):
+    # Create a mock DataConfig
+    data_config = DataConfig(
+        data_type="czi",
+        patch_size=[32, 32],
+        axes="SYX",
+    )
+
+    n_files = 10
+    files = []
+    data_array = np.random.rand(10, 3, 64, 64).astype(np.float32)
+    for i in range(n_files):
+        file = tmp_path / f"sample{i}.czi"
+        planes = [{"C": c, "T": 0, "Z": 0} for c in range(3)]
+
+        with pyczi.create_czi(
+            file, exist_ok=True, compression_options="uncompressed:"
+        ) as czidoc_w:
+            for plane in planes:
+
+                czidoc_w.write(
+                    data=data_array[i, plane["C"]],
+                    plane=plane,
+                )
+
+        files.append(file)
+    # Create the dataset instance
+    return (
+        CZIDataset(data_config=data_config, src_files=files, target_files=files),
+        data_array,
+    )
+
+
+def test_calculate_mean_and_std(dataset_czi):
+
+    image_stats, _ = dataset_czi[0]._calculate_mean_and_std()
+
+    # Check if the means and stds are calculated
+    assert image_stats.means is not None
+    assert image_stats.stds is not None
+    assert image_stats.means.shape == (3,)
+    assert np.allclose(image_stats.means, dataset_czi[1].mean(axis=(0, 2, 3)))
+    assert np.allclose(image_stats.stds, dataset_czi[1].std(axis=(0, 2, 3)))
+
+
+def test_iter(dataset_czi):
+
+    for patchs in dataset_czi[0]:
+        assert isinstance(patchs[0], np.ndarray)
+        assert isinstance(patchs[1], np.ndarray)
+        assert patchs[0].shape == (3, 32, 32)
+        assert patchs[1].shape == (3, 32, 32)
+
+
+def test_get_number_of_files(dataset_czi):
+    # Test the number of files
+    assert dataset_czi[0].get_number_of_files() == len(dataset_czi[0].data_files)
+
+
+def test_split_dataset(dataset_czi):
+    # Test splitting the dataset
+    split_dataset = dataset_czi[0].split_dataset(percentage=0.5, minimum_number=1)
+
+    # Check that the number of files in the split dataset is correct
+    assert split_dataset.get_number_of_files() == 5
+    assert dataset_czi[0].get_number_of_files() == 5
+
+
+def test_split_dataset_invalid_percentage(dataset_czi):
+    # Test invalid percentage
+    with pytest.raises(ValueError, match="Percentage must be between 0 and 1"):
+        dataset_czi[0].split_dataset(percentage=1.5)
+
+
+def test_split_dataset_invalid_minimum_number(dataset_czi):
+    # Test invalid minimum number
+    with pytest.raises(ValueError, match="Minimum number of files must be between 1"):
+        dataset_czi[0].split_dataset(minimum_number=20)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/dataset/test_czi_dataset_utils.py
+++ b/tests/dataset/test_czi_dataset_utils.py
@@ -1,0 +1,182 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from pylibCZIrw import czi as pyczi
+
+from careamics.dataset.czi_dataset_utils import (
+    extract_random_czi_patches,
+    extract_sequential_czi_patches,
+    get_czi_shape,
+    iterate_file_names,
+    plane_iterator,
+)
+from careamics.file_io.read import read_czi_roi
+
+
+# Mocking the CziReader for unit tests
+@pytest.fixture
+def mock_czi_reader():
+    mock_reader = MagicMock()
+    mock_reader.total_bounding_box = {
+        "Z": [0, 5],
+        "T": [0, 10],
+        "X": [0, 100],
+        "Y": [0, 100],
+    }
+    return mock_reader
+
+
+def test_iterate_file_names():
+    data_files = [Path(f"file_{i}.czi") for i in range(4)]
+    target_files = [Path(f"file_{i}.czi") for i in range(4)]
+
+    # Test with matching files
+    results = list(iterate_file_names(data_files, target_files))
+    assert len(results) == len(data_files)
+    for data, target in results:
+        assert data.name == target.name
+
+    # Test with non-matching files
+    target_files[1] = Path("mismatched_file.czi")
+    with pytest.raises(ValueError):
+        list(iterate_file_names(data_files, target_files))
+
+
+def test_get_czi_shape(mock_czi_reader):
+    shape = get_czi_shape(mock_czi_reader)
+    assert shape == [10, 100, 100]  # Based on the mocked bounding box and T>Z, TXY
+    mock_czi_reader.total_bounding_box.pop("T", None)
+    shape = get_czi_shape(mock_czi_reader)
+    assert shape == [5, 100, 100]  # ZXY as T is removed
+    # Test when Z and T are not present in total_bounding_box
+    mock_czi_reader.total_bounding_box.pop("Z", None)
+    shape = get_czi_shape(mock_czi_reader)
+    assert shape == [100, 100]  # XY as T and Z not there in the reader
+
+
+def test_plane_iterator(mock_czi_reader):
+    # Test with 2D patch
+    patch_size = (256, 256)
+    # With C dimension present
+    mock_czi_reader.total_bounding_box["C"] = (0, 3)
+    _, key_list, updated_patch_size = plane_iterator(mock_czi_reader, patch_size)
+    assert len(key_list) == 4  # Expecting Z,T, X and Y dimensions
+    assert updated_patch_size == (3, 1, 256, 256)  # patch size CZXY
+    assert "C" not in key_list  # C will be poped out if its present in the reader
+
+    # Without C dimension
+    _, key_list, updated_patch_size = plane_iterator(mock_czi_reader, patch_size)
+    assert len(key_list) == 4  # Expecting Z,T, X and Y dimensions
+    assert updated_patch_size == (1, 1, 256, 256)
+
+    # Test with 3D patch_size
+    patch_size = (5, 256, 256)
+    # With C dimension present
+    mock_czi_reader.total_bounding_box["C"] = (0, 3)
+    _, key_list, updated_patch_size = plane_iterator(mock_czi_reader, patch_size)
+    assert len(key_list) == 3  # Expecting  Z/T and XY dimensions
+    assert updated_patch_size == (3, 5, 256, 256)  # patch size CZXY
+    assert "C" not in key_list
+    assert "T" not in key_list  # as T is greater than Z in the mocked example
+
+
+def test_extract_sequential_czi_patches(tmp_path):
+    # create a sample czi file (CZTXY, C=3,Z=10,T=20)
+    file = tmp_path / "sample.czi"
+    planes = [
+        {"C": c, "T": t, "Z": z} for c in range(3) for z in range(10) for t in range(20)
+    ]
+    with pyczi.create_czi(
+        file, exist_ok=True, compression_options="uncompressed:"
+    ) as czidoc_w:
+        for plane in planes:
+            czidoc_w.write(
+                data=np.random.rand(10, 10).astype(np.float32),
+                plane=plane,
+            )
+
+    patches = list(
+        extract_sequential_czi_patches(
+            read_source_func=read_czi_roi, czi_file_path=Path(file)
+        )
+    )
+
+    assert len(patches) > 0
+
+    for patch in patches:
+        assert patch.shape[0] == 3
+        assert isinstance(patch, np.ndarray)
+
+
+def test_extract_random_czi_patches(tmp_path):
+    # create a sample czi file (CXY, C=3)
+    file = tmp_path / "sample.czi"
+    planes = [
+        {
+            "C": c,
+            "T": 0,
+        }
+        for c in range(3)
+    ]
+    with pyczi.create_czi(
+        file, exist_ok=True, compression_options="uncompressed:"
+    ) as czidoc_w:
+        for plane in planes:
+            czidoc_w.write(
+                data=np.random.rand(10, 10).astype(np.float32),
+                plane=plane,
+            )
+
+    # Extract 2d patch (each patch should be (C,*patch_size))
+    patch_size = (10, 10)
+    patches = list(
+        extract_random_czi_patches(file, patch_size, read_source_func=read_czi_roi)
+    )
+    assert len(patches) > 0
+    for patch in patches:
+        assert (
+            patch[0].shape[0] == 3
+        )  # 2D patch and data with C dimension return CXY patch
+        assert isinstance(patch[0], np.ndarray)
+        assert patch[1] is None  # since target is None
+
+    # Extract 3D patches from the sample data which does not have Z/T axis. Raises error
+    patch_size = (5, 10, 10)
+    with pytest.raises(ValueError):
+        patches = list(
+            extract_random_czi_patches(file, patch_size, read_source_func=read_czi_roi)
+        )
+
+    # create a sample with Z,T and C axis
+    planes = [
+        {"C": c, "T": t, "Z": z} for c in range(3) for t in range(20) for z in range(10)
+    ]
+    with pyczi.create_czi(
+        file, exist_ok=True, compression_options="uncompressed:"
+    ) as czidoc_w:
+        for plane in planes:
+            czidoc_w.write(data=np.random.rand(10, 10).astype(np.float32), plane=plane)
+
+    patch_size = (5, 10, 10)
+    patches = list(
+        extract_random_czi_patches(file, patch_size, read_source_func=read_czi_roi)
+    )
+    assert len(patches) > 0
+    for patch in patches:
+        assert (
+            patch[0].shape[0] == 3
+        )  # 3D patch and data with C dimension return CZXY patch
+        assert (
+            patch[0].shape[1] == 5
+        )  # 3D patch and data with C dimension return CZXY patch
+        assert isinstance(patch[0], np.ndarray)
+        assert patch[1] is None  # since target is None
+
+    # try to extract larger deth patch than the Z or T dimension
+    patch_size = (25, 10, 10)
+    with pytest.raises(ValueError):
+        patches = list(
+            extract_random_czi_patches(file, patch_size, read_source_func=read_czi_roi)
+        )

--- a/tests/file_io/read/test_czi_read.py
+++ b/tests/file_io/read/test_czi_read.py
@@ -1,0 +1,91 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from careamics.file_io.read.czi_read import read_czi_roi, squeeze_possible
+
+
+def test_squeeze_possible():
+    # Test with a 2D array with shape (1, 5)
+    array_1d = np.random.rand(1, 1, 5)
+    result = squeeze_possible(array_1d)
+    assert result.shape == (1, 5)  # Should squeeze the first dimension
+
+    # Test with a 2D array with shape (3, 5)
+    array_2d = np.random.rand(3, 5)
+    result = squeeze_possible(array_2d)
+    assert result.shape == (3, 5)  # Should not change the shape
+
+
+@pytest.mark.parametrize(
+    "patch_size",
+    [
+        (3, 2, 10, 10),
+        (2, 1, 10, 10),
+    ],
+)
+def test_read_czi_roi(patch_size):
+    # Mock the CziReader and its read method
+    mock_czi_reader = MagicMock()
+    mock_czi_reader.read.return_value = np.random.rand(1, 10, 10, 1)  # Mocked data
+
+    # Define patch size, coordinates, and plane
+    cords = [0, 0, 0]  # (Z, X, Y)
+    plane = {"C": 0}  # Assume a channel is specified
+
+    # Call the function
+    result = read_czi_roi("xy.czi", mock_czi_reader, patch_size, cords, plane)
+
+    # Check the result shape
+    assert result.shape[0] == patch_size[0]  # Should match the expected shape C
+    # Should match the expected shape Z if Z!=1
+    # else it squeezes the Z dimension to match the expected shape Y
+    assert (
+        result.shape[1] == patch_size[1]
+        if patch_size[1] != 1
+        else result.shape[1] == patch_size[2]
+    )
+
+    # # Test if read was called the expected number of times
+    assert mock_czi_reader.read.call_count == (patch_size[0] * patch_size[1])
+
+
+def test_read_czi_roi_invalid_patch_size():
+    mock_czi_reader = MagicMock()
+    patch_size = [2, 2, 10]  # Invalid (only 3 dimensions)
+    cords = [0, 0, 0]
+    plane = {"C": 0}
+
+    with pytest.raises(ValueError, match="patch_size must have 4 dimensions"):
+        read_czi_roi("xy.czi", mock_czi_reader, patch_size, cords, plane)
+
+
+def test_read_czi_roi_invalid_cords():
+    mock_czi_reader = MagicMock()
+    patch_size = [2, 2, 10, 10]
+    cords = [0, 0]  # Invalid (only 2 dimensions)
+    plane = {"C": 0}
+
+    with pytest.raises(ValueError, match="coords must have length 3"):
+        read_czi_roi("xy.czi", mock_czi_reader, patch_size, cords, plane)
+
+
+def test_read_czi_roi_none_plane():
+    mock_czi_reader = MagicMock()
+    patch_size = [2, 2, 10, 10]
+    cords = [0, 0, 0]
+    plane = None  # Invalid (None)
+
+    with pytest.raises(ValueError, match="plane and coords cannot be None"):
+        read_czi_roi("xy.czi", mock_czi_reader, patch_size, cords, plane)
+
+
+def test_read_czi_roi_none_cords():
+    mock_czi_reader = MagicMock()
+    patch_size = [2, 2, 10, 10]
+    cords = None  # Invalid (None)
+    plane = {"C": 0}
+
+    with pytest.raises(ValueError, match="plane and coords cannot be None"):
+        read_czi_roi("xy.czi", mock_czi_reader, patch_size, cords, plane)

--- a/tests/file_io/read/test_get_read_func.py
+++ b/tests/file_io/read/test_get_read_func.py
@@ -2,11 +2,15 @@ import pytest
 
 from careamics.config.support import SupportedData
 from careamics.file_io import get_read_func
-from careamics.file_io.read import read_tiff
+from careamics.file_io.read import read_czi_roi, read_tiff
 
 
 def test_get_read_tiff():
     assert get_read_func(SupportedData.TIFF) is read_tiff
+
+
+def test_get_read_czi():
+    assert get_read_func(SupportedData.CZI) is read_czi_roi
 
 
 def test_get_read_any_error():


### PR DESCRIPTION


### Description


- **What**: CZIDataset class for training on .czi files. The PR also consists of

  - The utility files related with the reading random and sequential patches from the .czi files for training and for calculating dataset statistics.
  - The necessary changes to use .czi as a SupportedData
  -  czi_read to read interested regions from a czi file
  - Dependency  pylibCZIrw for reading .czi files
  -  Pytests for the CZIDataset class and the utilities 

- **Why**: .czi file is very common data used in Zeiss and the current data classes does not support reading of .czi files for training and testing purposes.
- **How**:Created a CZIDataset class to iterate through the .czi files and load them on the fly depending on the random region of interest. 

### Changes Made

- **Added**: 
   - `czi_read.py` : Function to read czi patches 
   - `czi_dataset.py`: CZIDataset class that yields random patches for training
   - `czi_dataset_utils.py`: The utility funtions supporting the CZIDataset class
   - pytests for the added classes and funtions
- **Modified**: 
  -  `train_data_module.py`: To add support to the newly introduced CZIDatset class
  - sligth changes in some files to add .czi as a supported data



### Additional Notes and Examples
```markdown
      train_data_module = create_train_datamodule(
              train_data=train_path,
              val_data=val_path,
              data_type="czi",
              patch_size=(64, 64) 
              transforms=transforms,
              axes="SYX" 
              batch_size=16,
              dataloader_params={"num_workers": 4},
              use_n2v2=use_n2v2,
          ) 
```
---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
