### PR TITLE
Chore: Add zarr to list of dependapot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
       time: "08:00"
     ignore:
       - dependency-name: "numpy"
+      - dependency-name: "zarr"


### PR DESCRIPTION
### Description

Please provide a brief description of the changes in this PR. Include any relevant context or background information.

- **What**: Add zarr to list of dependapot ignores.
- **Why**: Our dependency on Zarr should match that of ome-zarr-py, they pin their dependency <3.
- **How**: Updated dependabot config file.

### Related Issues

- Closes #348 

A new tracking issue has been opened: #374 

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)