### PR TITLE
update to expose ModelCheckpoint parameters in convenience configuration functions

### DIFF
--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -52,6 +52,8 @@ class CAREamist:
         by default None.
     callbacks : list of Callback, optional
         List of callbacks to use during training and prediction, by default None.
+        Note: ModelCheckpoint configuration should be set through the Configuration 
+        object (config.training_config.model_checkpoint) rather than through callbacks.
 
     Attributes
     ----------
@@ -219,6 +221,11 @@ class CAREamist:
     def _define_callbacks(self, callbacks: Optional[list[Callback]] = None) -> None:
         """Define the callbacks for the training loop.
 
+        ModelCheckpoint configuration should be provided through the Configuration 
+        object (config.training_config.model_checkpoint) rather than through callbacks.
+        If no ModelCheckpoint is specified in the configuration, default checkpoint 
+        settings will be used.
+
         Parameters
         ----------
         callbacks : list of Callback, optional
@@ -247,7 +254,9 @@ class CAREamist:
         self.callbacks.extend(
             [
                 HyperParametersCallback(self.cfg),
-                ModelCheckpoint(
+                self.cfg.training_config.model_checkpoint
+                if self.cfg.training_config.model_checkpoint is not None
+                else ModelCheckpoint(
                     dirpath=self.work_dir / Path("checkpoints"),
                     filename=self.cfg.experiment_name,
                     **self.cfg.training_config.checkpoint_callback.model_dump(),

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -221,11 +221,14 @@ class CAREamist:
     def _define_callbacks(self, callbacks: Optional[list[Callback]] = None) -> None:
         """Define the callbacks for the training loop.
 
+<<<<<<< HEAD
         ModelCheckpoint configuration should be provided through the Configuration
         object (config.training_config.model_checkpoint) rather than through callbacks.
         If no ModelCheckpoint is specified in the configuration, default checkpoint
         settings will be used.
 
+=======
+>>>>>>> 3802fcd (Fix careamist.py, configuration_factories.py, and training_model.py per review feedback (PR #381))
         Parameters
         ----------
         callbacks : list of Callback, optional
@@ -254,6 +257,7 @@ class CAREamist:
         self.callbacks.extend(
             [
                 HyperParametersCallback(self.cfg),
+<<<<<<< HEAD
                 (
                     self.cfg.training_config.model_checkpoint
                     if self.cfg.training_config.model_checkpoint is not None
@@ -262,6 +266,12 @@ class CAREamist:
                         filename=self.cfg.experiment_name,
                         **self.cfg.training_config.checkpoint_callback.model_dump(),
                     )
+=======
+                ModelCheckpoint(
+                    dirpath=self.work_dir / Path("checkpoints"),
+                    filename=self.cfg.experiment_name,
+                    **self.cfg.training_config.checkpoint_callback.model_dump(),
+>>>>>>> 3802fcd (Fix careamist.py, configuration_factories.py, and training_model.py per review feedback (PR #381))
                 ),
                 ProgressBarCallback(),
             ]

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -52,7 +52,7 @@ class CAREamist:
         by default None.
     callbacks : list of Callback, optional
         List of callbacks to use during training and prediction, by default None.
-        Note: ModelCheckpoint configuration should be set through the Configuration 
+        Note: ModelCheckpoint configuration should be set through the Configuration
         object (config.training_config.model_checkpoint) rather than through callbacks.
 
     Attributes
@@ -221,9 +221,9 @@ class CAREamist:
     def _define_callbacks(self, callbacks: Optional[list[Callback]] = None) -> None:
         """Define the callbacks for the training loop.
 
-        ModelCheckpoint configuration should be provided through the Configuration 
+        ModelCheckpoint configuration should be provided through the Configuration
         object (config.training_config.model_checkpoint) rather than through callbacks.
-        If no ModelCheckpoint is specified in the configuration, default checkpoint 
+        If no ModelCheckpoint is specified in the configuration, default checkpoint
         settings will be used.
 
         Parameters
@@ -254,12 +254,14 @@ class CAREamist:
         self.callbacks.extend(
             [
                 HyperParametersCallback(self.cfg),
-                self.cfg.training_config.model_checkpoint
-                if self.cfg.training_config.model_checkpoint is not None
-                else ModelCheckpoint(
-                    dirpath=self.work_dir / Path("checkpoints"),
-                    filename=self.cfg.experiment_name,
-                    **self.cfg.training_config.checkpoint_callback.model_dump(),
+                (
+                    self.cfg.training_config.model_checkpoint
+                    if self.cfg.training_config.model_checkpoint is not None
+                    else ModelCheckpoint(
+                        dirpath=self.work_dir / Path("checkpoints"),
+                        filename=self.cfg.experiment_name,
+                        **self.cfg.training_config.checkpoint_callback.model_dump(),
+                    )
                 ),
                 ProgressBarCallback(),
             ]

--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -3,6 +3,7 @@
 from typing import Annotated, Any, Literal, Optional, Union
 
 from pydantic import Discriminator, Tag, TypeAdapter
+from pytorch_lightning.callbacks import ModelCheckpoint
 
 from careamics.config.algorithms import CAREAlgorithm, N2NAlgorithm, N2VAlgorithm
 from careamics.config.architectures import UNetModel
@@ -225,6 +226,7 @@ def _create_configuration(
     use_n2v2: bool = False,
     model_params: Optional[dict] = None,
     dataloader_params: Optional[dict] = None,
+    model_checkpoint: Optional[ModelCheckpoint] = None,
 ) -> Configuration:
     """
     Create a configuration for training N2V, CARE or Noise2Noise.
@@ -302,6 +304,7 @@ def _create_configuration(
         num_epochs=num_epochs,
         batch_size=batch_size,
         logger=None if logger == "none" else logger,
+        model_checkpoint=model_checkpoint, 
     )
 
     # create configuration
@@ -332,6 +335,7 @@ def _create_supervised_configuration(
     logger: Literal["wandb", "tensorboard", "none"] = "none",
     model_params: Optional[dict] = None,
     dataloader_params: Optional[dict] = None,
+    model_checkpoint: Optional[ModelCheckpoint] = None,
 ) -> Configuration:
     """
     Create a configuration for training CARE or Noise2Noise.
@@ -417,6 +421,7 @@ def _create_supervised_configuration(
         logger=logger,
         model_params=model_params,
         dataloader_params=dataloader_params,
+        model_checkpoint=model_checkpoint,
     )
 
 
@@ -435,6 +440,7 @@ def create_care_configuration(
     logger: Literal["wandb", "tensorboard", "none"] = "none",
     model_params: Optional[dict] = None,
     dataloader_params: Optional[dict] = None,
+    model_checkpoint: Optional[ModelCheckpoint] = None,
 ) -> Configuration:
     """
     Create a configuration for training CARE.
@@ -489,6 +495,9 @@ def create_care_configuration(
         UNetModel parameters.
     dataloader_params : dict, optional
         Parameters for the dataloader, see PyTorch notes, by default None.
+    modelcheckpoint : ModelCheckpoint, optional
+        PyTorch Lightning ModelCheckpoint configuration. If not provided, 
+        default checkpoint settings will be used.
 
     Returns
     -------
@@ -578,6 +587,7 @@ def create_care_configuration(
         logger=logger,
         model_params=model_params,
         dataloader_params=dataloader_params,
+        model_checkpoint=model_checkpoint,
     )
 
 

--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -18,6 +18,8 @@ from careamics.config.support import (
     SupportedPixelManipulation,
     SupportedTransform,
 )
+from careamics.config.callback_model import CheckpointModel
+from typing import Annotated, Any, Literal, Optional, Union, Dict
 from careamics.config.training_model import TrainingConfig
 from careamics.config.transformations import (
     N2V_TRANSFORMS_UNION,
@@ -226,7 +228,7 @@ def _create_configuration(
     use_n2v2: bool = False,
     model_params: Optional[dict] = None,
     dataloader_params: Optional[dict] = None,
-    model_checkpoint: Optional[ModelCheckpoint] = None,
+    model_checkpoint: Optional[Union[Dict[str, Any], CheckpointModel]] = None,
 ) -> Configuration:
     """
     Create a configuration for training N2V, CARE or Noise2Noise.
@@ -266,7 +268,9 @@ def _create_configuration(
         UNetModel parameters.
     dataloader_params : dict
         Parameters for the dataloader, see PyTorch notes, by default None.
-
+    model_checkpoint : Union[dict[str, Any], CheckpointModel]
+        Parameters for checkpoints can be a dictionary of parameters or an initialized object,
+        by default None.
     Returns
     -------
     Configuration
@@ -304,7 +308,7 @@ def _create_configuration(
         num_epochs=num_epochs,
         batch_size=batch_size,
         logger=None if logger == "none" else logger,
-        model_checkpoint=model_checkpoint,
+        checkpoint_callback=model_checkpoint,
     )
 
     # create configuration
@@ -335,7 +339,7 @@ def _create_supervised_configuration(
     logger: Literal["wandb", "tensorboard", "none"] = "none",
     model_params: Optional[dict] = None,
     dataloader_params: Optional[dict] = None,
-    model_checkpoint: Optional[ModelCheckpoint] = None,
+    model_checkpoint: Optional[Union[Dict[str, Any], CheckpointModel]] = None,
 ) -> Configuration:
     """
     Create a configuration for training CARE or Noise2Noise.
@@ -374,7 +378,9 @@ def _create_supervised_configuration(
         UNetModel parameters, by default {}.
     dataloader_params : dict, optional
         Parameters for the dataloader, see PyTorch notes, by default None.
-
+    model_checkpoint : Union[dict[str, Any], CheckpointModel]
+        Parameters for checkpoints can be a dictionary of parameters or an initialized object,
+        by default None.
     Returns
     -------
     Configuration
@@ -440,7 +446,7 @@ def create_care_configuration(
     logger: Literal["wandb", "tensorboard", "none"] = "none",
     model_params: Optional[dict] = None,
     dataloader_params: Optional[dict] = None,
-    model_checkpoint: Optional[ModelCheckpoint] = None,
+    model_checkpoint: Optional[Union[Dict[str, Any], CheckpointModel]] = None,
 ) -> Configuration:
     """
     Create a configuration for training CARE.
@@ -495,9 +501,15 @@ def create_care_configuration(
         UNetModel parameters.
     dataloader_params : dict, optional
         Parameters for the dataloader, see PyTorch notes, by default None.
+<<<<<<< HEAD
     modelcheckpoint : ModelCheckpoint, optional
         PyTorch Lightning ModelCheckpoint configuration. If not provided,
         default checkpoint settings will be used.
+=======
+    model_checkpoint : Union[dict[str, Any], CheckpointModel]
+        Parameters for checkpoints can be a dictionary of parameters or an initialized object,
+        by default None.
+>>>>>>> 3802fcd (Fix careamist.py, configuration_factories.py, and training_model.py per review feedback (PR #381))
 
     Returns
     -------

--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -1,12 +1,12 @@
 """Convenience functions to create configurations for training and inference."""
 
-from typing import Annotated, Any, Literal, Optional, Union
+from typing import Annotated, Any, Dict, Literal, Optional, Union
 
 from pydantic import Discriminator, Tag, TypeAdapter
-from pytorch_lightning.callbacks import ModelCheckpoint
 
 from careamics.config.algorithms import CAREAlgorithm, N2NAlgorithm, N2VAlgorithm
 from careamics.config.architectures import UNetModel
+from careamics.config.callback_model import CheckpointModel
 from careamics.config.care_configuration import CAREConfiguration
 from careamics.config.configuration import Configuration
 from careamics.config.data import DataConfig, N2VDataConfig
@@ -18,8 +18,6 @@ from careamics.config.support import (
     SupportedPixelManipulation,
     SupportedTransform,
 )
-from careamics.config.callback_model import CheckpointModel
-from typing import Annotated, Any, Literal, Optional, Union, Dict
 from careamics.config.training_model import TrainingConfig
 from careamics.config.transformations import (
     N2V_TRANSFORMS_UNION,
@@ -271,6 +269,7 @@ def _create_configuration(
     model_checkpoint : Union[dict[str, Any], CheckpointModel]
         Parameters for checkpoints can be a dictionary of parameters or an initialized object,
         by default None.
+
     Returns
     -------
     Configuration
@@ -381,6 +380,7 @@ def _create_supervised_configuration(
     model_checkpoint : Union[dict[str, Any], CheckpointModel]
         Parameters for checkpoints can be a dictionary of parameters or an initialized object,
         by default None.
+
     Returns
     -------
     Configuration
@@ -501,15 +501,15 @@ def create_care_configuration(
         UNetModel parameters.
     dataloader_params : dict, optional
         Parameters for the dataloader, see PyTorch notes, by default None.
-<<<<<<< HEAD
+    <<<<<<< HEAD
     modelcheckpoint : ModelCheckpoint, optional
         PyTorch Lightning ModelCheckpoint configuration. If not provided,
         default checkpoint settings will be used.
-=======
+    =======
     model_checkpoint : Union[dict[str, Any], CheckpointModel]
         Parameters for checkpoints can be a dictionary of parameters or an initialized object,
         by default None.
->>>>>>> 3802fcd (Fix careamist.py, configuration_factories.py, and training_model.py per review feedback (PR #381))
+    >>>>>>> 3802fcd (Fix careamist.py, configuration_factories.py, and training_model.py per review feedback (PR #381))
 
     Returns
     -------

--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -304,7 +304,7 @@ def _create_configuration(
         num_epochs=num_epochs,
         batch_size=batch_size,
         logger=None if logger == "none" else logger,
-        model_checkpoint=model_checkpoint, 
+        model_checkpoint=model_checkpoint,
     )
 
     # create configuration
@@ -496,7 +496,7 @@ def create_care_configuration(
     dataloader_params : dict, optional
         Parameters for the dataloader, see PyTorch notes, by default None.
     modelcheckpoint : ModelCheckpoint, optional
-        PyTorch Lightning ModelCheckpoint configuration. If not provided, 
+        PyTorch Lightning ModelCheckpoint configuration. If not provided,
         default checkpoint settings will be used.
 
     Returns

--- a/src/careamics/config/training_model.py
+++ b/src/careamics/config/training_model.py
@@ -8,7 +8,7 @@ from typing import Literal, Optional, Union
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .callback_model import CheckpointModel, EarlyStoppingModel
-
+from pytorch_lightning.callbacks import ModelCheckpoint
 
 class TrainingConfig(BaseModel):
     """
@@ -28,6 +28,7 @@ class TrainingConfig(BaseModel):
     # Pydantic class configuration
     model_config = ConfigDict(
         validate_assignment=True,
+        arbitrary_types_allowed=True, #test - Diya 27.1.25
     )
 
     num_epochs: int = Field(default=20, ge=1)
@@ -54,6 +55,9 @@ class TrainingConfig(BaseModel):
     checkpoint_callback: CheckpointModel = CheckpointModel()
     """Checkpoint callback configuration, following PyTorch Lightning Checkpoint
     callback."""
+
+    model_checkpoint: Optional[ModelCheckpoint] = None
+    """Optional override for the model checkpoint configuration."""
 
     early_stopping_callback: Optional[EarlyStoppingModel] = Field(
         default=None, validate_default=True

--- a/src/careamics/config/training_model.py
+++ b/src/careamics/config/training_model.py
@@ -29,7 +29,10 @@ class TrainingConfig(BaseModel):
     # Pydantic class configuration
     model_config = ConfigDict(
         validate_assignment=True,
+<<<<<<< HEAD
         arbitrary_types_allowed=True,  # test - Diya 27.1.25
+=======
+>>>>>>> 3802fcd (Fix careamist.py, configuration_factories.py, and training_model.py per review feedback (PR #381))
     )
 
     num_epochs: int = Field(default=20, ge=1)
@@ -52,14 +55,9 @@ class TrainingConfig(BaseModel):
     logger: Optional[Literal["wandb", "tensorboard"]] = None
     """Logger to use during training. If None, no logger will be used. Available
     loggers are defined in SupportedLogger."""
-
     checkpoint_callback: CheckpointModel = CheckpointModel()
     """Checkpoint callback configuration, following PyTorch Lightning Checkpoint
     callback."""
-
-    model_checkpoint: Optional[ModelCheckpoint] = None
-    """Optional override for the model checkpoint configuration."""
-
     early_stopping_callback: Optional[EarlyStoppingModel] = Field(
         default=None, validate_default=True
     )

--- a/src/careamics/config/training_model.py
+++ b/src/careamics/config/training_model.py
@@ -6,9 +6,10 @@ from pprint import pformat
 from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pytorch_lightning.callbacks import ModelCheckpoint
 
 from .callback_model import CheckpointModel, EarlyStoppingModel
-from pytorch_lightning.callbacks import ModelCheckpoint
+
 
 class TrainingConfig(BaseModel):
     """
@@ -28,7 +29,7 @@ class TrainingConfig(BaseModel):
     # Pydantic class configuration
     model_config = ConfigDict(
         validate_assignment=True,
-        arbitrary_types_allowed=True, #test - Diya 27.1.25
+        arbitrary_types_allowed=True,  # test - Diya 27.1.25
     )
 
     num_epochs: int = Field(default=20, ge=1)


### PR DESCRIPTION
### Description

- **What**: 
Added ModelCheckpoint import to training_model.py
Added arbitrary_types_allowed=True to the model configuration
Exposed ModelCheckpoint parameter in create_care_configuration() function
Propagated ModelCheckpoint parameter through configuration factory functions
- **Why**: 
Users need to modify checkpoint configuration after creating the configuration object by directly accessing training_config.checkpoint_callback. These changes allow users to set ModelCheckpoint parameters directly during configuration creation, making the API more user-friendly and explicit. 
- **How**: 
The ModelCheckpoint import was added to training_model.py and arbitrary_types_allowed flag was enabled to properly support the ModelCheckpoint type. ModelCheckpoint parameter was added to create_care_configuration() and propagated through the configuration factory functions.

### Changes Made

- **Added**: 
ModelCheckpoint import from pytorch_lightning.callbacks
model_checkpoint parameter to configuration creation functions
arbitrary_types_allowed=True to model configuration
- **Modified**: 
Updated documentation for configuration functions
Modified configuration factory chain to support ModelCheckpoint

### Related Issues
- Closes #353 

### Example config:
```python
config = create_care_configuration(
    experiment_name="experiment_name",
    data_type="tiff",  
    axes="ZYX",
    patch_size=[16, 64, 64],
    batch_size=1,
    num_epochs=1,
    model_checkpoint=ModelCheckpoint(  
        monitor="val_loss",
        save_top_k=10,
        save_last=True,
        mode="min",
        every_n_epochs=5,
        auto_insert_metric_name=False
    )
)
``` 
---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)