### PR TITLE
Feature: Add ability to set dataloader kwargs for validation dataset

### DIFF
--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -224,7 +224,8 @@ def _create_configuration(
     logger: Literal["wandb", "tensorboard", "none"],
     use_n2v2: bool = False,
     model_params: Optional[dict] = None,
-    dataloader_params: Optional[dict] = None,
+    train_dataloader_params: Optional[dict[str, Any]] = None,
+    val_dataloader_params: Optional[dict[str, Any]] = None,
 ) -> Configuration:
     """
     Create a configuration for training N2V, CARE or Noise2Noise.
@@ -262,8 +263,10 @@ def _create_configuration(
         Whether to use N2V2, by default False.
     model_params : dict
         UNetModel parameters.
-    dataloader_params : dict
-        Parameters for the dataloader, see PyTorch notes, by default None.
+    train_dataloader_params : dict
+        Parameters for the training dataloader, see PyTorch notes, by default None.
+    val_dataloader_params : dict
+        Parameters for the validation dataloader, see PyTorch notes, by default None.
 
     Returns
     -------
@@ -294,8 +297,12 @@ def _create_configuration(
         "patch_size": patch_size,
         "batch_size": batch_size,
         "transforms": augmentations,
-        "dataloader_params": dataloader_params,
     }
+    # Don't override defaults set in DataConfig class
+    if train_dataloader_params is not None:
+        data["train_dataloader_params"] = train_dataloader_params
+    if val_dataloader_params is not None:
+        data["val_dataloader_params"] = val_dataloader_params
 
     # training model
     training = TrainingConfig(
@@ -331,7 +338,8 @@ def _create_supervised_configuration(
     n_channels_out: Optional[int] = None,
     logger: Literal["wandb", "tensorboard", "none"] = "none",
     model_params: Optional[dict] = None,
-    dataloader_params: Optional[dict] = None,
+    train_dataloader_params: Optional[dict[str, Any]] = None,
+    val_dataloader_params: Optional[dict[str, Any]] = None,
 ) -> Configuration:
     """
     Create a configuration for training CARE or Noise2Noise.
@@ -368,8 +376,10 @@ def _create_supervised_configuration(
         Logger to use, by default "none".
     model_params : dict, optional
         UNetModel parameters, by default {}.
-    dataloader_params : dict, optional
-        Parameters for the dataloader, see PyTorch notes, by default None.
+    train_dataloader_params : dict
+        Parameters for the training dataloader, see PyTorch notes, by default None.
+    val_dataloader_params : dict
+        Parameters for the validation dataloader, see PyTorch notes, by default None.
 
     Returns
     -------
@@ -416,7 +426,8 @@ def _create_supervised_configuration(
         n_channels_out=n_channels_out,
         logger=logger,
         model_params=model_params,
-        dataloader_params=dataloader_params,
+        train_dataloader_params=train_dataloader_params,
+        val_dataloader_params=val_dataloader_params,
     )
 
 
@@ -434,7 +445,8 @@ def create_care_configuration(
     n_channels_out: Optional[int] = None,
     logger: Literal["wandb", "tensorboard", "none"] = "none",
     model_params: Optional[dict] = None,
-    dataloader_params: Optional[dict] = None,
+    train_dataloader_params: Optional[dict[str, Any]] = None,
+    val_dataloader_params: Optional[dict[str, Any]] = None,
 ) -> Configuration:
     """
     Create a configuration for training CARE.
@@ -456,6 +468,11 @@ def create_care_configuration(
     rotations by 90 degrees in the XY plane) are applied. Rather than the default
     transforms, a list of transforms can be passed to the `augmentations` parameter. To
     disable the transforms, simply pass an empty list.
+
+    By setting `train_dataloader_params` and `val_dataloader_params` to `None` the
+    defaults set in the `DataConfig` will be used. This is the dictionary
+    {"shuffle": True} for the `train_dataloader_params` and the empty dict {} for
+    the `val_dataloader_params`.
 
     Parameters
     ----------
@@ -487,8 +504,10 @@ def create_care_configuration(
         Logger to use.
     model_params : dict, default=None
         UNetModel parameters.
-    dataloader_params : dict, optional
-        Parameters for the dataloader, see PyTorch notes, by default None.
+    train_dataloader_params : dict
+        Parameters for the training dataloader, see PyTorch notes, by default None.
+    val_dataloader_params : dict
+        Parameters for the validation dataloader, see PyTorch notes, by default None.
 
     Returns
     -------
@@ -577,7 +596,8 @@ def create_care_configuration(
         n_channels_out=n_channels_out,
         logger=logger,
         model_params=model_params,
-        dataloader_params=dataloader_params,
+        train_dataloader_params=train_dataloader_params,
+        val_dataloader_params=val_dataloader_params,
     )
 
 
@@ -595,7 +615,8 @@ def create_n2n_configuration(
     n_channels_out: Optional[int] = None,
     logger: Literal["wandb", "tensorboard", "none"] = "none",
     model_params: Optional[dict] = None,
-    dataloader_params: Optional[dict] = None,
+    train_dataloader_params: Optional[dict[str, Any]] = None,
+    val_dataloader_params: Optional[dict[str, Any]] = None,
 ) -> Configuration:
     """
     Create a configuration for training Noise2Noise.
@@ -617,6 +638,11 @@ def create_n2n_configuration(
     rotations by 90 degrees in the XY plane) are applied. Rather than the default
     transforms, a list of transforms can be passed to the `augmentations` parameter. To
     disable the transforms, simply pass an empty list.
+
+    By setting `train_dataloader_params` and `val_dataloader_params` to `None` the
+    defaults set in the `DataConfig` will be used. This is the dictionary
+    {"shuffle": True} for the `train_dataloader_params` and the empty dict {} for
+    the `val_dataloader_params`.
 
     Parameters
     ----------
@@ -648,8 +674,10 @@ def create_n2n_configuration(
         Logger to use, by default "none".
     model_params : dict, optional
         UNetModel parameters, by default {}.
-    dataloader_params : dict, optional
-        Parameters for the dataloader, see PyTorch notes, by default None.
+    train_dataloader_params : dict
+        Parameters for the training dataloader, see PyTorch notes, by default None.
+    val_dataloader_params : dict
+        Parameters for the validation dataloader, see PyTorch notes, by default None.
 
     Returns
     -------
@@ -738,7 +766,8 @@ def create_n2n_configuration(
         n_channels_out=n_channels_out,
         logger=logger,
         model_params=model_params,
-        dataloader_params=dataloader_params,
+        train_dataloader_params=train_dataloader_params,
+        val_dataloader_params=val_dataloader_params,
     )
 
 
@@ -759,7 +788,8 @@ def create_n2v_configuration(
     struct_n2v_span: int = 5,
     logger: Literal["wandb", "tensorboard", "none"] = "none",
     model_params: Optional[dict] = None,
-    dataloader_params: Optional[dict] = None,
+    train_dataloader_params: Optional[dict[str, Any]] = None,
+    val_dataloader_params: Optional[dict[str, Any]] = None,
 ) -> Configuration:
     """
     Create a configuration for training Noise2Void.
@@ -802,6 +832,11 @@ def create_n2v_configuration(
     If you pass "horizontal" or "vertical" to `struct_n2v_axis`, then structN2V mask
     will be applied to each manipulated pixel.
 
+    By setting `train_dataloader_params` and `val_dataloader_params` to `None` the
+    defaults set in the `DataConfig` will be used. This is the dictionary
+    {"shuffle": True} for the `train_dataloader_params` and the empty dict {} for
+    the `val_dataloader_params`.
+
     Parameters
     ----------
     experiment_name : str
@@ -838,8 +873,10 @@ def create_n2v_configuration(
         Logger to use, by default "none".
     model_params : dict, optional
         UNetModel parameters, by default None.
-    dataloader_params : dict, optional
-        Parameters for the dataloader, see PyTorch notes, by default None.
+    train_dataloader_params : dict
+        Parameters for the training dataloader, see PyTorch notes, by default None.
+    val_dataloader_params : dict
+        Parameters for the validation dataloader, see PyTorch notes, by default None.
 
     Returns
     -------
@@ -979,5 +1016,6 @@ def create_n2v_configuration(
         n_channels_out=n_channels,
         logger=logger,
         model_params=model_params,
-        dataloader_params=dataloader_params,
+        train_dataloader_params=train_dataloader_params,
+        val_dataloader_params=val_dataloader_params,
     )

--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -469,11 +469,6 @@ def create_care_configuration(
     transforms, a list of transforms can be passed to the `augmentations` parameter. To
     disable the transforms, simply pass an empty list.
 
-    By setting `train_dataloader_params` and `val_dataloader_params` to `None` the
-    defaults set in the `DataConfig` will be used. This is the dictionary
-    {"shuffle": True} for the `train_dataloader_params` and the empty dict {} for
-    the `val_dataloader_params`.
-
     Parameters
     ----------
     experiment_name : str
@@ -504,10 +499,14 @@ def create_care_configuration(
         Logger to use.
     model_params : dict, default=None
         UNetModel parameters.
-    train_dataloader_params : dict
-        Parameters for the training dataloader, see PyTorch notes, by default None.
-    val_dataloader_params : dict
-        Parameters for the validation dataloader, see PyTorch notes, by default None.
+    train_dataloader_params : dict, optional
+        Parameters for the training dataloader, see the PyTorch docs for `DataLoader`.
+        If left as `None`, the dict `{"shuffle": True}` will be used, this is set in
+        the `GeneralDataConfig`.
+    val_dataloader_params : dict, optional
+        Parameters for the validation dataloader, see PyTorch the docs for `DataLoader`.
+        If left as `None`, the empty dict `{}` will be used, this is set in the
+        `GeneralDataConfig`.
 
     Returns
     -------
@@ -639,11 +638,6 @@ def create_n2n_configuration(
     transforms, a list of transforms can be passed to the `augmentations` parameter. To
     disable the transforms, simply pass an empty list.
 
-    By setting `train_dataloader_params` and `val_dataloader_params` to `None` the
-    defaults set in the `DataConfig` will be used. This is the dictionary
-    {"shuffle": True} for the `train_dataloader_params` and the empty dict {} for
-    the `val_dataloader_params`.
-
     Parameters
     ----------
     experiment_name : str
@@ -674,10 +668,14 @@ def create_n2n_configuration(
         Logger to use, by default "none".
     model_params : dict, optional
         UNetModel parameters, by default {}.
-    train_dataloader_params : dict
-        Parameters for the training dataloader, see PyTorch notes, by default None.
-    val_dataloader_params : dict
-        Parameters for the validation dataloader, see PyTorch notes, by default None.
+    train_dataloader_params : dict, optional
+        Parameters for the training dataloader, see the PyTorch docs for `DataLoader`.
+        If left as `None`, the dict `{"shuffle": True}` will be used, this is set in
+        the `GeneralDataConfig`.
+    val_dataloader_params : dict, optional
+        Parameters for the validation dataloader, see PyTorch the docs for `DataLoader`.
+        If left as `None`, the empty dict `{}` will be used, this is set in the
+        `GeneralDataConfig`.
 
     Returns
     -------
@@ -832,11 +830,6 @@ def create_n2v_configuration(
     If you pass "horizontal" or "vertical" to `struct_n2v_axis`, then structN2V mask
     will be applied to each manipulated pixel.
 
-    By setting `train_dataloader_params` and `val_dataloader_params` to `None` the
-    defaults set in the `DataConfig` will be used. This is the dictionary
-    {"shuffle": True} for the `train_dataloader_params` and the empty dict {} for
-    the `val_dataloader_params`.
-
     Parameters
     ----------
     experiment_name : str
@@ -873,10 +866,14 @@ def create_n2v_configuration(
         Logger to use, by default "none".
     model_params : dict, optional
         UNetModel parameters, by default None.
-    train_dataloader_params : dict
-        Parameters for the training dataloader, see PyTorch notes, by default None.
-    val_dataloader_params : dict
-        Parameters for the validation dataloader, see PyTorch notes, by default None.
+    train_dataloader_params : dict, optional
+        Parameters for the training dataloader, see the PyTorch docs for `DataLoader`.
+        If left as `None`, the dict `{"shuffle": True}` will be used, this is set in
+        the `GeneralDataConfig`.
+    val_dataloader_params : dict, optional
+        Parameters for the validation dataloader, see PyTorch the docs for `DataLoader`.
+        If left as `None`, the empty dict `{}` will be used, this is set in the
+        `GeneralDataConfig`.
 
     Returns
     -------

--- a/tests/config/data/test_data_model.py
+++ b/tests/config/data/test_data_model.py
@@ -154,6 +154,16 @@ def test_passing_incorrect_element(minimum_data: dict):
         DataConfig(**minimum_data)
 
 
+def test_no_shuffle_in_train_dataloader_params(minimum_data: dict):
+    """
+    Test that an error is raised if there is no "shuffle" value in
+    `train_dataloader_params`.
+    """
+    minimum_data["train_dataloader_params"] = {"num_workers": 4}
+    with pytest.raises(ValueError):
+        DataConfig(**minimum_data)
+
+
 def test_export_to_yaml_float32_stats(tmp_path, minimum_data: dict):
     """Test exporting and loading the pydantic model when the statistics are
     np.float32."""

--- a/tests/config/test_configuration_factories.py
+++ b/tests/config/test_configuration_factories.py
@@ -210,7 +210,11 @@ def test_create_configuration():
     model_params = {
         "depth": 5,
     }
-    dataloader_params = {
+    train_dataloader_params = {
+        "num_workers": 4,
+        "shuffle": True,
+    }
+    val_dataloader_params = {
         "num_workers": 4,
     }
 
@@ -230,7 +234,8 @@ def test_create_configuration():
         n_channels_out=n_channels_out,
         logger=logger,
         model_params=model_params,
-        dataloader_params=dataloader_params,
+        train_dataloader_params=train_dataloader_params,
+        val_dataloader_params=val_dataloader_params,
     )
 
     assert config.algorithm_config.algorithm == algorithm
@@ -247,7 +252,8 @@ def test_create_configuration():
     assert config.algorithm_config.model.num_classes == n_channels_out
     assert config.training_config.logger == logger
     assert config.algorithm_config.model.depth == model_params["depth"]
-    assert config.data_config.train_dataloader_params == dataloader_params
+    assert config.data_config.train_dataloader_params == train_dataloader_params
+    assert config.data_config.val_dataloader_params == val_dataloader_params
 
 
 def test_supervised_configuration_error_with_channel_axes():

--- a/tests/config/test_configuration_factories.py
+++ b/tests/config/test_configuration_factories.py
@@ -247,7 +247,7 @@ def test_create_configuration():
     assert config.algorithm_config.model.num_classes == n_channels_out
     assert config.training_config.logger == logger
     assert config.algorithm_config.model.depth == model_params["depth"]
-    assert config.data_config.dataloader_params == dataloader_params
+    assert config.data_config.train_dataloader_params == dataloader_params
 
 
 def test_supervised_configuration_error_with_channel_axes():


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

> [!NOTE]  
> **tldr**: <!-- Write a one sentence summary. --> This PR gives users the ability to set the dataloader parameters for the validation dataset. Also included is a minor refactor for the train dataloader parameters to be validated in the `GeneralDataConfig` rather than be modified in the `TrainDataModule.train_dataloader` method.

### Background - why do we need this PR?

Previously there was no way in which users could modify the dataloader parameters for the validation dataset; not being able to set something like the number of workers could unnecessarily slow down users code. 

Validation that `train_dataloader_params` has a `shuffle` parameter was added to the `GeneralDataConfig` because it is better to notify a user when their configuration is wrong rather than silently change behaviour. One small unfortunate thing however, is that the `IterableDataset` cannot be shuffled; so in this case the `shuffle` argument is not given to the dataloader. There are plans to remove the iterable dataset, so this won't be necessary in the future. 

### Overview - what changed?

- `GeneralDataConfig` now has `train_dataloader_params` and `val_dataloader_params` rather than just `dataloader_params`. 
- All configuration creation convenience functions now accept `train_dataloader_params` and `val_dataloader_params` rather than just `dataloader_params`. 

### Implementation - how did you implement the changes?

Added new fields to `GeneralDataConfig` and updated configuration creation convenience functions accordingly.

## Changes Made

### Modified features or files

- `GeneralDataConfig`
  - added `val_dataloader_params` field.
  - added `train_dataloader_params` field.
  - removed `dataloader_params` field.
  - added field validator to ensure `train_dataloader_params` has shuffle key.
- all configuration creation convenience functions
  - added `val_dataloader_params` argument
  - added `train_dataloader_params` argument
  - removed `dataloader_params` argument.
- `TrainDataModule`
  - `train_dataloader` method
  - `val_dataloader` method

### Removed features or files

- `TrainDataModule.dataloader_params` attribute 
  - just access from data_config no need to copy the attribute.

## How has this been tested?

- Modified existing `test_create_configuration` to also check `val_dataloader_params` are set as expected.
- Added an additional test to ensure than an error is raised if `train_dataloader_params` does not include a "shuffle" key.

## Related Issues

- Resolves #342 

## Breaking changes

<!-- Describe any breaking changes introduced by this PR. -->
Old configuration that include `dataloader_params`.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)