### PR TITLE
Fix: Change tqdm import so it automatically detects whether it is rendering within a notebook

### DIFF
--- a/src/careamics/lightning/callbacks/progress_bar_callback.py
+++ b/src/careamics/lightning/callbacks/progress_bar_callback.py
@@ -5,7 +5,7 @@ from typing import Union
 
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import TQDMProgressBar
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 
 class ProgressBarCallback(TQDMProgressBar):


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

> [!NOTE]  
> **tldr**: tqdm has functionality to automatically detect whether it is rendering from within a notebook or not, but it has to be imported from `tqdm.auto`. Doing this will improve the rendering of progress bars within notebooks. See [tqdm docs](https://tqdm.github.io/docs/shortcuts/#tqdmauto)


### Background - why do we need this PR?

Progress bar rendering was pretty ugly within notebooks, especially when using jupyter directly.

### Overview - what changed?

tqdm import.

### Implementation - how did you implement the changes?

Do `from tqdm.auto import tqdm` instead of `import tqdm`. 


## Changes Made

### Modified features or files

<!-- List important modified features or files. -->
- import in `careamics/lightning/callbacks/progress_bar_callback.py`

## How has this been tested?

- Looked at progress bar outputs in a notebook. (But haven't checked normal script).

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)