### PR TITLE
fix: Add CAREamics version to BMZ

### DIFF
--- a/src/careamics/model_io/bioimage/bioimage_utils.py
+++ b/src/careamics/model_io/bioimage/bioimage_utils.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from typing import Union
 
+from careamics.utils.version import get_clean_version
+
 
 def get_unzip_path(zip_path: Union[Path, str]) -> Path:
     """Generate unzipped folder path from the bioimage.io model path.
@@ -44,11 +46,11 @@ def create_env_text(pytorch_version: str, torchvision_version: str) -> str:
         f"name: careamics\n"
         f"dependencies:\n"
         f"  - python=3.10\n"
-        f"  - pytorch={pytorch_version}\n"
-        f"  - torchvision={torchvision_version}\n"
         f"  - pip\n"
         f"  - pip:\n"
-        f"    - git+https://github.com/CAREamics/careamics.git\n"
+        f"    - torch=={pytorch_version}\n"
+        f"    - torchvision=={torchvision_version}\n"
+        f"    - careamics=={get_clean_version()}"
     )
 
     return env

--- a/src/careamics/model_io/bioimage/bioimage_utils.py
+++ b/src/careamics/model_io/bioimage/bioimage_utils.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Union
 
-from careamics.utils.version import get_clean_version
+from careamics.utils.version import get_careamics_version
 
 
 def get_unzip_path(zip_path: Union[Path, str]) -> Path:
@@ -50,7 +50,7 @@ def create_env_text(pytorch_version: str, torchvision_version: str) -> str:
         f"  - pip:\n"
         f"    - torch=={pytorch_version}\n"
         f"    - torchvision=={torchvision_version}\n"
-        f"    - careamics=={get_clean_version()}"
+        f"    - careamics=={get_careamics_version()}"
     )
 
     return env

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Optional, Union
 
 import numpy as np
-import pkg_resources
 from bioimageio.core import load_model_description, test_model
 from bioimageio.spec import ValidationSummary, save_bioimageio_package
 from pydantic import HttpUrl
@@ -16,6 +15,7 @@ from torchvision import __version__ as TORCHVISION_VERSION
 from careamics.config import Configuration, load_configuration, save_configuration
 from careamics.config.support import SupportedArchitecture
 from careamics.lightning.lightning_module import FCNModule, VAEModule
+from careamics.utils.version import get_careamics_version
 
 from .bioimage import (
     create_env_text,
@@ -139,7 +139,7 @@ def export_to_bmz(
         path_to_archive.parent.mkdir(parents=True, exist_ok=True)
 
     # versions
-    careamics_version = pkg_resources.get_distribution("careamics").version
+    careamics_version = get_careamics_version()
 
     # save files in temporary folder
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/src/careamics/utils/version.py
+++ b/src/careamics/utils/version.py
@@ -1,9 +1,13 @@
 """Version utility."""
 
+import logging
+
 from careamics import __version__
 
+logger = logging.getLogger(__name__)
 
-def get_clean_version() -> str:
+
+def get_careamics_version() -> str:
     """Get clean CAREamics version.
 
     This method returns the latest `Major.Minor.Patch` version of CAREamics, removing
@@ -14,11 +18,21 @@ def get_clean_version() -> str:
     str
         Clean CAREamics version.
     """
-    parts = __version__.split(".")  # Remove any local version identifier
+    parts = __version__.split(".")
 
     # for local installs that do not detect the latest versions via tags
-    # (typically our CI)
+    # (typically our CI will install `0.1.devX<hash>` versions)
     if "dev" in parts[-1]:
         parts[-1] = "*"
+        clean_version = ".".join(parts[:3])
 
+        logger.warning(
+            f"Your CAREamics version seems to be a locally modified version "
+            f"({__version__}). The recorded version for loading models will be "
+            f"{clean_version}, which may not exist. If you want to ensure "
+            f"exporting the model with an existing version, please install the "
+            f"closest CAREamics version from PyPI or conda-forge."
+        )
+
+    # Remove any local version identifier)
     return ".".join(parts[:3])

--- a/src/careamics/utils/version.py
+++ b/src/careamics/utils/version.py
@@ -1,0 +1,18 @@
+"""Version utility."""
+
+from careamics import __version__
+
+
+def get_clean_version() -> str:
+    """Get clean CAREamics version.
+
+    This method returns the latest `Major.Minor.Patch` version of CAREamics, removing
+    any local version identifier.
+
+    Returns
+    -------
+    str
+        Clean CAREamics version.
+    """
+    parts = __version__.split(".")  # Remove any local version identifier
+    return ".".join(parts[:3])

--- a/src/careamics/utils/version.py
+++ b/src/careamics/utils/version.py
@@ -15,4 +15,10 @@ def get_clean_version() -> str:
         Clean CAREamics version.
     """
     parts = __version__.split(".")  # Remove any local version identifier
+
+    # for local installs that do not detect the latest versions via tags
+    # (typically our CI)
+    if "dev" in parts[-1]:
+        parts[-1] = "*"
+
     return ".".join(parts[:3])

--- a/tests/utils/test_version.py
+++ b/tests/utils/test_version.py
@@ -1,10 +1,10 @@
-from careamics.utils.version import get_clean_version
+from careamics.utils.version import get_careamics_version
 
 
 def test_get_clean_version():
     """Test that the result has three members (major, minor, patch) and that the last
     one does not include `dev`."""
-    version_members = get_clean_version().split(".")
+    version_members = get_careamics_version().split(".")
 
     assert len(version_members) == 3
     assert "dev" not in version_members[-1]

--- a/tests/utils/test_version.py
+++ b/tests/utils/test_version.py
@@ -1,0 +1,10 @@
+from careamics.utils.version import get_clean_version
+
+
+def test_get_clean_version():
+    """Test that the result has three members (major, minor, patch) and that the last
+    one does not include `dev`."""
+    version_members = get_clean_version().split(".")
+
+    assert len(version_members) == 3
+    assert "dev" not in version_members[-1]


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

> [!NOTE]  
> **tldr**: Make BMZ use the latest PyPI version of CAREamics.

Following https://github.com/CAREamics/careamics/issues/385, this PR adds utilities to extract the version of CAREamics and modifies the BMZ environment yaml to fetch this version from PyPI.


### Background - why do we need this PR?

<!-- What problem are you solving? Describe in a few sentences the state before
this PR. Use code examples if useful. -->

The BMZ env yaml was fetching and installing CAREamics via the main branch in Github, this can cause errors as the main branch might have breaking changes compared to the latest PyPI or even older versions users might have installed.

### Overview - what changed?

<!-- What aspects and mechanisms of the code base changed? Describe only the general 
idea and overarching features. -->

This PR introduces a new utils function to get the `Major.minor.patch` version of CAREamics, and builds the BMZ env yaml such that `torch`, `torchvision`, and `CAREamics` are fetched from PyPI according to their know versions.

### Implementation - how did you implement the changes?

<!-- How did you solve the issue technically? Explain why you chose this approach and 
provide code examples if applicable (e.g. change in the API for users). -->

Locally (e.g. when installed via `pip install -e .`) the CAREamics `__version__` is returned as a dev versions: e.g. `0.0.7.dev10a43fe0b087f`. The new `get_clean_version` utility only keeps the `Major.minor.patch` version.

Finally, the function building up the BMZ env yaml now calls this utility and fetches `torch`, `torchvision` and `CAREamics` from PyPI.

Note that the choice of moving `torch` and `torchvision` to PyPI is motivated by [PyTorch's conda package discontinuation](https://github.com/pytorch/pytorch/issues/138506).

## Changes Made

<!-- This section highlights the important features and files that reviewers should
pay attention to when reviewing. Only list important features or files, this is useful for 
reviewers to correctly assess how deeply the modifications impact the code base.

For instance:

### New features or files
- `NewClass` added to `new_file.py`
- `new_function` added to `existing_file.py`

...
-->

### New features or files

<!-- List new features or files added. -->
- `careamics.utils.version.get_clean_version` to get the CAREamics version, and corresponding test.

### Modified features or files

<!-- List important modified features or files. -->
- `careamics.model_io.bioimage.bioimage_utils.create_env_text` now includes CAREamics version and installs `torch` and `torchvision` from pip.


## How has this been tested?

<!-- Describe the tests that you ran to verify your changes. This can be a short 
description of the tests added to the PR or code snippet to reproduce the change
in behaviour. -->

Only via `pytest`. 

> [!WARNING]  
> This should be tested with an install from PyPI (or with a tagged commit) and with upload to the BMZ to verify that the env is valid.

## Related Issues

<!-- Link to any related issues or discussions. Use keywords like "Fixes", "Resolves",
or "Closes" to link to issues automatically. -->

- Resolves https://github.com/CAREamics/careamics/issues/385

## Additional Notes and Examples

<!-- Provide any additional information that will help reviewers understand the
changes. This can be links to documentations, forum posts, past discussions etc. -->


> [!WARNING]  
> If working on a local editable install, `pip` automatically increases the patch version from the latest **known**. If you `pip install -e .` again, this might increase the latest known version. BMZ models should therefore preferentially be uploaded from an env installed from PyPI.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)