### PR TITLE
Enforce `shuffling` in convenience functions

### DIFF
--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -242,11 +242,11 @@ def _create_data_configuration(
     }
     # Don't override defaults set in DataConfig class
     if train_dataloader_params is not None:
-        data["train_dataloader_params"] = train_dataloader_params
-
         # DataConfig enforces the presence of `shuffle` key in the dataloader parameters
         if "shuffle" not in train_dataloader_params:
             train_dataloader_params["shuffle"] = True
+
+        data["train_dataloader_params"] = train_dataloader_params
 
     if val_dataloader_params is not None:
         data["val_dataloader_params"] = val_dataloader_params

--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -243,6 +243,11 @@ def _create_data_configuration(
     # Don't override defaults set in DataConfig class
     if train_dataloader_params is not None:
         data["train_dataloader_params"] = train_dataloader_params
+
+        # DataConfig enforces the presence of `shuffle` key in the dataloader parameters
+        if "shuffle" not in train_dataloader_params:
+            train_dataloader_params["shuffle"] = True
+
     if val_dataloader_params is not None:
         data["val_dataloader_params"] = val_dataloader_params
 

--- a/src/careamics/config/data/data_model.py
+++ b/src/careamics/config/data/data_model.py
@@ -139,7 +139,9 @@ class DataConfig(BaseModel):
     train_dataloader_params: dict[str, Any] = Field(
         default={"shuffle": True}, validate_default=True
     )
-    """Dictionary of PyTorch training dataloader parameters."""
+    """Dictionary of PyTorch training dataloader parameters. The dataloader parameters,
+    should include the `shuffle` key, which is set to `True` by default. We strongly
+    recommend to keep it as `True` to ensure the best training results."""
 
     val_dataloader_params: dict[str, Any] = Field(default={})
     """Dictionary of PyTorch validation dataloader parameters."""
@@ -242,7 +244,7 @@ class DataConfig(BaseModel):
         ):
             warn(
                 "Dataloader parameters include `shuffle=False`, this will be passed to "
-                "the training dataloader and may result in bad results.",
+                "the training dataloader and may lead to lower quality results.",
                 stacklevel=1,
             )
         return train_dataloader_params

--- a/tests/config/test_configuration_factories.py
+++ b/tests/config/test_configuration_factories.py
@@ -11,6 +11,7 @@ from careamics.config import (
     create_n2v_configuration,
 )
 from careamics.config.configuration_factories import (
+    _create_data_configuration,
     _create_supervised_config_dict,
     _create_unet_configuration,
     _list_spatial_augmentations,
@@ -94,6 +95,16 @@ def test_list_aug_error_wrong_transform():
         _list_spatial_augmentations(
             augmentations=[XYFlipModel(), N2VManipulateModel()],
         )
+
+
+def test_create_data_configuration_train_dataloader_params(minimum_data):
+    """Test that shuffle is added silently to the train_dataloader_params."""
+    config_dict = minimum_data
+    config_dict["train_dataloader_params"] = {"num_workers": 4}
+
+    config = _create_data_configuration(batch_size=1, augmentations=[], **config_dict)
+    assert "shuffle" in config.train_dataloader_params
+    assert config.train_dataloader_params["shuffle"]
 
 
 def test_supervised_configuration_passing_transforms():
@@ -299,6 +310,7 @@ def test_n2n_configuration():
         patch_size=[64, 64],
         batch_size=8,
         num_epochs=100,
+        train_dataloader_params={"num_workers": 2},
     )
     assert config.algorithm_config.algorithm == "n2n"
 
@@ -345,6 +357,7 @@ def test_care_configuration():
         patch_size=[64, 64],
         batch_size=8,
         num_epochs=100,
+        train_dataloader_params={"num_workers": 2},
     )
     assert config.algorithm_config.algorithm == "care"
 
@@ -391,6 +404,7 @@ def test_n2v_configuration():
         patch_size=[64, 64],
         batch_size=8,
         num_epochs=100,
+        train_dataloader_params={"num_workers": 2},
     )
     assert isinstance(config.algorithm_config, N2VAlgorithm)
 


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

> [!NOTE]  
> **tldr**: Prevent users from running into errors as soon as they add training dataloader parameters.

I ran into this error while fixing the docs: if one wishes to change `num_workers` in the train dataloader, then an error would be raised (Pydantic validation) if the `shuffle` parameter is also absent.

This PR enforces the presence of the `shuffle` parameter for users.


### Background - why do we need this PR?

<!-- What problem are you solving? Describe in a few sentences the state before
this PR. Use code examples if useful. -->

The current mindset of the configuration is the following:
- Pydantic configuration do not change the user input and the sole responsibility is coherence and clarity of errors (at least those we write).
- Convenience functions are the entry point for users and these should minimize the potential for misconfigurations (and therefore validation errors).

The current behaviour leads to easy to stumble upon errors: any parameter but `shuffle` passed to the `train_dataloader_params` parameter of the convenience functions will lead to an error thrown at the user.

### Overview - what changed?

<!-- What aspects and mechanisms of the code base changed? Describe only the general 
idea and overarching features. -->

This PR enforces the addition of `shuffle` to the `train_dataloader_params` if it was not passed by users to the convenience functions.

### Implementation - how did you implement the changes?

<!-- How did you solve the issue technically? Explain why you chose this approach and 
provide code examples if applicable (e.g. change in the API for users). -->

The convenience functions call `_create_data_configuration`, which now test for the presence of `shuffle` and adds it if absent.

## Changes Made

<!-- This section highlights the important features and files that reviewers should
pay attention to when reviewing. Only list important features or files, this is useful for 
reviewers to correctly assess how deeply the modifications impact the code base.

For instance:

### New features or files
- `NewClass` added to `new_file.py`
- `new_function` added to `existing_file.py`

...
-->

### Modified features or files

<!-- List important modified features or files. -->
- `_create_data_configuration` checks for presence in `train_dataloader_params` and add `"shuffle" : True` if absent
- Updated the description of the parameter to mention the necessity to have the `shuffle` parameter.
- Added a test to check the behaviour.


## How has this been tested?

<!-- Describe the tests that you ran to verify your changes. This can be a short 
description of the tests added to the PR or code snippet to reproduce the change
in behaviour. -->

Locally and via the tests.

## Breaking changes

<!-- Describe any breaking changes introduced by this PR. -->

No breaking changes I can think of.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [x] PR to the documentation exists (for bug fixes / features)