### PR TITLE
Refac(Next-Gen Dataset): More easily user customisable `PatchExtractor` construction

### DIFF
--- a/src/careamics/dataset_ng/patch_extractor/__init__.py
+++ b/src/careamics/dataset_ng/patch_extractor/__init__.py
@@ -1,7 +1,6 @@
 __all__ = [
     "PatchExtractor",
-    "PatchExtractorConstructor",
     "PatchSpecs",
 ]
 
-from .patch_extractor import PatchExtractor, PatchExtractorConstructor, PatchSpecs
+from .patch_extractor import PatchExtractor, PatchSpecs

--- a/src/careamics/dataset_ng/patch_extractor/__init__.py
+++ b/src/careamics/dataset_ng/patch_extractor/__init__.py
@@ -1,6 +1,11 @@
 __all__ = [
+    "ImageStackLoader",
     "PatchExtractor",
     "PatchSpecs",
+    "create_patch_extractor",
+    "get_image_stack_loader",
 ]
 
+from .image_stack_loader import ImageStackLoader, get_image_stack_loader
 from .patch_extractor import PatchExtractor, PatchSpecs
+from .patch_extractor_factory import create_patch_extractor

--- a/src/careamics/dataset_ng/patch_extractor/demo_custom_image_stack_loader.ipynb
+++ b/src/careamics/dataset_ng/patch_extractor/demo_custom_image_stack_loader.ipynb
@@ -132,7 +132,7 @@
     "    data_paths: Sequence[str]\n",
     "\n",
     "def custom_image_stack_loader(\n",
-    "    data_config: DataConfig, source: ZarrSource\n",
+    "    data_config: DataConfig, source: ZarrSource, *args, **kwargs\n",
     "):\n",
     "    axes = data_config.axes\n",
     "    image_stacks = [\n",

--- a/src/careamics/dataset_ng/patch_extractor/demo_custom_image_stack_loader.ipynb
+++ b/src/careamics/dataset_ng/patch_extractor/demo_custom_image_stack_loader.ipynb
@@ -132,9 +132,8 @@
     "    data_paths: Sequence[str]\n",
     "\n",
     "def custom_image_stack_loader(\n",
-    "    data_config: DataConfig, source: ZarrSource, *args, **kwargs\n",
+    "    source: ZarrSource, axes: str, *args, **kwargs\n",
     "):\n",
-    "    axes = data_config.axes\n",
     "    image_stacks = [\n",
     "        ZarrImageStack(store=source[\"store\"], data_path=data_path, axes=axes)\n",
     "        for data_path in source[\"data_paths\"]\n",
@@ -167,9 +166,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from careamics.config.support import SupportedData"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from careamics.dataset_ng.patch_extractor.image_stack_loader import ImageStackLoader\n",
+    "\n",
+    "image_stack_loader: ImageStackLoader = custom_image_stack_loader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# So pylance knows that datatype is custom to match function overloads\n",
+    "assert data_config.data_type is SupportedData.CUSTOM\n",
+    "\n",
     "patch_extractor = create_patch_extractor(\n",
-    "    data_config=data_config,\n",
     "    source={\"store\": store, \"data_paths\":data_paths},\n",
+    "    axes=data_config.axes,\n",
+    "    data_type=data_config.data_type,\n",
     "    image_stack_loader=custom_image_stack_loader,\n",
     ")"
    ]

--- a/src/careamics/dataset_ng/patch_extractor/demo_custom_image_stack_loader.ipynb
+++ b/src/careamics/dataset_ng/patch_extractor/demo_custom_image_stack_loader.ipynb
@@ -8,7 +8,9 @@
    "source": [
     "from collections.abc import Sequence\n",
     "from pathlib import Path\n",
+    "from typing import TypedDict\n",
     "\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import zarr\n",
     "from numpy.typing import NDArray\n",
@@ -21,7 +23,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from careamics.dataset_ng.patch_extractor import PatchExtractor\n",
+    "from careamics.config import DataConfig\n",
+    "from careamics.dataset_ng.patch_extractor import create_patch_extractor\n",
     "from careamics.dataset_ng.patch_extractor.image_stack import ZarrImageStack"
    ]
   },
@@ -45,26 +48,18 @@
     "    array[...] = data\n",
     "    store.close()\n",
     "\n",
-    "def create_zarr_group(file_path: Path, group_path: str):\n",
-    "    store = FSStore(url=file_path.resolve())\n",
-    "    zarr.open_group(store, path=group_path)\n",
-    "    store.close()\n",
-    "\n",
-    "# def create_zarr(\n",
-    "#     file_path: Path, data_paths: Sequence[str], data: Sequence[NDArray]\n",
-    "# ):\n",
-    "#     store = FSStore(url=file_path.resolve())\n",
-    "#     _ = zarr.open_group(store)\n",
-    "#     store.close()\n",
-    "#     for data_path, array in zip(data_paths, data):\n",
-    "#         for parent_path in Path(data_path).parents[-2::-1]:\n",
-    "#             create_zarr_group(file_path=file_path, group_path=str(parent_path))\n",
-    "#         create_zarr_array(file_path=file_path, data_path=data_path, data=array)\n",
     "def create_zarr(\n",
     "    file_path: Path, data_paths: Sequence[str], data: Sequence[NDArray]\n",
     "):\n",
     "    for data_path, array in zip(data_paths, data):\n",
     "        create_zarr_array(file_path=file_path, data_path=data_path, data=array)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create example ZARR file"
    ]
   },
   {
@@ -90,7 +85,15 @@
     "data = [\n",
     "    np.random.randint(1, 255, size=shape, dtype=np.uint8) for shape in data_shapes\n",
     "]\n",
-    "create_zarr(file_path, data_paths, data)"
+    "if not file_path.is_file() and not file_path.is_dir():\n",
+    "    create_zarr(file_path, data_paths, data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Make sure file exists"
    ]
   },
   {
@@ -112,12 +115,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "zarr.open_group(store)[\"group_1\"]"
+    "### Define custom loading function"
    ]
   },
   {
@@ -126,22 +127,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def custom_image_stack_loader(store: FSStore, data_paths: Sequence[str], axes=\"str\"):\n",
+    "class ZarrSource(TypedDict):\n",
+    "    store: FSStore\n",
+    "    data_paths: Sequence[str]\n",
+    "\n",
+    "def custom_image_stack_loader(\n",
+    "    data_config: DataConfig, source: ZarrSource\n",
+    "):\n",
+    "    axes = data_config.axes\n",
     "    image_stacks = [\n",
-    "        ZarrImageStack(store=store, data_path=data_path, axes=axes)\n",
-    "        for data_path in data_paths\n",
+    "        ZarrImageStack(store=source[\"store\"], data_path=data_path, axes=axes)\n",
+    "        for data_path in source[\"data_paths\"]\n",
     "    ]\n",
     "    return image_stacks"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test custom loading func"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "image_stacks = custom_image_stack_loader(\n",
-    "    store=store, data_paths=data_paths, axes=\"SCYX\"\n",
+    "# dummy data config\n",
+    "data_config = DataConfig(\n",
+    "    data_type=\"custom\", patch_size=[64, 64], axes=\"SCYX\"\n",
     ")"
    ]
   },
@@ -151,7 +167,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "patch_extractor = PatchExtractor(image_stacks)"
+    "patch_extractor = create_patch_extractor(\n",
+    "    data_config=data_config,\n",
+    "    source={\"store\": store, \"data_paths\":data_paths},\n",
+    "    image_stack_loader=custom_image_stack_loader,\n",
+    ")"
    ]
   },
   {
@@ -160,16 +180,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import matplotlib.pyplot as plt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "patch = patch_extractor.extract_patch(0, 0, (8, 16), (16, 16))\n",
+    "# extract patch and display\n",
+    "patch = patch_extractor.extract_patch(2, 0, (8, 16), (16, 16))\n",
     "plt.imshow(np.moveaxis(patch, 0, -1))"
    ]
   },

--- a/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
@@ -3,12 +3,12 @@ from pathlib import Path
 from typing import (
     Any,
     Optional,
-    ParamSpec,
     Protocol,
     Union,
 )
 
 from numpy.typing import NDArray
+from typing_extensions import ParamSpec
 
 from careamics.config import DataConfig
 from careamics.config.support import SupportedData

--- a/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
@@ -12,10 +12,15 @@ from typing_extensions import ParamSpec
 
 from careamics.config.support import SupportedData
 from careamics.file_io.read import ReadFunc
+from careamics.utils import BaseEnum
 
 from .image_stack import ImageStack, InMemoryImageStack, ZarrImageStack
 
 P = ParamSpec("P")
+
+
+class SupportedDataDev(str, BaseEnum):
+    ZARR = "zarr"
 
 
 class ImageStackLoader(Protocol[P]):
@@ -117,7 +122,7 @@ def from_ome_zarr_files(
 
 
 def get_image_stack_loader(
-    data_type: Union[SupportedData, str],  # Union with string temp for zarr
+    data_type: Union[SupportedData, SupportedDataDev],
     image_stack_loader: Optional[ImageStackLoader] = None,
 ) -> ImageStackLoader:
     if data_type == SupportedData.ARRAY:

--- a/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
@@ -62,6 +62,7 @@ class ImageStackLoader(Protocol[P]):
     ...         for data_path in source["data_paths"]
     ...     ]
     ...     return image_stacks
+
     TODO: show example use in the `CAREamicsDataset`
 
     The example above defines a `ZarrSource` dict because to determine _which_ ZARR

--- a/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
@@ -1,9 +1,17 @@
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Callable, Literal, Optional, ParamSpec, Union, overload
+from typing import (
+    Any,
+    Optional,
+    ParamSpec,
+    Protocol,
+    Union,
+    overload,
+)
 
 from numpy.typing import NDArray
 
+from careamics.config import DataConfig
 from careamics.config.support import SupportedData
 from careamics.file_io.read import ReadFunc
 
@@ -11,20 +19,38 @@ from .image_stack import ImageStack, InMemoryImageStack, ZarrImageStack
 from .patch_extractor import PatchExtractor
 
 P = ParamSpec("P")
-ImageStackLoader = Callable[P, Sequence[ImageStack]]
 
 
-def from_arrays(source: Sequence[NDArray], axes: str) -> list[InMemoryImageStack]:
+class ImageStackLoader(Protocol[P]):
+
+    def __call__(
+        self, source: Any, data_config: DataConfig, *args: P.args, **kwargs: P.kwargs
+    ) -> Sequence[ImageStack]: ...
+
+
+def from_arrays(
+    source: Sequence[NDArray], data_config: DataConfig, *args, **kwargs
+) -> list[InMemoryImageStack]:
+    axes = data_config.axes
     return [InMemoryImageStack.from_array(data=array, axes=axes) for array in source]
 
 
-def from_tiff_files(source: Sequence[Path], axes: str) -> list[InMemoryImageStack]:
+def from_tiff_files(
+    source: Sequence[Path], data_config: DataConfig, *args, **kwargs
+) -> list[InMemoryImageStack]:
+    axes = data_config.axes
     return [InMemoryImageStack.from_tiff(path=path, axes=axes) for path in source]
 
 
 def from_custom_file_type(
-    source: Sequence[Path], axes: str, read_func: ReadFunc, read_kwargs: dict[str, Any]
+    source: Sequence[Path],
+    data_config: DataConfig,
+    read_func: ReadFunc,
+    read_kwargs: dict[str, Any],
+    *args,
+    **kwargs,
 ) -> list[InMemoryImageStack]:
+    axes = data_config.axes
     return [
         InMemoryImageStack.from_custom_file_type(
             path=path,
@@ -36,12 +62,14 @@ def from_custom_file_type(
     ]
 
 
-def from_ome_zarr_files(source: Sequence[Path]) -> list[ZarrImageStack]:
+def from_ome_zarr_files(
+    source: Sequence[Path], data_config: DataConfig, *args, **kwargs
+) -> list[ZarrImageStack]:
     return [ZarrImageStack.from_ome_zarr(path) for path in source]
 
 
 def get_image_stack_loader(
-    data_type: Union[SupportedData, str],
+    data_type: Union[SupportedData, str],  # Union with string temp for zarr
     image_stack_loader: Optional[ImageStackLoader] = None,
 ) -> ImageStackLoader:
     if data_type == SupportedData.ARRAY:
@@ -61,59 +89,128 @@ def get_image_stack_loader(
 
 @overload
 def create_patch_extractor(
-    data_type: Literal[SupportedData.ARRAY],
     source: Sequence[NDArray],
-    image_stack_loader: Literal[None] = None,
-    *,
-    axes: str = "",
-) -> PatchExtractor: ...
+    data_config: DataConfig,
+) -> PatchExtractor:
+    """
+    Create a patch extractor from a sequence of numpy arrays.
+
+    Parameters
+    ----------
+    source: sequence of numpy.ndarray
+        The source arrays of the data.
+    data_config: DataConfig
+        The data configuration, `data_config.data_type` should have the value "array",
+        and `data_config.axes` should describe the axes of every array in the `source`.
+
+    Returns
+    -------
+    PatchExtractor
+    """
 
 
 @overload
 def create_patch_extractor(
-    data_type: Literal[SupportedData.TIFF],
     source: Sequence[Path],
-    image_stack_loader: Literal[None] = None,
-    *,
-    axes: str = "",
-) -> PatchExtractor: ...
+    data_config: DataConfig,
+) -> PatchExtractor:
+    """
+    Create a patch extractor from a sequence of files that match our supported types.
+
+    Supported file types include TIFF and ZARR.
+
+    If the files are ZARR files they must follow the OME standard. If you have ZARR
+    files that do not follow the OME standard, see documentation on how to create
+    a custom `image_stack_loader`. (TODO: Add link).
+
+    Parameters
+    ----------
+    source: sequence of Path
+        The source files for the data.
+    data_config: DataConfig
+        The data configuration, `data_config.data_type` should have the value "tiff" or
+        "zarr", and `data_config.axes` should describe the axes of every image in the
+        `source`.
+
+    Returns
+    -------
+    PatchExtractor
+    """
 
 
 @overload
 def create_patch_extractor(
-    data_type: Literal["zarr"],
-    source: Sequence[Path],
-    image_stack_loader: Literal[None] = None,
-) -> PatchExtractor: ...
-
-
-@overload
-def create_patch_extractor(
-    data_type: Literal[SupportedData.CUSTOM],
-    source: Sequence[Path],
-    image_stack_loader: Literal[None] = None,
+    source: Any,
+    data_config: DataConfig,
     *,
-    axes: str,
     read_func: ReadFunc,
     read_kwargs: dict[str, Any],
-) -> PatchExtractor: ...
+) -> PatchExtractor:
+    """
+    Create a patch extractor from a sequence of files of a custom type.
+
+    Parameters
+    ----------
+    source: sequence of Path
+        The source files for the data.
+    data_config: DataConfig
+        The data configuration, `data_config.data_type` should have the value "custom".
+    read_func : ReadFunc
+        A function to read the custom file type, see the `ReadFunc` protocol.
+    read_kwargs : dict of {str: Any}
+        Kwargs that will be passed to the custom `read_func`.
+
+    Returns
+    -------
+    PatchExtractor
+    """
 
 
 @overload
 def create_patch_extractor(
-    data_type: Literal[SupportedData.CUSTOM],
     source: Any,
-    image_stack_loader: ImageStackLoader,
-    **kwargs,
-) -> PatchExtractor: ...
+    data_config: DataConfig,
+    image_stack_loader: ImageStackLoader[P],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> PatchExtractor:
+    """
+    Create a patch extractor using a custom `ImageStackLoader`.
+
+    The custom image stack loader must follow the `ImageStackLoader` protocol, i.e.
+    it must have the following function signature:
+    ```
+    def image_loader_example(
+        source: Any, data_config: DataConfig, *args, **kwargs
+    ) -> Sequence[ImageStack]:
+    ```
+
+    Parameters
+    ----------
+    source: sequence of Path
+        The source files for the data.
+    data_config: DataConfig
+        The data configuration, `data_config.data_type` should have the value "custom".
+    image_stack_loader: ImageStackLoader
+        A custom image stack loader callable.
+    *args: Any
+        Positional arguments that will be passed to the custom image stack loader.
+    **kwargs: Any
+        Keyword arguments that will be passed to the custom image stack loader.
+
+    Returns
+    -------
+    PatchExtractor
+    """
 
 
 def create_patch_extractor(
-    data_type: Union[SupportedData, str],
     source: Any,
-    image_stack_loader: Optional[ImageStackLoader] = None,
-    **kwargs,
+    data_config: DataConfig,
+    image_stack_loader: Optional[ImageStackLoader[P]] = None,
+    *args: P.args,
+    **kwargs: P.kwargs,
 ) -> PatchExtractor:
-    loader = get_image_stack_loader(data_type, image_stack_loader)
-    image_stacks = loader(source, **kwargs)
+    loader = get_image_stack_loader(data_config.data_type, image_stack_loader)
+    image_stacks = loader(source, data_config, *args, **kwargs)
     return PatchExtractor(image_stacks)

--- a/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
@@ -22,27 +22,27 @@ P = ParamSpec("P")
 class ImageStackLoader(Protocol[P]):
 
     def __call__(
-        self, source: Any, data_config: DataConfig, *args: P.args, **kwargs: P.kwargs
+        self, data_config: DataConfig, source: Any, *args: P.args, **kwargs: P.kwargs
     ) -> Sequence[ImageStack]: ...
 
 
 def from_arrays(
-    source: Sequence[NDArray], data_config: DataConfig, *args, **kwargs
+    data_config: DataConfig, source: Sequence[NDArray], *args, **kwargs
 ) -> list[InMemoryImageStack]:
     axes = data_config.axes
     return [InMemoryImageStack.from_array(data=array, axes=axes) for array in source]
 
 
 def from_tiff_files(
-    source: Sequence[Path], data_config: DataConfig, *args, **kwargs
+    data_config: DataConfig, source: Sequence[Path], *args, **kwargs
 ) -> list[InMemoryImageStack]:
     axes = data_config.axes
     return [InMemoryImageStack.from_tiff(path=path, axes=axes) for path in source]
 
 
 def from_custom_file_type(
-    source: Sequence[Path],
     data_config: DataConfig,
+    source: Sequence[Path],
     read_func: ReadFunc,
     read_kwargs: dict[str, Any],
     *args,
@@ -61,7 +61,7 @@ def from_custom_file_type(
 
 
 def from_ome_zarr_files(
-    source: Sequence[Path], data_config: DataConfig, *args, **kwargs
+    data_config: DataConfig, source: Sequence[Path], *args, **kwargs
 ) -> list[ZarrImageStack]:
     return [ZarrImageStack.from_ome_zarr(path) for path in source]
 

--- a/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
@@ -1,0 +1,119 @@
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, Callable, Literal, Optional, ParamSpec, Union, overload
+
+from numpy.typing import NDArray
+
+from careamics.config.support import SupportedData
+from careamics.file_io.read import ReadFunc
+
+from .image_stack import ImageStack, InMemoryImageStack, ZarrImageStack
+from .patch_extractor import PatchExtractor
+
+P = ParamSpec("P")
+ImageStackLoader = Callable[P, Sequence[ImageStack]]
+
+
+def from_arrays(source: Sequence[NDArray], axes: str) -> list[InMemoryImageStack]:
+    return [InMemoryImageStack.from_array(data=array, axes=axes) for array in source]
+
+
+def from_tiff_files(source: Sequence[Path], axes: str) -> list[InMemoryImageStack]:
+    return [InMemoryImageStack.from_tiff(path=path, axes=axes) for path in source]
+
+
+def from_custom_file_type(
+    source: Sequence[Path], axes: str, read_func: ReadFunc, read_kwargs: dict[str, Any]
+) -> list[InMemoryImageStack]:
+    return [
+        InMemoryImageStack.from_custom_file_type(
+            path=path,
+            axes=axes,
+            read_func=read_func,
+            **read_kwargs,
+        )
+        for path in source
+    ]
+
+
+def from_ome_zarr_files(source: Sequence[Path]) -> list[ZarrImageStack]:
+    return [ZarrImageStack.from_ome_zarr(path) for path in source]
+
+
+def get_image_stack_loader(
+    data_type: Union[SupportedData, str],
+    image_stack_loader: Optional[ImageStackLoader] = None,
+) -> ImageStackLoader:
+    if data_type == SupportedData.ARRAY:
+        return from_arrays
+    elif data_type == SupportedData.TIFF:
+        return from_tiff_files
+    elif data_type == "zarr":  # temp for testing until zarr is added to SupportedData
+        return from_ome_zarr_files
+    elif data_type == SupportedData.CUSTOM:
+        if image_stack_loader is None:
+            return from_custom_file_type
+        else:
+            return image_stack_loader
+    else:
+        raise ValueError
+
+
+@overload
+def create_patch_extractor(
+    data_type: Literal[SupportedData.ARRAY],
+    source: Sequence[NDArray],
+    image_stack_loader: Literal[None] = None,
+    *,
+    axes: str = "",
+) -> PatchExtractor: ...
+
+
+@overload
+def create_patch_extractor(
+    data_type: Literal[SupportedData.TIFF],
+    source: Sequence[Path],
+    image_stack_loader: Literal[None] = None,
+    *,
+    axes: str = "",
+) -> PatchExtractor: ...
+
+
+@overload
+def create_patch_extractor(
+    data_type: Literal["zarr"],
+    source: Sequence[Path],
+    image_stack_loader: Literal[None] = None,
+) -> PatchExtractor: ...
+
+
+@overload
+def create_patch_extractor(
+    data_type: Literal[SupportedData.CUSTOM],
+    source: Sequence[Path],
+    image_stack_loader: Literal[None] = None,
+    *,
+    axes: str,
+    read_func: ReadFunc,
+    read_kwargs: dict[str, Any],
+) -> PatchExtractor: ...
+
+
+@overload
+def create_patch_extractor(
+    data_type: Literal[SupportedData.CUSTOM],
+    source: Any,
+    image_stack_loader: ImageStackLoader,
+    **kwargs,
+) -> PatchExtractor: ...
+
+
+def create_patch_extractor(
+    data_type: Union[SupportedData, str],
+    source: Any,
+    image_stack_loader: Optional[ImageStackLoader] = None,
+    **kwargs,
+) -> PatchExtractor:
+    loader = get_image_stack_loader(data_type, image_stack_loader)
+    image_stacks = loader(source, **kwargs)
+    return PatchExtractor(image_stacks)

--- a/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
@@ -6,7 +6,6 @@ from typing import (
     ParamSpec,
     Protocol,
     Union,
-    overload,
 )
 
 from numpy.typing import NDArray
@@ -16,7 +15,6 @@ from careamics.config.support import SupportedData
 from careamics.file_io.read import ReadFunc
 
 from .image_stack import ImageStack, InMemoryImageStack, ZarrImageStack
-from .patch_extractor import PatchExtractor
 
 P = ParamSpec("P")
 
@@ -85,132 +83,3 @@ def get_image_stack_loader(
             return image_stack_loader
     else:
         raise ValueError
-
-
-@overload
-def create_patch_extractor(
-    source: Sequence[NDArray],
-    data_config: DataConfig,
-) -> PatchExtractor:
-    """
-    Create a patch extractor from a sequence of numpy arrays.
-
-    Parameters
-    ----------
-    source: sequence of numpy.ndarray
-        The source arrays of the data.
-    data_config: DataConfig
-        The data configuration, `data_config.data_type` should have the value "array",
-        and `data_config.axes` should describe the axes of every array in the `source`.
-
-    Returns
-    -------
-    PatchExtractor
-    """
-
-
-@overload
-def create_patch_extractor(
-    source: Sequence[Path],
-    data_config: DataConfig,
-) -> PatchExtractor:
-    """
-    Create a patch extractor from a sequence of files that match our supported types.
-
-    Supported file types include TIFF and ZARR.
-
-    If the files are ZARR files they must follow the OME standard. If you have ZARR
-    files that do not follow the OME standard, see documentation on how to create
-    a custom `image_stack_loader`. (TODO: Add link).
-
-    Parameters
-    ----------
-    source: sequence of Path
-        The source files for the data.
-    data_config: DataConfig
-        The data configuration, `data_config.data_type` should have the value "tiff" or
-        "zarr", and `data_config.axes` should describe the axes of every image in the
-        `source`.
-
-    Returns
-    -------
-    PatchExtractor
-    """
-
-
-@overload
-def create_patch_extractor(
-    source: Any,
-    data_config: DataConfig,
-    *,
-    read_func: ReadFunc,
-    read_kwargs: dict[str, Any],
-) -> PatchExtractor:
-    """
-    Create a patch extractor from a sequence of files of a custom type.
-
-    Parameters
-    ----------
-    source: sequence of Path
-        The source files for the data.
-    data_config: DataConfig
-        The data configuration, `data_config.data_type` should have the value "custom".
-    read_func : ReadFunc
-        A function to read the custom file type, see the `ReadFunc` protocol.
-    read_kwargs : dict of {str: Any}
-        Kwargs that will be passed to the custom `read_func`.
-
-    Returns
-    -------
-    PatchExtractor
-    """
-
-
-@overload
-def create_patch_extractor(
-    source: Any,
-    data_config: DataConfig,
-    image_stack_loader: ImageStackLoader[P],
-    *args: P.args,
-    **kwargs: P.kwargs,
-) -> PatchExtractor:
-    """
-    Create a patch extractor using a custom `ImageStackLoader`.
-
-    The custom image stack loader must follow the `ImageStackLoader` protocol, i.e.
-    it must have the following function signature:
-    ```
-    def image_loader_example(
-        source: Any, data_config: DataConfig, *args, **kwargs
-    ) -> Sequence[ImageStack]:
-    ```
-
-    Parameters
-    ----------
-    source: sequence of Path
-        The source files for the data.
-    data_config: DataConfig
-        The data configuration, `data_config.data_type` should have the value "custom".
-    image_stack_loader: ImageStackLoader
-        A custom image stack loader callable.
-    *args: Any
-        Positional arguments that will be passed to the custom image stack loader.
-    **kwargs: Any
-        Keyword arguments that will be passed to the custom image stack loader.
-
-    Returns
-    -------
-    PatchExtractor
-    """
-
-
-def create_patch_extractor(
-    source: Any,
-    data_config: DataConfig,
-    image_stack_loader: Optional[ImageStackLoader[P]] = None,
-    *args: P.args,
-    **kwargs: P.kwargs,
-) -> PatchExtractor:
-    loader = get_image_stack_loader(data_config.data_type, image_stack_loader)
-    image_stacks = loader(source, data_config, *args, **kwargs)
-    return PatchExtractor(image_stacks)

--- a/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
@@ -33,6 +33,7 @@ def from_arrays(
     return [InMemoryImageStack.from_array(data=array, axes=axes) for array in source]
 
 
+# TODO: change source to directory path? Like in current implementation
 def from_tiff_files(
     data_config: DataConfig, source: Sequence[Path], *args, **kwargs
 ) -> list[InMemoryImageStack]:
@@ -40,6 +41,7 @@ def from_tiff_files(
     return [InMemoryImageStack.from_tiff(path=path, axes=axes) for path in source]
 
 
+# TODO: change source to directory path? Like in current implementation
 def from_custom_file_type(
     data_config: DataConfig,
     source: Sequence[Path],

--- a/src/careamics/dataset_ng/patch_extractor/load_custom_zarr_dev.ipynb
+++ b/src/careamics/dataset_ng/patch_extractor/load_custom_zarr_dev.ipynb
@@ -1,0 +1,205 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections.abc import Sequence\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import zarr\n",
+    "from numpy.typing import NDArray\n",
+    "from zarr.storage import FSStore"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from careamics.dataset_ng.patch_extractor import PatchExtractor\n",
+    "from careamics.dataset_ng.patch_extractor.image_stack import ZarrImageStack"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_zarr_array(file_path: Path, data_path: str, data: NDArray):\n",
+    "    store = FSStore(url=file_path.resolve())\n",
+    "    # create array\n",
+    "    array = zarr.create(\n",
+    "        store=store,\n",
+    "        shape=data.shape,\n",
+    "        chunks=data.shape,  # only 1 chunk\n",
+    "        dtype=np.uint16,\n",
+    "        path=data_path,\n",
+    "    )\n",
+    "    # write data\n",
+    "    array[...] = data\n",
+    "    store.close()\n",
+    "\n",
+    "def create_zarr_group(file_path: Path, group_path: str):\n",
+    "    store = FSStore(url=file_path.resolve())\n",
+    "    zarr.open_group(store, path=group_path)\n",
+    "    store.close()\n",
+    "\n",
+    "# def create_zarr(\n",
+    "#     file_path: Path, data_paths: Sequence[str], data: Sequence[NDArray]\n",
+    "# ):\n",
+    "#     store = FSStore(url=file_path.resolve())\n",
+    "#     _ = zarr.open_group(store)\n",
+    "#     store.close()\n",
+    "#     for data_path, array in zip(data_paths, data):\n",
+    "#         for parent_path in Path(data_path).parents[-2::-1]:\n",
+    "#             create_zarr_group(file_path=file_path, group_path=str(parent_path))\n",
+    "#         create_zarr_array(file_path=file_path, data_path=data_path, data=array)\n",
+    "def create_zarr(\n",
+    "    file_path: Path, data_paths: Sequence[str], data: Sequence[NDArray]\n",
+    "):\n",
+    "    for data_path, array in zip(data_paths, data):\n",
+    "        create_zarr_array(file_path=file_path, data_path=data_path, data=array)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dir_path = Path(\"/home/melisande.croft/Documents/Data\")\n",
+    "file_name = \"test_ngff_image.zarr\"\n",
+    "file_path = dir_path / file_name\n",
+    "\n",
+    "data_paths = [\n",
+    "    \"image_1\",\n",
+    "    \"group_1/image_1.1\",\n",
+    "    \"group_1/image_1.2\",\n",
+    "]\n",
+    "data_shapes = [\n",
+    "    (1, 3, 64, 64),\n",
+    "    (1, 3, 32, 48),\n",
+    "    (1, 3, 32, 32)\n",
+    "]\n",
+    "data = [\n",
+    "    np.random.randint(1, 255, size=shape, dtype=np.uint8) for shape in data_shapes\n",
+    "]\n",
+    "create_zarr(file_path, data_paths, data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store = FSStore(url=file_path.resolve(), mode=\"r\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list(store.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zarr.open_group(store)[\"group_1\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def custom_image_stack_loader(store: FSStore, data_paths: Sequence[str], axes=\"str\"):\n",
+    "    image_stacks = [\n",
+    "        ZarrImageStack(store=store, data_path=data_path, axes=axes)\n",
+    "        for data_path in data_paths\n",
+    "    ]\n",
+    "    return image_stacks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_stacks = custom_image_stack_loader(\n",
+    "    store=store, data_paths=data_paths, axes=\"SCYX\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "patch_extractor = PatchExtractor(image_stacks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "patch = patch_extractor.extract_patch(0, 0, (8, 16), (16, 16))\n",
+    "plt.imshow(np.moveaxis(patch, 0, -1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Protocol, TypedDict, Union
+from typing import TypedDict
 
 from numpy.typing import NDArray
 from typing_extensions import Self
@@ -15,16 +15,6 @@ class PatchSpecs(TypedDict):
     sample_idx: int
     coords: Sequence[int]
     patch_size: Sequence[int]
-
-
-class PatchExtractorConstructor(Protocol):
-
-    # TODO: expand Union for new constructors, or just type hint as Any
-    def __call__(
-        self,
-        source: Union[Sequence[NDArray], Sequence[Path]],
-        **kwargs: Any,
-    ) -> "PatchExtractor": ...
 
 
 class PatchExtractor:

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor.py
@@ -1,13 +1,9 @@
 from collections.abc import Sequence
-from pathlib import Path
 from typing import TypedDict
 
 from numpy.typing import NDArray
-from typing_extensions import Self
 
-from careamics.file_io.read import ReadFunc
-
-from .image_stack import ImageStack, InMemoryImageStack, ZarrImageStack
+from .image_stack import ImageStack
 
 
 class PatchSpecs(TypedDict):
@@ -24,62 +20,6 @@ class PatchExtractor:
 
     def __init__(self, image_stacks: Sequence[ImageStack]):
         self.image_stacks: list[ImageStack] = list(image_stacks)
-
-    # TODO: do away with all these constructors
-    #   create ImageStackConstructor protocol
-    #   just have:
-    # @classmethod
-    # def from_image_stack_constructor(
-    #     self,
-    #     constructor: ImageStackConstructor,
-    #     sources: Sequence[SourceTypes],
-    #     **constructor_kwargs,
-    # ) -> Self: ...
-    #
-    # Even though this is a bit abstract users don't interact with this
-    # It will be easier for people who want to write their own ImageStack
-    #   we can pass their ImageStackConstructor to the PatchExtractor
-
-    @classmethod
-    def from_arrays(cls, source: Sequence[NDArray], *, axes: str) -> Self:
-        image_stacks = [
-            InMemoryImageStack.from_array(data=array, axes=axes) for array in source
-        ]
-        return cls(image_stacks=image_stacks)
-
-    # TODO: rename to load_from_tiff_files?
-    #   - to distiguish from possible pointer to files
-    @classmethod
-    def from_tiff_files(cls, source: Sequence[Path], *, axes: str) -> Self:
-        image_stacks = [
-            InMemoryImageStack.from_tiff(path=path, axes=axes) for path in source
-        ]
-        return cls(image_stacks=image_stacks)
-
-    # TODO: similar to tiff - rename to load_from_custom_file_type?
-    @classmethod
-    def from_custom_file_type(
-        cls,
-        source: Sequence[Path],
-        axes: str,
-        read_func: ReadFunc,
-        **read_kwargs,
-    ) -> Self:
-        image_stacks = [
-            InMemoryImageStack.from_custom_file_type(
-                path=path,
-                axes=axes,
-                read_func=read_func,
-                **read_kwargs,
-            )
-            for path in source
-        ]
-        return cls(image_stacks=image_stacks)
-
-    @classmethod
-    def from_ome_zarr_files(cls, source: Sequence[Path]) -> Self:
-        image_stacks = [ZarrImageStack.from_ome_zarr(path) for path in source]
-        return cls(image_stacks=image_stacks)
 
     def extract_patch(
         self,

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
@@ -27,43 +27,24 @@ def get_patch_extractor_constructor(
 
 def create_patch_extractors(
     data_config: DataConfig,
-    train_data: Union[Sequence[NDArray], Sequence[Path]],
-    val_data: Optional[Union[Sequence[NDArray], Sequence[Path]]] = None,
-    train_data_target: Optional[Union[Sequence[NDArray], Sequence[Path]]] = None,
-    val_data_target: Optional[Union[Sequence[NDArray], Sequence[Path]]] = None,
+    data: Union[Sequence[NDArray], Sequence[Path]],
+    target_data: Optional[Union[Sequence[NDArray], Sequence[Path]]] = None,
     **kwargs,
-) -> tuple[
-    PatchExtractor,
-    Optional[PatchExtractor],
-    Optional[PatchExtractor],
-    Optional[PatchExtractor],
-]:
-
+) -> tuple[PatchExtractor, Optional[PatchExtractor]]:
     # get correct constructor
     constructor = get_patch_extractor_constructor(data_config)
 
     # build key word args
     constructor_kwargs = {"axes": data_config.axes, **kwargs}
 
-    # --- train data extractor
-    train_patch_extractor: PatchExtractor = constructor(
-        source=train_data, **constructor_kwargs
-    )
-    # --- additional data extractors
-    additional_patch_extractors: list[Union[PatchExtractor, None]] = []
-    additional_data_sources = [val_data, train_data_target, val_data_target]
-    for data_source in additional_data_sources:
-        if data_source is not None:
-            additional_patch_extractor: Optional[PatchExtractor] = constructor(
-                source=data_source, **constructor_kwargs
-            )
-        else:
-            additional_patch_extractor = None
-        additional_patch_extractors.append(additional_patch_extractor)
+    # --- data extractor
+    patch_extractor: PatchExtractor = constructor(source=data, **constructor_kwargs)
+    # --- optional target extractor
+    if target_data is not None:
+        target_patch_extractor: PatchExtractor = constructor(
+            source=target_data, **constructor_kwargs
+        )
 
-    return (
-        train_patch_extractor,
-        additional_patch_extractors[0],
-        additional_patch_extractors[1],
-        additional_patch_extractors[2],
-    )
+        return patch_extractor, target_patch_extractor
+
+    return patch_extractor, None

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
@@ -149,9 +149,7 @@ def create_patch_extractor(
 def create_patch_extractor(
     source: Any,
     axes: str,
-    data_type: Union[
-        SupportedData, SupportedDataDev
-    ],  # temp union with strin for "zarr"
+    data_type: Union[SupportedData, SupportedDataDev],
     image_stack_loader: Optional[ImageStackLoader[P]] = None,
     *args: P.args,
     **kwargs: P.kwargs,

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
@@ -148,7 +148,7 @@ def create_patch_extractor(
     **kwargs: P.kwargs,
 ) -> PatchExtractor:
     loader = get_image_stack_loader(data_config.data_type, image_stack_loader)
-    image_stacks = loader(source, data_config, *args, **kwargs)
+    image_stacks = loader(data_config, source, *args, **kwargs)
     return PatchExtractor(image_stacks)
 
 

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
@@ -143,7 +143,7 @@ def create_patch_extractor(
 def create_patch_extractor(
     source: Any,
     axes: str,
-    data_type: SupportedData | str,  # temp union with strin for "zarr"
+    data_type: Union[SupportedData, str],  # temp union with strin for "zarr"
     image_stack_loader: Optional[ImageStackLoader[P]] = None,
     *args: P.args,
     **kwargs: P.kwargs,

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
@@ -1,48 +1,184 @@
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional, ParamSpec, overload
 
 from numpy.typing import NDArray
 
 from careamics.config import DataConfig
-from careamics.config.support import SupportedData
-from careamics.dataset_ng.patch_extractor import (
-    PatchExtractor,
-    PatchExtractorConstructor,
-)
+from careamics.dataset_ng.patch_extractor import PatchExtractor
+from careamics.file_io.read import ReadFunc
+
+from .image_stack_loader import ImageStackLoader, get_image_stack_loader
+
+P = ParamSpec("P")
 
 
-def get_patch_extractor_constructor(
+@overload
+def create_patch_extractor(
     data_config: DataConfig,
-) -> PatchExtractorConstructor:
-    if data_config.data_type == SupportedData.ARRAY:
-        return PatchExtractor.from_arrays
-    elif data_config.data_type == SupportedData.TIFF:
-        return PatchExtractor.from_tiff_files
-    elif data_config.data_type == SupportedData.CUSTOM:
-        return PatchExtractor.from_custom_file_type
-    else:
-        raise ValueError(f"Data type {data_config.data_type} is not supported.")
+    source: Sequence[NDArray],
+) -> PatchExtractor:
+    """
+    Create a patch extractor from a sequence of numpy arrays.
+
+    Parameters
+    ----------
+    source: sequence of numpy.ndarray
+        The source arrays of the data.
+    data_config: DataConfig
+        The data configuration, `data_config.data_type` should have the value "array",
+        and `data_config.axes` should describe the axes of every array in the `source`.
+
+    Returns
+    -------
+    PatchExtractor
+    """
 
 
+@overload
+def create_patch_extractor(
+    data_config: DataConfig,
+    source: Sequence[Path],
+) -> PatchExtractor:
+    """
+    Create a patch extractor from a sequence of files that match our supported types.
+
+    Supported file types include TIFF and ZARR.
+
+    If the files are ZARR files they must follow the OME standard. If you have ZARR
+    files that do not follow the OME standard, see documentation on how to create
+    a custom `image_stack_loader`. (TODO: Add link).
+
+    Parameters
+    ----------
+    source: sequence of Path
+        The source files for the data.
+    data_config: DataConfig
+        The data configuration, `data_config.data_type` should have the value "tiff" or
+        "zarr", and `data_config.axes` should describe the axes of every image in the
+        `source`.
+
+    Returns
+    -------
+    PatchExtractor
+    """
+
+
+@overload
+def create_patch_extractor(
+    data_config: DataConfig,
+    source: Any,
+    *,
+    read_func: ReadFunc,
+    read_kwargs: dict[str, Any],
+) -> PatchExtractor:
+    """
+    Create a patch extractor from a sequence of files of a custom type.
+
+    Parameters
+    ----------
+    source: sequence of Path
+        The source files for the data.
+    data_config: DataConfig
+        The data configuration, `data_config.data_type` should have the value "custom".
+    read_func : ReadFunc
+        A function to read the custom file type, see the `ReadFunc` protocol.
+    read_kwargs : dict of {str: Any}
+        Kwargs that will be passed to the custom `read_func`.
+
+    Returns
+    -------
+    PatchExtractor
+    """
+
+
+@overload
+def create_patch_extractor(
+    data_config: DataConfig,
+    source: Any,
+    image_stack_loader: ImageStackLoader[P],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> PatchExtractor:
+    """
+    Create a patch extractor using a custom `ImageStackLoader`.
+
+    The custom image stack loader must follow the `ImageStackLoader` protocol, i.e.
+    it must have the following function signature:
+    ```
+    def image_loader_example(
+        source: Any, data_config: DataConfig, *args, **kwargs
+    ) -> Sequence[ImageStack]:
+    ```
+
+    Parameters
+    ----------
+    source: sequence of Path
+        The source files for the data.
+    data_config: DataConfig
+        The data configuration, `data_config.data_type` should have the value "custom".
+    image_stack_loader: ImageStackLoader
+        A custom image stack loader callable.
+    *args: Any
+        Positional arguments that will be passed to the custom image stack loader.
+    **kwargs: Any
+        Keyword arguments that will be passed to the custom image stack loader.
+
+    Returns
+    -------
+    PatchExtractor
+    """
+
+
+@overload
+def create_patch_extractor(
+    data_config: DataConfig,
+    source: Any,
+    image_stack_loader: Optional[ImageStackLoader[P]] = None,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> PatchExtractor: ...
+
+
+def create_patch_extractor(
+    data_config: DataConfig,
+    source: Any,
+    image_stack_loader: Optional[ImageStackLoader[P]] = None,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> PatchExtractor:
+    loader = get_image_stack_loader(data_config.data_type, image_stack_loader)
+    image_stacks = loader(source, data_config, *args, **kwargs)
+    return PatchExtractor(image_stacks)
+
+
+# TODO: Remove this and just call `create_patch_extractor` within the Dataset class
+# Keeping for consistency for now
 def create_patch_extractors(
     data_config: DataConfig,
-    data: Union[Sequence[NDArray], Sequence[Path]],
-    target_data: Optional[Union[Sequence[NDArray], Sequence[Path]]] = None,
+    source: Any,
+    target_source: Optional[Any] = None,
+    image_stack_loader: Optional[ImageStackLoader] = None,
+    *args,
     **kwargs,
 ) -> tuple[PatchExtractor, Optional[PatchExtractor]]:
-    # get correct constructor
-    constructor = get_patch_extractor_constructor(data_config)
-
-    # build key word args
-    constructor_kwargs = {"axes": data_config.axes, **kwargs}
 
     # --- data extractor
-    patch_extractor: PatchExtractor = constructor(source=data, **constructor_kwargs)
+    patch_extractor: PatchExtractor = create_patch_extractor(
+        data_config,
+        source,
+        image_stack_loader,
+        *args,
+        **kwargs,
+    )
     # --- optional target extractor
-    if target_data is not None:
-        target_patch_extractor: PatchExtractor = constructor(
-            source=target_data, **constructor_kwargs
+    if target_source is not None:
+        target_patch_extractor = create_patch_extractor(
+            data_config,
+            target_source,
+            image_stack_loader,
+            *args,
+            **kwargs,
         )
 
         return patch_extractor, target_patch_extractor

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
@@ -1,8 +1,9 @@
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Optional, ParamSpec, overload
+from typing import Any, Optional, overload
 
 from numpy.typing import NDArray
+from typing_extensions import ParamSpec
 
 from careamics.config import DataConfig
 from careamics.dataset_ng.patch_extractor import PatchExtractor

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
@@ -13,6 +13,8 @@ from .image_stack_loader import ImageStackLoader, get_image_stack_loader
 P = ParamSpec("P")
 
 
+# Define overloads for each implemented ImageStackLoader case
+# Array case
 @overload
 def create_patch_extractor(
     data_config: DataConfig,
@@ -35,6 +37,7 @@ def create_patch_extractor(
     """
 
 
+# TIFF and ZARR case
 @overload
 def create_patch_extractor(
     data_config: DataConfig,
@@ -64,6 +67,7 @@ def create_patch_extractor(
     """
 
 
+# Custom file type case (loaded into memory)
 @overload
 def create_patch_extractor(
     data_config: DataConfig,
@@ -92,6 +96,7 @@ def create_patch_extractor(
     """
 
 
+# Custom ImageStackLoader case
 @overload
 def create_patch_extractor(
     data_config: DataConfig,
@@ -130,6 +135,8 @@ def create_patch_extractor(
     """
 
 
+# final overload to match the implentation function signature
+# Need this so it works later in the code
 @overload
 def create_patch_extractor(
     data_config: DataConfig,
@@ -147,7 +154,11 @@ def create_patch_extractor(
     *args: P.args,
     **kwargs: P.kwargs,
 ) -> PatchExtractor:
-    loader = get_image_stack_loader(data_config.data_type, image_stack_loader)
+    # TODO: Do we need to catch data_config.data_type and source mismatches?
+    #   e.g. data_config.data_type is "array" but source is not Sequence[NDArray]
+    loader: ImageStackLoader[P] = get_image_stack_loader(
+        data_config.data_type, image_stack_loader
+    )
     image_stacks = loader(data_config, source, *args, **kwargs)
     return PatchExtractor(image_stacks)
 

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
@@ -9,7 +9,11 @@ from careamics.config.support import SupportedData
 from careamics.dataset_ng.patch_extractor import PatchExtractor
 from careamics.file_io.read import ReadFunc
 
-from .image_stack_loader import ImageStackLoader, get_image_stack_loader
+from .image_stack_loader import (
+    ImageStackLoader,
+    SupportedDataDev,
+    get_image_stack_loader,
+)
 
 P = ParamSpec("P")
 
@@ -40,7 +44,9 @@ def create_patch_extractor(
 # TIFF and ZARR case
 @overload
 def create_patch_extractor(
-    source: Sequence[Path], axes: str, data_type: Literal[SupportedData.TIFF, "zarr"]
+    source: Sequence[Path],
+    axes: str,
+    data_type: Literal[SupportedData.TIFF, SupportedDataDev.ZARR],
 ) -> PatchExtractor:
     """
     Create a patch extractor from a sequence of files that match our supported types.
@@ -143,7 +149,9 @@ def create_patch_extractor(
 def create_patch_extractor(
     source: Any,
     axes: str,
-    data_type: Union[SupportedData, str],  # temp union with strin for "zarr"
+    data_type: Union[
+        SupportedData, SupportedDataDev
+    ],  # temp union with strin for "zarr"
     image_stack_loader: Optional[ImageStackLoader[P]] = None,
     *args: P.args,
     **kwargs: P.kwargs,
@@ -153,7 +161,7 @@ def create_patch_extractor(
 def create_patch_extractor(
     source: Any,
     axes: str,
-    data_type: Union[SupportedData, str],  # temp union with strin for "zarr"
+    data_type: Union[SupportedData, SupportedDataDev],
     image_stack_loader: Optional[ImageStackLoader[P]] = None,
     *args: P.args,
     **kwargs: P.kwargs,
@@ -171,7 +179,7 @@ def create_patch_extractors(
     source: Any,
     target_source: Optional[Any],
     axes: str,
-    data_type: Union[SupportedData, str],
+    data_type: Union[SupportedData, SupportedDataDev],
     image_stack_loader: Optional[ImageStackLoader] = None,
     *args,
     **kwargs,


### PR DESCRIPTION
## Description

> [!NOTE]  
> **tldr**: A refactor of the `PatchExtractor` construction that should make it easier for advanced users to define their own custom `ImageStacks` and how to load them.

### Background - why do we need this PR?

In the new dataset class we want it to be possible for users to define their own `ImageStacks`; in particular, for custom NGFF formats such as HDF5, CZI and IMS, which require more custom patch reading than simply loading the entire array into memory.

### Overview - what changed?

I removed the `PatchExtractorConstructor` protocol and instead created a protocol that defines a callable that should return a sequence of `ImageStacks`, which will then in turn instantiate the `PatchExtractor`.

I made this change because I thought it would be conceptually clearer for users: if they define their own `ImageStack` class then they also have to define a function to load a series of them.

Now there are three ways that a user can customise loading their own data:
1. Define a custom `ImageStack` _and_ a custom function to load their `ImageStack`s.
2. Define a custom function function to load an existing `ImageStack` implementation, I provide an example of this method below.
3. Define a simple `ReadFunc` that will load all the data in memory as an `InMemoryImageStack`.

### Implementation - how did you implement the changes?

To do this, I removed the `PatchExtractorConstructor` protocol and I also removed all the class constructors from the `PatchExtractor`. I then created the `ImageStackLoader` protocol and converted the old `PatchExtractor` class constructors to `ImageStackLoader` implementations within a new `image_stack_loader.py` file.

An `ImageStackLoader` is a callable that must take the CAREamics `DataConfig` as the first argument and the `source` of the data as the second argument. Additional `*args` and `**kwargs` are allowed, but they should only be used to determine _how_ the data is loaded, not _what_ data is loaded. The `source` argument has to wholly determine _what_ data is loaded, this is because, downstream both an input-source and a target-source have to be specified but they will share `*args` and `**kwargs`.

I then created a new `create_patch_extractor` function with overloads for each of the different cases.

I updated the existing `create_patch_extractors` function, so it could still work with `CAREamicsDataset` class in #420 but maybe it can be removed, see TODO. Note I cherry-picked the commit from #420 that  modified the `create_patch_extractors` so it would be compatible (but I changed the arguments so there will still be conflicts).

## Changes Made

### New features or files

<!-- List new features or files added. -->
- `dataset_ng/patch_extractor/image_stack_loader.py` file
- `ImageStackLoader` protocol class
- A few `ImageStackLoader` implementations
- `create_patch_extractor` function
- Demo notebook `dataset_ng/patch_extractor/demo_custom_image_stack_loader.ipynb` 

### Modified features or files

<!-- List important modified features or files. -->
- `PatchExtractor` class (removed constructors)
- `create_patch_extractors` function

### Removed features or files

<!-- List removed features or files. -->
- `PatchExtractorConstructor` protocol class
- `get_patch_extractor_constructor` function

## How has this been tested?

So far tested in the demo notebook. But I also plan to add some tests for the existing image stack loader functions.

## Related Issues

- Resolves #424 

## Breaking changes

Interacts with #420 and will cause some small conflicts with calling `create_patch_extractors`.

## Additional Notes and Examples

This is the example that I tested in the provide demo notebook. It is intended for loading non-OME Zarrs that are all contained within one Zarr file. I also included this example in the docstring of `ImageStackLoader`.

```python
class ZarrSource(TypedDict):
    store: FSStore
    data_paths: Sequence[str]

def custom_image_stack_loader(
    data_config: DataConfig, source: ZarrSource, *args, **kwargs
) -> list[ZarrImageStack]:
    axes = data_config.axes
    image_stacks = [
        ZarrImageStack(store=source["store"], data_path=data_path, axes=axes)
        for data_path in source["data_paths"]
    ]
    return image_stacks
```
This can then initialise a `PatchExtractor` with the following
```python
patch_extractor = create_patch_extractor(
    data_config=data_config,
    source={"store": store, "data_paths":data_paths},
    image_stack_loader=custom_image_stack_loader,
)
```
See the notebook to test it out!

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)