### PR TITLE
feat: Next-Gen Dataset - Uniform data configuration

### DIFF
--- a/src/careamics/config/__init__.py
+++ b/src/careamics/config/__init__.py
@@ -10,7 +10,6 @@ __all__ = [
     "CAREAlgorithm",
     "CheckpointModel",
     "Configuration",
-    "DataConfig",
     "GaussianMixtureNMConfig",
     "InferenceConfig",
     "LVAELossConfig",
@@ -18,6 +17,7 @@ __all__ = [
     "N2NAlgorithm",
     "N2VAlgorithm",
     "TrainingConfig",
+    "TrainingDataConfig",
     "UNetBasedAlgorithm",
     "VAEBasedAlgorithm",
     "algorithm_factory",
@@ -44,7 +44,7 @@ from .configuration_factories import (
     create_n2v_configuration,
 )
 from .configuration_io import load_configuration, save_configuration
-from .data import DataConfig
+from .data import TrainingDataConfig
 from .inference_model import InferenceConfig
 from .loss_model import LVAELossConfig
 from .nm_model import GaussianMixtureNMConfig, MultiChannelNMConfig

--- a/src/careamics/config/configuration.py
+++ b/src/careamics/config/configuration.py
@@ -15,7 +15,7 @@ from careamics.config.algorithms import (
     N2NAlgorithm,
     N2VAlgorithm,
 )
-from careamics.config.data import DataConfig
+from careamics.config.data import TrainingDataConfig
 from careamics.config.training_model import TrainingConfig
 
 ALGORITHMS = Union[
@@ -137,7 +137,7 @@ class Configuration(BaseModel):
     """Algorithm configuration, holding all parameters required to configure the
     model."""
 
-    data_config: DataConfig
+    data_config: TrainingDataConfig
     """Data configuration, holding all parameters required to configure the training
     data loader."""
 
@@ -212,6 +212,7 @@ class Configuration(BaseModel):
         """
         return pformat(self.model_dump())
 
+    # TODO unused? remove?
     def set_3D(self, is_3D: bool, axes: str, patch_size: list[int]) -> None:
         """
         Set 3D flag and axes.

--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -6,7 +6,7 @@ from pydantic import Field, TypeAdapter
 
 from careamics.config.algorithms import CAREAlgorithm, N2NAlgorithm, N2VAlgorithm
 from careamics.config.architectures import UNetModel
-from careamics.config.data import DataConfig
+from careamics.config.data import TrainingDataConfig
 from careamics.config.support import (
     SupportedArchitecture,
     SupportedPixelManipulation,
@@ -206,7 +206,7 @@ def _create_data_configuration(
     augmentations: Union[list[SPATIAL_TRANSFORMS_UNION]],
     train_dataloader_params: Optional[dict[str, Any]] = None,
     val_dataloader_params: Optional[dict[str, Any]] = None,
-) -> DataConfig:
+) -> TrainingDataConfig:
     """
     Create a dictionary with the parameters of the data model.
 
@@ -251,7 +251,7 @@ def _create_data_configuration(
     if val_dataloader_params is not None:
         data["val_dataloader_params"] = val_dataloader_params
 
-    return DataConfig(**data)
+    return TrainingDataConfig(**data)
 
 
 def _create_training_configuration(

--- a/src/careamics/config/data/__init__.py
+++ b/src/careamics/config/data/__init__.py
@@ -2,6 +2,10 @@
 
 __all__ = [
     "DataConfig",
+    "PredictionDataConfig",
+    "TrainingDataConfig",
 ]
 
-from .data_model import DataConfig
+from .general_data_model import DataConfig
+from .prediction_data_model import PredictionDataConfig
+from .training_data_model import TrainingDataConfig

--- a/src/careamics/config/data/general_data_model.py
+++ b/src/careamics/config/data/general_data_model.py
@@ -105,10 +105,10 @@ class DataConfig(BaseModel):
     patch_size: Optional[Union[list[int]]] = Field(
         default=None, min_length=2, max_length=3
     )
-    """Patch size, as used during training."""
+    """Patch size."""
 
     batch_size: int = Field(default=1, ge=1, validate_default=True)
-    """Batch size for training."""
+    """Batch size."""
 
     # Optional fields
     image_means: Optional[list[Float]] = Field(
@@ -122,13 +122,14 @@ class DataConfig(BaseModel):
     target_means: Optional[list[Float]] = Field(
         default=None, min_length=0, max_length=32
     )
-    """Means of the target data across channels, used for normalization."""
+    """Means of the target data across channels, used for normalization during
+    training."""
 
     target_stds: Optional[list[Float]] = Field(
         default=None, min_length=0, max_length=32
     )
     """Standard deviations of the target data across channels, used for
-    normalization."""
+    normalization during training."""
 
     transforms: Sequence[Union[XYFlipModel, XYRandomRotate90Model]] = Field(
         default=[],
@@ -147,7 +148,7 @@ class DataConfig(BaseModel):
     """Random seed for reproducibility."""
 
     patch_overlap: Optional[list[int]] = Field(default=None, min_length=2, max_length=3)
-    """Overlap between patches, only used at inference time."""
+    """Overlap between patches, only used during prediction."""
 
     @field_validator("axes")
     @classmethod

--- a/src/careamics/config/data/general_data_model.py
+++ b/src/careamics/config/data/general_data_model.py
@@ -147,7 +147,9 @@ class DataConfig(BaseModel):
     random_seed: Optional[int] = Field(default=None, ge=0)
     """Random seed for reproducibility."""
 
-    patch_overlap: Optional[list[int]] = Field(default=None, min_length=2, max_length=3)
+    patch_overlaps: Optional[list[int]] = Field(
+        default=None, min_length=2, max_length=3
+    )
     """Overlap between patches, only used during prediction."""
 
     @field_validator("axes")
@@ -261,3 +263,16 @@ class DataConfig(BaseModel):
             Patch size.
         """
         self._update(axes=axes, patch_size=patch_size)
+
+    def is_tiled(self) -> bool:
+        """
+        Check if the data should be tiled.
+
+        Data should be tiled if both `patch_size` and `patch_overlaps` are not None.
+
+        Returns
+        -------
+        bool
+            True if the data should be tiled, False otherwise.
+        """
+        return self.patch_size is not None and self.patch_overlaps is not None

--- a/src/careamics/config/data/prediction_data_model.py
+++ b/src/careamics/config/data/prediction_data_model.py
@@ -1,0 +1,55 @@
+"""Prediction data configuration."""
+
+from typing import Any, Optional, Union
+
+from pydantic import Field
+
+from .general_data_model import DataConfig
+
+
+class PredictionDataConfig(DataConfig):
+    """Prediction data configuration.
+
+    The following parameters defined in the parent `DataConfig` are aliased:
+    - `path_size` -> `tile_size`
+    - `patch_overlap` -> `tile_overlap`
+    - `train_dataloader_params` -> `dataloader_params`
+
+    The aliases should be used to pass the parameters to the model.
+
+    As opposed to `DataConfig`, the `val_dataloader_params` is set to `None` by default.
+    Likewise, `patche_size` (`tile_size`) and `patch_overlap` (`tile_overlap`) can be
+    `None` to predict on the entire image at once.
+
+    Examples
+    --------
+    Minimum example:
+
+    >>> data = PredictionDataConfig(
+    ...     data_type="array", # defined in SupportedData
+    ...     batch_size=4,
+    ...     axes="YX"
+    ... )
+
+    """
+
+    patch_size: Optional[Union[list[int]]] = Field(
+        default=None, min_length=2, max_length=3, alias="tile_size"
+    )
+    """Tile size used during prediction. If `None`, the entire image is predicted at
+    once."""
+
+    patch_overlap: Optional[Union[list[int]]] = Field(
+        default=[48, 48], min_length=2, max_length=3, alias="tile_overlap"
+    )
+    """Overlap between tiles during prediction."""
+
+    train_dataloader_params: dict[str, Any] = Field(
+        default={}, validate_default=True, alias="dataloader_params"
+    )
+    """Dictionary of PyTorch prediction dataloader parameters."""
+
+    val_dataloader_params: Optional[dict[str, Any]] = Field(default=None)
+    """This parameter is unused during prediction."""
+
+    # TODO: validate length patch size and patch overlap vs axes

--- a/src/careamics/config/data/prediction_data_model.py
+++ b/src/careamics/config/data/prediction_data_model.py
@@ -46,6 +46,7 @@ class PredictionDataConfig(DataConfig):
     )
     """Overlap between tiles during prediction."""
 
+    # TODO: should we enforce `suffle=False` for prediction? does it matter?
     train_dataloader_params: dict[str, Any] = Field(
         default={}, validate_default=True, alias="dataloader_params"
     )

--- a/src/careamics/config/data/prediction_data_model.py
+++ b/src/careamics/config/data/prediction_data_model.py
@@ -41,8 +41,8 @@ class PredictionDataConfig(DataConfig):
     """Tile size used during prediction. If `None`, the entire image is predicted at
     once."""
 
-    patch_overlap: Optional[Union[list[int]]] = Field(
-        default=[48, 48], min_length=2, max_length=3, alias="tile_overlap"
+    patch_overlaps: Optional[Union[list[int]]] = Field(
+        default=[48, 48], min_length=2, max_length=3, alias="tile_overlaps"
     )
     """Overlap between tiles during prediction."""
 

--- a/src/careamics/config/data/prediction_data_model.py
+++ b/src/careamics/config/data/prediction_data_model.py
@@ -21,6 +21,8 @@ class PredictionDataConfig(DataConfig):
     Likewise, `patche_size` (`tile_size`) and `patch_overlap` (`tile_overlap`) can be
     `None` to predict on the entire image at once.
 
+    If `transforms` are provided, then they are used as test-time augmentations (TTA).
+
     Examples
     --------
     Minimum example:

--- a/src/careamics/config/data/training_data_model.py
+++ b/src/careamics/config/data/training_data_model.py
@@ -1,0 +1,225 @@
+"""Data configuration."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Union
+from warnings import warn
+
+from pydantic import (
+    Field,
+    field_validator,
+    model_validator,
+)
+from typing_extensions import Self
+
+from ..transformations import XYFlipModel, XYRandomRotate90Model
+from ..validators import patch_size_ge_than_8_power_of_2
+from .general_data_model import DataConfig
+
+
+class TrainingDataConfig(DataConfig):
+    """Training data configuration.
+
+    If std is specified, mean must be specified as well. Note that setting the std first
+    and then the mean (if they were both `None` before) will raise a validation error.
+    Prefer instead `set_mean_and_std` to set both at once. Means and stds are expected
+    to be lists of floats, one for each channel. For supervised tasks, the mean and std
+    of the target could be different from the input data.
+
+    All supported transforms are defined in the SupportedTransform enum.
+
+    Examples
+    --------
+    Minimum example:
+
+    >>> data = DataConfig(
+    ...     data_type="array", # defined in SupportedData
+    ...     patch_size=[128, 128],
+    ...     batch_size=4,
+    ...     axes="YX"
+    ... )
+
+    To change the image_means and image_stds of the data:
+    >>> data.set_means_and_stds(image_means=[214.3], image_stds=[84.5])
+
+    One can pass also a list of transformations, by keyword, using the
+    SupportedTransform value:
+    >>> from careamics.config.support import SupportedTransform
+    >>> data = DataConfig(
+    ...     data_type="tiff",
+    ...     patch_size=[128, 128],
+    ...     batch_size=4,
+    ...     axes="YX",
+    ...     transforms=[
+    ...         {
+    ...             "name": "XYFlip",
+    ...         }
+    ...     ]
+    ... )
+    """
+
+    patch_size: Union[list[int]] = Field(..., min_length=2, max_length=3)
+    """Patch size, as used during training."""
+
+    transforms: Sequence[Union[XYFlipModel, XYRandomRotate90Model]] = Field(
+        default=[
+            XYFlipModel(),
+            XYRandomRotate90Model(),
+        ],
+        validate_default=True,
+    )
+    """List of transformations to apply to the data, available transforms are defined
+    in SupportedTransform."""
+
+    train_dataloader_params: dict[str, Any] = Field(
+        default={"shuffle": True}, validate_default=True
+    )
+    """Dictionary of PyTorch training dataloader parameters. The dataloader parameters,
+    should include the `shuffle` key, which is set to `True` by default. We strongly
+    recommend to keep it as `True` to ensure the best training results."""
+
+    @field_validator("patch_size")
+    @classmethod
+    def all_elements_power_of_2_minimum_8(
+        cls, patch_list: Union[list[int]]
+    ) -> Union[list[int]]:
+        """
+        Validate patch size.
+
+        Patch size must be powers of 2 and minimum 8.
+
+        Parameters
+        ----------
+        patch_list : list of int
+            Patch size.
+
+        Returns
+        -------
+        list of int
+            Validated patch size.
+
+        Raises
+        ------
+        ValueError
+            If the patch size is smaller than 8.
+        ValueError
+            If the patch size is not a power of 2.
+        """
+        patch_size_ge_than_8_power_of_2(patch_list)
+
+        return patch_list
+
+    @field_validator("train_dataloader_params")
+    @classmethod
+    def shuffle_train_dataloader(
+        cls, train_dataloader_params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """
+        Validate that "shuffle" is included in the training dataloader params.
+
+        A warning will be raised if `shuffle=False`.
+
+        Parameters
+        ----------
+        train_dataloader_params : dict of {str: Any}
+            The training dataloader parameters.
+
+        Returns
+        -------
+        dict of {str: Any}
+            The validated training dataloader parameters.
+
+        Raises
+        ------
+        ValueError
+            If "shuffle" is not included in the training dataloader params.
+        """
+        if "shuffle" not in train_dataloader_params:
+            raise ValueError(
+                "Value for 'shuffle' was not included in the `train_dataloader_params`."
+            )
+        elif ("shuffle" in train_dataloader_params) and (
+            not train_dataloader_params["shuffle"]
+        ):
+            warn(
+                "Dataloader parameters include `shuffle=False`, this will be passed to "
+                "the training dataloader and may lead to lower quality results.",
+                stacklevel=1,
+            )
+        return train_dataloader_params
+
+    @model_validator(mode="after")
+    def std_only_with_mean(self: Self) -> Self:
+        """
+        Check that mean and std are either both None, or both specified.
+
+        Returns
+        -------
+        Self
+            Validated data model.
+
+        Raises
+        ------
+        ValueError
+            If std is not None and mean is None.
+        """
+        # check that mean and std are either both None, or both specified
+        if (self.image_means and not self.image_stds) or (
+            self.image_stds and not self.image_means
+        ):
+            raise ValueError(
+                "Mean and std must be either both None, or both specified."
+            )
+
+        elif (self.image_means is not None and self.image_stds is not None) and (
+            len(self.image_means) != len(self.image_stds)
+        ):
+            raise ValueError("Mean and std must be specified for each input channel.")
+
+        if (self.target_means and not self.target_stds) or (
+            self.target_stds and not self.target_means
+        ):
+            raise ValueError(
+                "Mean and std must be either both None, or both specified "
+            )
+
+        elif self.target_means is not None and self.target_stds is not None:
+            if len(self.target_means) != len(self.target_stds):
+                raise ValueError(
+                    "Mean and std must be either both None, or both specified for each "
+                    "target channel."
+                )
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_dimensions(self: Self) -> Self:
+        """
+        Validate 2D/3D dimensions between axes and patch size.
+
+        Returns
+        -------
+        Self
+            Validated data model.
+
+        Raises
+        ------
+        ValueError
+            If the transforms are not valid.
+        """
+        if "Z" in self.axes:
+            if len(self.patch_size) != 3:
+                raise ValueError(
+                    f"Patch size must have 3 dimensions if the data is 3D "
+                    f"({self.axes})."
+                )
+
+        else:
+            if len(self.patch_size) != 2:
+                raise ValueError(
+                    f"Patch size must have 3 dimensions if the data is 3D "
+                    f"({self.axes})."
+                )
+
+        return self

--- a/src/careamics/config/data/training_data_model.py
+++ b/src/careamics/config/data/training_data_model.py
@@ -60,7 +60,7 @@ class TrainingDataConfig(DataConfig):
     """
 
     patch_size: Union[list[int]] = Field(..., min_length=2, max_length=3)
-    """Patch size, as used during training."""
+    """Patch size used during training."""
 
     transforms: Sequence[Union[XYFlipModel, XYRandomRotate90Model]] = Field(
         default=[

--- a/src/careamics/config/data/training_data_model.py
+++ b/src/careamics/config/data/training_data_model.py
@@ -206,7 +206,7 @@ class TrainingDataConfig(DataConfig):
         Raises
         ------
         ValueError
-            If the transforms are not valid.
+            If the patch size does not match axes.
         """
         if "Z" in self.axes:
             if len(self.patch_size) != 3:

--- a/src/careamics/dataset/dataset_utils/iterate_over_files.py
+++ b/src/careamics/dataset/dataset_utils/iterate_over_files.py
@@ -9,7 +9,7 @@ from typing import Callable, Optional, Union
 from numpy.typing import NDArray
 from torch.utils.data import get_worker_info
 
-from careamics.config import DataConfig, InferenceConfig
+from careamics.config import InferenceConfig, TrainingDataConfig
 from careamics.file_io.read import read_tiff
 from careamics.utils.logging import get_logger
 
@@ -19,7 +19,7 @@ logger = get_logger(__name__)
 
 
 def iterate_over_files(
-    data_config: Union[DataConfig, InferenceConfig],
+    data_config: Union[TrainingDataConfig, InferenceConfig],
     data_files: list[Path],
     target_files: Optional[list[Path]] = None,
     read_source_func: Callable = read_tiff,

--- a/src/careamics/dataset/in_memory_dataset.py
+++ b/src/careamics/dataset/in_memory_dataset.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Optional, Union
 import numpy as np
 from torch.utils.data import Dataset
 
-from careamics.config import DataConfig
+from careamics.config import TrainingDataConfig
 from careamics.config.transformations import NormalizeModel
 from careamics.dataset.patching.patching import (
     PatchedOutput,
@@ -46,7 +46,7 @@ class InMemoryDataset(Dataset):
 
     def __init__(
         self,
-        data_config: DataConfig,
+        data_config: TrainingDataConfig,
         inputs: Union[np.ndarray, list[Path]],
         input_target: Optional[Union[np.ndarray, list[Path]]] = None,
         read_source_func: Callable = read_tiff,

--- a/src/careamics/dataset/iterable_dataset.py
+++ b/src/careamics/dataset/iterable_dataset.py
@@ -10,7 +10,7 @@ from typing import Callable, Optional
 import numpy as np
 from torch.utils.data import IterableDataset
 
-from careamics.config import DataConfig
+from careamics.config import TrainingDataConfig
 from careamics.config.transformations import NormalizeModel
 from careamics.file_io.read import read_tiff
 from careamics.transforms import Compose
@@ -49,7 +49,7 @@ class PathIterableDataset(IterableDataset):
 
     def __init__(
         self,
-        data_config: DataConfig,
+        data_config: TrainingDataConfig,
         src_files: list[Path],
         target_files: Optional[list[Path]] = None,
         read_source_func: Callable = read_tiff,

--- a/src/careamics/dataset_ng/dataset/dataset.py
+++ b/src/careamics/dataset_ng/dataset/dataset.py
@@ -91,7 +91,7 @@ class CareamicsDataset(Dataset):
         patching_strategy: PatchingStrategy
         if self.mode == Mode.TRAINING:
             if not isinstance(self.config, TrainingDataConfig):
-                raise ValueError("Inference config cannot be used for training.")
+                raise ValueError("Prediction config cannot be used for training.")
 
             patching_strategy = RandomPatchingStrategy(
                 data_shapes=self.input_extractor.shape,
@@ -100,7 +100,7 @@ class CareamicsDataset(Dataset):
             )
         elif self.mode == Mode.VALIDATING:
             if not isinstance(self.config, TrainingDataConfig):
-                raise ValueError("Inference config cannot be used for validating.")
+                raise ValueError("Prediction config cannot be used for validating.")
 
             patching_strategy = FixedRandomPatchingStrategy(
                 data_shapes=self.input_extractor.shape,

--- a/src/careamics/dataset_ng/demo_dataset.ipynb
+++ b/src/careamics/dataset_ng/demo_dataset.ipynb
@@ -56,25 +56,42 @@
    "outputs": [],
    "source": [
     "# 1. Train val from an array\n",
+    "from careamics.config.data.training_data_model import TrainingDataConfig\n",
     "\n",
-    "train_data_config = create_n2n_configuration(\n",
-    "    \"test_exp\",\n",
+    "# train_data_config = create_n2n_configuration(\n",
+    "#     \"test_exp\",\n",
+    "#     data_type=\"array\",\n",
+    "#     axes=\"YX\",\n",
+    "#     patch_size=(32, 32),\n",
+    "#     batch_size=1,\n",
+    "#     num_epochs=1,\n",
+    "# ).data_config\n",
+    "\n",
+    "# val_data_config = create_n2n_configuration(\n",
+    "#     \"test_exp\",\n",
+    "#     data_type=\"array\",\n",
+    "#     axes=\"YX\",\n",
+    "#     patch_size=(32, 32),\n",
+    "#     batch_size=1,\n",
+    "#     num_epochs=1,\n",
+    "#     augmentations=[],\n",
+    "# ).data_config\n",
+    "\n",
+    "train_data_config = TrainingDataConfig(\n",
     "    data_type=\"array\",\n",
     "    axes=\"YX\",\n",
     "    patch_size=(32, 32),\n",
     "    batch_size=1,\n",
     "    num_epochs=1,\n",
-    ").data_config\n",
-    "\n",
-    "val_data_config = create_n2n_configuration(\n",
-    "    \"test_exp\",\n",
+    ")\n",
+    "val_data_config = TrainingDataConfig(\n",
     "    data_type=\"array\",\n",
     "    axes=\"YX\",\n",
     "    patch_size=(32, 32),\n",
     "    batch_size=1,\n",
     "    num_epochs=1,\n",
     "    augmentations=[],\n",
-    ").data_config\n",
+    ")\n",
     "\n",
     "\n",
     "train_dataset = CareamicsDataset(\n",
@@ -100,8 +117,53 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create dataset for prediction\n",
+    "from careamics.config.data.prediction_data_model import PredictionDataConfig\n",
+    "\n",
+    "prediction_data_config = PredictionDataConfig(\n",
+    "    data_type=\"array\",\n",
+    "    axes=\"YX\",\n",
+    "    batch_size=1,\n",
+    ")\n",
+    "\n",
+    "prediction_dataset = CareamicsDataset(\n",
+    "    data_config=prediction_data_config,\n",
+    "    mode=Mode.PREDICTING,\n",
+    "    inputs=[example_data],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prediction_data_config = PredictionDataConfig(\n",
+    "    data_type=\"array\",\n",
+    "    axes=\"YX\",\n",
+    "    tile_size=(32, 32),\n",
+    "    tile_overlap=(16, 16),\n",
+    "    batch_size=1,\n",
+    ")\n",
+    "\n",
+    "prediction_dataset = CareamicsDataset(\n",
+    "    data_config=prediction_data_config,\n",
+    "    mode=Mode.PREDICTING,\n",
+    "    inputs=[example_data],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
    "metadata": {},
    "source": [
     "### 2. From tiff "
@@ -110,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +220,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "8",
    "metadata": {},
    "source": [
     "### 3. Prediction from array"
@@ -167,7 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +258,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "source": [
     "### 4. From custom data type "
@@ -205,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -263,7 +325,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/src/careamics/dataset_ng/demo_dataset.ipynb
+++ b/src/careamics/dataset_ng/demo_dataset.ipynb
@@ -150,7 +150,7 @@
     "    data_type=\"array\",\n",
     "    axes=\"YX\",\n",
     "    tile_size=(32, 32),\n",
-    "    tile_overlap=(16, 16),\n",
+    "    tile_overlaps=(16, 16),\n",
     "    batch_size=1,\n",
     ")\n",
     "\n",

--- a/src/careamics/dataset_ng/patch_extractor/demo_custom_image_stack_loader.py
+++ b/src/careamics/dataset_ng/patch_extractor/demo_custom_image_stack_loader.py
@@ -9,7 +9,7 @@ import zarr
 from numpy.typing import NDArray
 from zarr.storage import FSStore
 
-from careamics.config import DataConfig
+from careamics.config import TrainingDataConfig
 from careamics.config.support import SupportedData
 from careamics.dataset_ng.patch_extractor import create_patch_extractor
 from careamics.dataset_ng.patch_extractor.image_stack import ZarrImageStack
@@ -87,7 +87,7 @@ def custom_image_stack_loader(source: ZarrSource, axes: str, *args, **kwargs):
 
 # %%
 # dummy data config
-data_config = DataConfig(data_type="custom", patch_size=[64, 64], axes="SCYX")
+data_config = TrainingDataConfig(data_type="custom", patch_size=[64, 64], axes="SCYX")
 
 # %%
 image_stack_loader: ImageStackLoader = custom_image_stack_loader

--- a/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack_loader.py
@@ -49,7 +49,7 @@ class ImageStackLoader(Protocol[P]):
 
     >>> from zarr.storage import FSStore
 
-    >>> from careamics.config import DataConfig
+    >>> from careamics.config import TrainingDataConfig
     >>> from careamics.dataset_ng.patch_extractor.image_stack import ZarrImageStack
 
     >>> # Define a zarr source

--- a/src/careamics/lightning/train_data_module.py
+++ b/src/careamics/lightning/train_data_module.py
@@ -8,7 +8,7 @@ import pytorch_lightning as L
 from numpy.typing import NDArray
 from torch.utils.data import DataLoader, IterableDataset
 
-from careamics.config.data import DataConfig
+from careamics.config.data import TrainingDataConfig
 from careamics.config.support import SupportedData
 from careamics.config.transformations import TransformModel
 from careamics.dataset.dataset_utils import (
@@ -118,7 +118,7 @@ class TrainDataModule(L.LightningDataModule):
 
     def __init__(
         self,
-        data_config: DataConfig,
+        data_config: TrainingDataConfig,
         train_data: Union[Path, str, NDArray],
         val_data: Optional[Union[Path, str, NDArray]] = None,
         train_data_target: Optional[Union[Path, str, NDArray]] = None,
@@ -218,7 +218,7 @@ class TrainDataModule(L.LightningDataModule):
             )
 
         # configuration
-        self.data_config: DataConfig = data_config
+        self.data_config: TrainingDataConfig = data_config
         self.data_type: str = data_config.data_type
         self.batch_size: int = data_config.batch_size
         self.use_in_memory: bool = use_in_memory
@@ -633,7 +633,7 @@ def create_train_datamodule(
         data_dict["transforms"] = transforms
 
     # instantiate data configuration
-    data_config = DataConfig(**data_dict)
+    data_config = TrainingDataConfig(**data_dict)
 
     # sanity check on the dataloader parameters
     if "batch_size" in dataloader_params:

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -28,14 +28,14 @@ from bioimageio.spec.model.v0_5 import (
     WeightsDescr,
 )
 
-from careamics.config import Configuration, DataConfig
+from careamics.config import Configuration, TrainingDataConfig
 
 from ._readme_factory import readme_factory
 
 
 def _create_axes(
     array: np.ndarray,
-    data_config: DataConfig,
+    data_config: TrainingDataConfig,
     channel_names: Optional[list[str]] = None,
     is_input: bool = True,
 ) -> list[AxisBase]:
@@ -102,7 +102,7 @@ def _create_axes(
 def _create_inputs_ouputs(
     input_array: np.ndarray,
     output_array: np.ndarray,
-    data_config: DataConfig,
+    data_config: TrainingDataConfig,
     input_path: Union[Path, str],
     output_path: Union[Path, str],
     channel_names: Optional[list[str]] = None,

--- a/tests/config/data/test_data_model.py
+++ b/tests/config/data/test_data_model.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import yaml
 
-from careamics.config.data.data_model import DataConfig
+from careamics.config.data.training_data_model import TrainingDataConfig
 from careamics.config.support import (
     SupportedTransform,
 )
@@ -17,7 +17,7 @@ def test_wrong_extensions(minimum_data: dict, ext: str):
 
     # instantiate DataModel model
     with pytest.raises(ValueError):
-        DataConfig(**minimum_data)
+        TrainingDataConfig(**minimum_data)
 
 
 @pytest.mark.parametrize("mean, std", [(0, 124.5), (12.6, 0.1)])
@@ -28,7 +28,7 @@ def test_mean_std_non_negative(minimum_data: dict, mean, std):
     minimum_data["target_means"] = [mean]
     minimum_data["target_stds"] = [std]
 
-    data_model = DataConfig(**minimum_data)
+    data_model = TrainingDataConfig(**minimum_data)
     assert data_model.image_means == [mean]
     assert data_model.image_stds == [std]
     assert data_model.target_means == [mean]
@@ -38,28 +38,28 @@ def test_mean_std_non_negative(minimum_data: dict, mean, std):
 def test_mean_std_both_specified_or_none(minimum_data: dict):
     """Test an error is raised if std is specified but mean is None."""
     # No error if both are None
-    DataConfig(**minimum_data)
+    TrainingDataConfig(**minimum_data)
 
     # Error if only mean is defined
     minimum_data["image_means"] = [10.4]
     with pytest.raises(ValueError):
-        DataConfig(**minimum_data)
+        TrainingDataConfig(**minimum_data)
 
     # Error if only std is defined
     minimum_data.pop("image_means")
     minimum_data["image_stds"] = [10.4]
     with pytest.raises(ValueError):
-        DataConfig(**minimum_data)
+        TrainingDataConfig(**minimum_data)
 
     # No error if both are specified
     minimum_data["image_means"] = [10.4]
     minimum_data["image_stds"] = [10.4]
-    DataConfig(**minimum_data)
+    TrainingDataConfig(**minimum_data)
 
     # Error if target mean is defined but target std is None
     minimum_data["target_stds"] = [10.4, 11]
     with pytest.raises(ValueError):
-        DataConfig(**minimum_data)
+        TrainingDataConfig(**minimum_data)
 
 
 def test_set_mean_and_std(minimum_data: dict):
@@ -67,7 +67,7 @@ def test_set_mean_and_std(minimum_data: dict):
     # they can be set both, when they None
     mean = [4.07]
     std = [14.07]
-    data = DataConfig(**minimum_data)
+    data = TrainingDataConfig(**minimum_data)
     data.set_means_and_stds(mean, std)
     assert data.image_means == mean
     assert data.image_stds == std
@@ -88,19 +88,19 @@ def test_normalize_not_accepted(minimum_data: dict):
     ]
 
     with pytest.raises(ValueError):
-        DataConfig(**minimum_data)
+        TrainingDataConfig(**minimum_data)
 
 
 def test_patch_size(minimum_data: dict):
     """Test that non-zero even patch size are accepted."""
     # 2D
-    data_model = DataConfig(**minimum_data)
+    data_model = TrainingDataConfig(**minimum_data)
 
     # 3D
     minimum_data["patch_size"] = [16, 8, 8]
     minimum_data["axes"] = "ZYX"
 
-    data_model = DataConfig(**minimum_data)
+    data_model = TrainingDataConfig(**minimum_data)
     assert data_model.patch_size == minimum_data["patch_size"]
 
 
@@ -113,12 +113,12 @@ def test_wrong_patch_size(minimum_data: dict, patch_size):
     minimum_data["patch_size"] = patch_size
 
     with pytest.raises(ValueError):
-        DataConfig(**minimum_data)
+        TrainingDataConfig(**minimum_data)
 
 
 def test_set_3d(minimum_data: dict):
     """Test that 3D can be set."""
-    data = DataConfig(**minimum_data)
+    data = TrainingDataConfig(**minimum_data)
     assert "Z" not in data.axes
     assert len(data.patch_size) == 2
 
@@ -127,12 +127,12 @@ def test_set_3d(minimum_data: dict):
         data.axes = "ZYX"
 
     # or patch size
-    data = DataConfig(**minimum_data)
+    data = TrainingDataConfig(**minimum_data)
     with pytest.raises(ValueError):
         data.patch_size = [64, 64, 64]
 
     # set 3D
-    data = DataConfig(**minimum_data)
+    data = TrainingDataConfig(**minimum_data)
     data.set_3D("ZYX", [64, 64, 64])
     assert "Z" in data.axes
     assert len(data.patch_size) == 3
@@ -141,7 +141,7 @@ def test_set_3d(minimum_data: dict):
 def test_passing_empty_transforms(minimum_data: dict):
     """Test that empty list of transforms can be passed."""
     minimum_data["transforms"] = []
-    DataConfig(**minimum_data)
+    TrainingDataConfig(**minimum_data)
 
 
 def test_passing_incorrect_element(minimum_data: dict):
@@ -151,7 +151,7 @@ def test_passing_incorrect_element(minimum_data: dict):
         {"name": get_all_transforms()[SupportedTransform.XY_FLIP.value]()},
     ]
     with pytest.raises(ValueError):
-        DataConfig(**minimum_data)
+        TrainingDataConfig(**minimum_data)
 
 
 def test_no_shuffle_in_train_dataloader_params(minimum_data: dict):
@@ -161,13 +161,13 @@ def test_no_shuffle_in_train_dataloader_params(minimum_data: dict):
     """
     minimum_data["train_dataloader_params"] = {"num_workers": 4}
     with pytest.raises(ValueError):
-        DataConfig(**minimum_data)
+        TrainingDataConfig(**minimum_data)
 
 
 def test_export_to_yaml_float32_stats(tmp_path, minimum_data: dict):
     """Test exporting and loading the pydantic model when the statistics are
     np.float32."""
-    data = DataConfig(**minimum_data)
+    data = TrainingDataConfig(**minimum_data)
 
     # set np.float32 stats values
     data.set_means_and_stds([np.float32(1234.5678)], [np.float32(21.73)])
@@ -180,5 +180,5 @@ def test_export_to_yaml_float32_stats(tmp_path, minimum_data: dict):
 
     # load model
     dictionary = yaml.load(config_path.open("r"), Loader=yaml.SafeLoader)
-    read_data = DataConfig(**dictionary)
+    read_data = TrainingDataConfig(**dictionary)
     assert read_data.model_dump() == data.model_dump()

--- a/tests/dataset/test_in_memory_dataset.py
+++ b/tests/dataset/test_in_memory_dataset.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import tifffile
 
-from careamics.config import DataConfig
+from careamics.config import TrainingDataConfig
 from careamics.config.support import SupportedData
 from careamics.dataset import InMemoryDataset
 
@@ -18,7 +18,7 @@ def test_number_of_patches(ordered_array):
         "patch_size": [8, 8],
         "axes": "YX",
     }
-    config = DataConfig(**config_dict)
+    config = TrainingDataConfig(**config_dict)
 
     # create dataset
     dataset = InMemoryDataset(
@@ -42,7 +42,7 @@ def test_extracting_val_array(ordered_array, percentage):
         "patch_size": [8, 8],
         "axes": "YX",
     }
-    config = DataConfig(**config_dict)
+    config = TrainingDataConfig(**config_dict)
 
     # create dataset
     dataset = InMemoryDataset(
@@ -82,7 +82,7 @@ def test_extracting_val_files(tmp_path, ordered_array, percentage):
         "patch_size": [8, 8],
         "axes": "YX",
     }
-    config = DataConfig(**config_dict)
+    config = TrainingDataConfig(**config_dict)
 
     # create dataset
     dataset = InMemoryDataset(

--- a/tests/dataset/test_iterable_dataset.py
+++ b/tests/dataset/test_iterable_dataset.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import tifffile
 
-from careamics.config import DataConfig
+from careamics.config import TrainingDataConfig
 from careamics.config.support import SupportedData
 from careamics.dataset import PathIterableDataset
 from careamics.file_io.read import read_tiff
@@ -39,7 +39,7 @@ def test_number_of_files(tmp_path, ordered_array, shape, axes, patch_size):
         "patch_size": patch_size,
         "axes": axes,
     }
-    config = DataConfig(**config_dict)
+    config = TrainingDataConfig(**config_dict)
 
     # create dataset
     dataset = PathIterableDataset(
@@ -82,7 +82,7 @@ def test_read_function(tmp_path, ordered_array):
         "patch_size": patch_sizes,
         "axes": "YX",
     }
-    config = DataConfig(**config_dict)
+    config = TrainingDataConfig(**config_dict)
 
     # create dataset
     dataset = PathIterableDataset(
@@ -116,7 +116,7 @@ def test_extracting_val_files(tmp_path, ordered_array, percentage):
         "patch_size": [8, 8],
         "axes": "YX",
     }
-    config = DataConfig(**config_dict)
+    config = TrainingDataConfig(**config_dict)
 
     # create dataset
     dataset = PathIterableDataset(
@@ -167,7 +167,7 @@ def test_compute_mean_std_transform_welford(tmp_path, shape, axes, patch_size):
         "patch_size": patch_size,
         "axes": axes,
     }
-    config = DataConfig(**config_dict)
+    config = TrainingDataConfig(**config_dict)
 
     # create dataset
     dataset = PathIterableDataset(
@@ -219,7 +219,7 @@ def test_compute_mean_std_transform_welford_with_targets(
         "patch_size": patch_size,
         "axes": axes,
     }
-    config = DataConfig(**config_dict)
+    config = TrainingDataConfig(**config_dict)
 
     # create dataset
     dataset = PathIterableDataset(

--- a/tests/lightning/test_train_data_module.py
+++ b/tests/lightning/test_train_data_module.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from tifffile import imwrite
 
-from careamics.config import DataConfig
+from careamics.config import TrainingDataConfig
 from careamics.config.support import (
     SupportedData,
     SupportedTransform,
@@ -22,19 +22,22 @@ def test_mismatching_types_array(simple_array, minimum_algorithm_n2v):
     minimum_algorithm_n2v["data_type"] = SupportedData.TIFF.value
     with pytest.raises(ValueError):
         TrainDataModule(
-            data_config=DataConfig(**minimum_algorithm_n2v), train_data=simple_array
+            data_config=TrainingDataConfig(**minimum_algorithm_n2v),
+            train_data=simple_array,
         )
 
     minimum_algorithm_n2v["data_type"] = SupportedData.CUSTOM.value
     with pytest.raises(ValueError):
         TrainDataModule(
-            data_config=DataConfig(**minimum_algorithm_n2v), train_data=simple_array
+            data_config=TrainingDataConfig(**minimum_algorithm_n2v),
+            train_data=simple_array,
         )
 
     minimum_algorithm_n2v["data_type"] = SupportedData.ARRAY.value
     with pytest.raises(ValueError):
         TrainDataModule(
-            data_config=DataConfig(**minimum_algorithm_n2v), train_data="path/to/data"
+            data_config=TrainingDataConfig(**minimum_algorithm_n2v),
+            train_data="path/to/data",
         )
 
 
@@ -108,7 +111,7 @@ def test_get_data_statistics(tmp_path):
     data_val = rng.integers(0, 10, (2, 3, 32, 32))
 
     # create data module with in memory
-    data_config = DataConfig(
+    data_config = TrainingDataConfig(
         data_type=SupportedData.ARRAY.value,
         patch_size=(16, 16),
         axes="SCYX",
@@ -140,7 +143,7 @@ def test_get_data_statistics(tmp_path):
         data_path = val_path / f"data_{i}.tif"
         imwrite(data_path, data_val[i])
 
-    data_config = DataConfig(
+    data_config = TrainingDataConfig(
         data_type=SupportedData.TIFF.value,
         patch_size=(16, 16),
         axes="CYX",

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -2,7 +2,7 @@
 
 from careamics.config import Configuration
 from careamics.config.algorithms import UNetBasedAlgorithm
-from careamics.config.data import DataConfig
+from careamics.config.data import TrainingDataConfig
 from careamics.config.inference_model import InferenceConfig
 from careamics.config.training_model import TrainingConfig
 
@@ -14,7 +14,7 @@ def test_minimum_algorithm(minimum_algorithm_n2v):
 
 def test_minimum_data(minimum_data):
     # create data configuration
-    DataConfig(**minimum_data)
+    TrainingDataConfig(**minimum_data)
 
 
 def test_minimum_prediction(minimum_inference):


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

> [!NOTE]  
> **tldr**: Have Training and Prediction data configurations share parameters.

This PR is an attempt at exploring how to improve the Pydantic data models for the next generation dataset.

### Background - why do we need this PR?

<!-- What problem are you solving? Describe in a few sentences the state before
this PR. Use code examples if useful. -->

In the current code base, `DataConfig` and `InferenceConfig` share a lot of parameters, or have similar parameters that are differently named (e.g. `patch_size` vs `tile_size`, `transforms` vs `tta_transform`). This adds unnecessary complexity in checking and calling these parameters.

See https://github.com/CAREamics/careamics/issues/436.

### Overview - what changed?

<!-- What aspects and mechanisms of the code base changed? Describe only the general 
idea and overarching features. -->

In order to simplify handling the data configs, this PR does the following:
- Introduce a parent Pydantic model that defines parameters (taking the namespace `DataConfig`).
- Define two child Pydantic models that add additional constraints and validations to the parameters defined in the parent class.

### Implementation - how did you implement the changes?

<!-- How did you solve the issue technically? Explain why you chose this approach and 
provide code examples if applicable (e.g. change in the API for users). -->

- `DataConfig` has now extended parameters with fewer constraints (e.g. optional patches, optional new parameter called `patch_overlap`), including a new `random_seed` parameter, and some of the validations
- The training configuration is now called `TrainingDataConfig` and adds constraints that are necessary during training: non-null patches, defaults for transforms and dataloader etc.
- The inference configuration is `PredictionDataConfig` and adds constraints that are necessary during prediction.

Importantly, `TrainingDataConfig` and `PredictionDataConfig` share all parameters, including `patch_size`, `patch_overlap`, `transforms` etc. In `PredictionDataConfig`, `patch_size`, `patch_overlap` and `train_dataloader_params` have aliases, which means that the configurations have to be instantiated as follow:

``` python
t = TrainingDataConfig(
    data_type="array",
    axes="YX",
    patch_size=[64, 64]
)
print(t.patch_size)

p = PredictionDataConfig(
    data_type="array",
    axes="YX",
    tile_size=[64, 64], # optional, could be omitted
)
print(p.patch_size) # the parameter is still accessed as patch_size
```

As far as the NG Dataset is concerned, we only need to declare the `DataConfig` type:

``` python
class CareamicsDataset(Dataset):
    def __init__(
        self,
        data_config: DataConfig,
        ...
```

Then, whenever parameters are passed to another function, to avoid `mypy` errors, we still need to have a check:
```python
if not isinstance(self.config, TrainingDataConfig):
    raise ValueError("Prediction config cannot be used for validating.")

...
```

But the need to specify different parameters is now alleviated, example:

``` python
        ...
        return Compose(
            transform_list=list(self.config.transforms), # works for both training and prediction (tta)
        )
```


## Changes Made

<!-- This section highlights the important features and files that reviewers should
pay attention to when reviewing. Only list important features or files, this is useful for 
reviewers to correctly assess how deeply the modifications impact the code base.

For instance:

### New features or files
- `NewClass` added to `new_file.py`
- `new_function` added to `existing_file.py`

...
-->

### New features or files

<!-- List new features or files added. -->
- `general_data_model.py` contains now `DataConfig`, which is a general parent (Pydantic) model
- New file `prediction_data_model.py` contains the prediction data model
- New file `training_data_model.py` contains the training data model

### Modified features or files

<!-- List important modified features or files. -->
- `CAREamicsDataset` was modified to take a `DataConfig` and to simplify where the parameters are now identical between the two child models.

### Removed features or files

<!-- List removed features or files. -->
-

## How has this been tested?

<!-- Describe the tests that you ran to verify your changes. This can be a short 
description of the tests added to the PR or code snippet to reproduce the change
in behaviour. -->

Using the jupyter notebook provided in the `dataset_ng` module.

## Related Issues

<!-- Link to any related issues or discussions. Use keywords like "Fixes", "Resolves",
or "Closes" to link to issues automatically. -->

- Resolves https://github.com/CAREamics/careamics/issues/436

## Additional Notes and Examples

<!-- Provide any additional information that will help reviewers understand the
changes. This can be links to documentations, forum posts, past discussions etc. -->

### Should we stick to aliases

Aliases bring a strange behaviour:
```python
p = PredictionDataConfig(
    data_type="array",
    axes="YX",
    tile_size=[64, 64], # optional, could be omitted
)
print(p.patch_size) # the parameter is still accessed as patch_size
```

This means that `PredictionDataConfig` is closer upon instantiation to the current API of the CAREamist and the `create_predict_datamodule`, and internally not different from the training data config.

But passing a parameter named differently to the member parameter is strange and we might just as well stick to `patch_shape` and `patch_overlap`. We can still have the `tiling` vocabulary elsewhere.

### Unused parameters

Now both the training and prediction data config have unused/unrelated parameters (e.g. overlaps for training, validation dataloader for prediction). I don't think that this is a problem as long as the default values and the descriptions are clear (e.g. "unused"). Two ways to go about it:

- Ignore them, don't validate them, they will/should not be called anyway
- Validate against them, enforce for instance that `patch_overlaps` is `None` in training data 

I think we could try the first approach, if our code is well compartmentalized that should not be an issue. Now it may introduce strange behaviour the day we pass the wrong config to the wrong function... So solution 2 would guard against it.

### Training dataloader parameters

Currently both models have `training_dataloader_params`, but this is quite awkward for prediction. We should probably rename that to `dataloader_params` and in the description explicitly say that it is either training or prediction.

### TODOs

Left to do or consider:

- [ ] Naming change `TrainingDataConfig` -> `TrainDataConfig`
- [ ] Replacing `InferenceConfig` by the `PredictionDataConfig`
- [x] Implementing validators in `PredictionDataConfig`
- [ ] Should we keep `train_dataloader_params` name even though it will be called for prediction as well?
- [ ] Decide on whether to keep aliases
- [ ] Discuss constraints on unused parameters
- [ ] Clean up jupyter notebook (used for testing)
- [ ] Add tests


### Merging order

This may impact https://github.com/CAREamics/careamics/pull/444 and should be merged afterwards (if approved).

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)