### PR TITLE
Fix: artefacts from two incompatible PRs being merged into main

### DIFF
--- a/src/careamics/dataset_ng/dataset/dataset.py
+++ b/src/careamics/dataset_ng/dataset/dataset.py
@@ -1,8 +1,7 @@
 from collections.abc import Sequence
 from enum import Enum
 from pathlib import Path
-from typing import Any, Literal, NamedTuple, Optional, Union
-
+from typing import Any, Generic, Literal, NamedTuple, Optional, Union
 
 import numpy as np
 from numpy.typing import NDArray

--- a/src/careamics/dataset_ng/demo_dataset.ipynb
+++ b/src/careamics/dataset_ng/demo_dataset.ipynb
@@ -148,7 +148,6 @@
     ")\n",
     "val_dataset = CareamicsDataset(\n",
     "    data_config=val_data_config, mode=Mode.VALIDATING, inputs=data, targets=targets\n",
-
     ")\n",
     "\n",
     "fig, ax = plt.subplots(2, 5, figsize=(10, 5))\n",
@@ -262,7 +261,6 @@
    "metadata": {},
    "outputs": [],
    "source": []
-
   }
  ],
  "metadata": {

--- a/src/careamics/dataset_ng/demo_dataset.ipynb
+++ b/src/careamics/dataset_ng/demo_dataset.ipynb
@@ -143,12 +143,19 @@
     "\n",
     "data = sorted(Path(\"./\").glob(\"example_data*.tiff\"))\n",
     "targets = sorted(Path(\"./\").glob(\"example_target*.tiff\"))\n",
-    "train_dataset = CareamicsDataset(\n",
-    "    data_config=train_data_config, mode=Mode.TRAINING, inputs=data, targets=targets\n",
+    "train_dataset = create_dataset(\n",
+    "    config=train_data_config,\n",
+    "    mode=Mode.TRAINING,\n",
+    "    inputs=data,\n",
+    "    targets=targets,\n",
+    "    in_memory=True,\n",
     ")\n",
-    "val_dataset = CareamicsDataset(\n",
-    "    data_config=val_data_config, mode=Mode.VALIDATING, inputs=data, targets=targets\n",
-
+    "val_dataset = create_dataset(\n",
+    "    config=val_data_config,\n",
+    "    mode=Mode.VALIDATING,\n",
+    "    inputs=data,\n",
+    "    targets=targets,\n",
+    "    in_memory=True,\n",
     ")\n",
     "\n",
     "fig, ax = plt.subplots(2, 5, figsize=(10, 5))\n",
@@ -262,7 +269,6 @@
    "metadata": {},
    "outputs": [],
    "source": []
-
   }
  ],
  "metadata": {

--- a/tests/dataset_ng/patching_strategies/test_tiling_strategy.py
+++ b/tests/dataset_ng/patching_strategies/test_tiling_strategy.py
@@ -1,11 +1,10 @@
 import numpy as np
 import pytest
 
-from careamics.config.support import SupportedData
 from careamics.dataset_ng.dataset import ImageRegionData
 from careamics.dataset_ng.legacy_interoperability import imageregions_to_tileinfos
 from careamics.dataset_ng.patch_extractor.patch_extractor_factory import (
-    create_patch_extractor,
+    create_array_extractor,
 )
 from careamics.dataset_ng.patching_strategies import TilingStrategy
 from careamics.prediction_utils.stitch_prediction import stitch_prediction
@@ -25,9 +24,7 @@ def _test_tiling_output(
     data = [
         np.arange(np.prod(data_shape)).reshape(data_shape) for data_shape in data_shapes
     ]
-    patch_extractor = create_patch_extractor(
-        source=data, axes=axes, data_type=SupportedData.ARRAY
-    )
+    patch_extractor = create_array_extractor(source=data, axes=axes)
     tiling_strategy = TilingStrategy(
         data_shapes=data_shapes, tile_size=patch_size, overlaps=overlaps
     )


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

> [!NOTE]  
> **tldr**: Minor incompatibility with two merged PRs


#444 Introduced a new test that required the `create_patch_extractor` function. But #449 removed this function in favour of individual functions to create each type of patch extractor. I replaced the function with the relevant `create_array_extractor`.

Somehow import of `Generic` from typing was missing in the main dataset module.

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)