### PR TITLE
Fix: wrong axes in BMZ specs

### DIFF
--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -160,7 +160,7 @@ def _create_inputs_ouputs(
             preprocessing=[
                 FixedZeroMeanUnitVarianceDescr(
                     kwargs=FixedZeroMeanUnitVarianceAlongAxisKwargs(
-                        mean=means, std=stds, axis="channel"
+                        mean=means, std=stds, axis="xy"
                     )
                 )
             ],
@@ -172,7 +172,7 @@ def _create_inputs_ouputs(
             postprocessing=[
                 FixedZeroMeanUnitVarianceDescr(
                     kwargs=FixedZeroMeanUnitVarianceAlongAxisKwargs(  # invert norm
-                        mean=inv_means, std=inv_stds, axis="channel"
+                        mean=inv_means, std=inv_stds, axis="xy"
                     )
                 )
             ],


### PR DESCRIPTION
## Description

Following https://github.com/bioimage-io/collection-bioimage-io/issues/750, https://github.com/bioimage-io/collection-bioimage-io/issues/747 and https://github.com/bioimage-io/collection-bioimage-io/issues/749, it appears that we had a bug (or rather a misunderstanding) in the BMZ specs export.

This fixes this issue by correctly specifying `xy` as the normalizing axes. Not sure why the BMZ validation would work with the normalization being wrong...