### PR TITLE
Support CZI file format with NextGen datasets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ dependencies = [
     'zarr<3.0.0',
     'pillow<=11.2.1',
     'matplotlib<=3.10.1',
-    'xarray<2025.3.0'
+    'xarray<2025.3.0',
+    'pylibCZIrw>=4.1.2,<6.0.0',
 ]
 
 [project.optional-dependencies]

--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -199,7 +199,7 @@ def _create_algorithm_configuration(
 
 
 def _create_data_configuration(
-    data_type: Literal["array", "tiff", "custom"],
+    data_type: Literal["array", "tiff", "czi", "custom"],
     axes: str,
     patch_size: list[int],
     batch_size: int,
@@ -212,7 +212,7 @@ def _create_data_configuration(
 
     Parameters
     ----------
-    data_type : {"array", "tiff", "custom"}
+    data_type : {"array", "tiff", "czi", "custom"}
         Type of the data.
     axes : str
         Axes of the data.
@@ -282,7 +282,7 @@ def _create_training_configuration(
 def _create_supervised_config_dict(
     algorithm: Literal["care", "n2n"],
     experiment_name: str,
-    data_type: Literal["array", "tiff", "custom"],
+    data_type: Literal["array", "tiff", "czi", "custom"],
     axes: str,
     patch_size: list[int],
     batch_size: int,
@@ -306,7 +306,7 @@ def _create_supervised_config_dict(
         Algorithm to use.
     experiment_name : str
         Name of the experiment.
-    data_type : Literal["array", "tiff", "custom"]
+    data_type : Literal["array", "tiff", "czi", "custom"]
         Type of the data.
     axes : str
         Axes of the data (e.g. SYX).
@@ -405,7 +405,7 @@ def _create_supervised_config_dict(
 
 def create_care_configuration(
     experiment_name: str,
-    data_type: Literal["array", "tiff", "custom"],
+    data_type: Literal["array", "tiff", "czi", "custom"],
     axes: str,
     patch_size: list[int],
     batch_size: int,
@@ -445,7 +445,7 @@ def create_care_configuration(
     ----------
     experiment_name : str
         Name of the experiment.
-    data_type : Literal["array", "tiff", "custom"]
+    data_type : Literal["array", "tiff", "czi", "custom"]
         Type of the data.
     axes : str
         Axes of the data (e.g. SYX).
@@ -551,6 +551,33 @@ def create_care_configuration(
     ...     n_channels_in=3,
     ...     n_channels_out=1 # if applicable
     ... )
+
+    If you would like to train on CZI files, use `"czi"` as `data_type` and `"SCYX"` as
+    `axes` for 2-D or `"SCZYX"` for 3-D denoising. Note that `"SCYX"` can also be used
+    for 3-D data but spatial context along the Z dimension will then not be taken into
+    account.
+    >>> config_2d = create_care_configuration(
+    ...     experiment_name="care_experiment",
+    ...     data_type="czi",
+    ...     axes="SCYX",
+    ...     patch_size=[64, 64],
+    ...     batch_size=32,
+    ...     num_epochs=100,
+    ...     independent_channels=True,
+    ...     n_channels_in=1,
+    ...     n_channels_out=1,
+    ... )
+    ... config_3d = create_care_configuration(
+    ...     experiment_name="care_experiment",
+    ...     data_type="czi",
+    ...     axes="SCZYX",
+    ...     patch_size=[16, 64, 64],
+    ...     batch_size=16,
+    ...     num_epochs=100,
+    ...     independent_channels=True,
+    ...     n_channels_in=1,
+    ...     n_channels_out=1,
+    ... )
     """
     return Configuration(
         **_create_supervised_config_dict(
@@ -576,7 +603,7 @@ def create_care_configuration(
 
 def create_n2n_configuration(
     experiment_name: str,
-    data_type: Literal["array", "tiff", "custom"],
+    data_type: Literal["array", "tiff", "czi", "custom"],
     axes: str,
     patch_size: list[int],
     batch_size: int,
@@ -616,7 +643,7 @@ def create_n2n_configuration(
     ----------
     experiment_name : str
         Name of the experiment.
-    data_type : Literal["array", "tiff", "custom"]
+    data_type : Literal["array", "tiff", "czi", "custom"]
         Type of the data.
     axes : str
         Axes of the data (e.g. SYX).
@@ -722,6 +749,33 @@ def create_n2n_configuration(
     ...     n_channels_in=3,
     ...     n_channels_out=1 # if applicable
     ... )
+
+    If you would like to train on CZI files, use `"czi"` as `data_type` and `"SCYX"` as
+    `axes` for 2-D or `"SCZYX"` for 3-D denoising. Note that `"SCYX"` can also be used
+    for 3-D data but spatial context along the Z dimension will then not be taken into
+    account.
+    >>> config_2d = create_n2n_configuration(
+    ...     experiment_name="n2n_experiment",
+    ...     data_type="czi",
+    ...     axes="SCYX",
+    ...     patch_size=[64, 64],
+    ...     batch_size=32,
+    ...     num_epochs=100,
+    ...     independent_channels=True,
+    ...     n_channels_in=1,
+    ...     n_channels_out=1,
+    ... )
+    ... config_3d = create_n2n_configuration(
+    ...     experiment_name="n2n_experiment",
+    ...     data_type="czi",
+    ...     axes="SCZYX",
+    ...     patch_size=[16, 64, 64],
+    ...     batch_size=16,
+    ...     num_epochs=100,
+    ...     independent_channels=True,
+    ...     n_channels_in=1,
+    ...     n_channels_out=1,
+    ... )
     """
     return Configuration(
         **_create_supervised_config_dict(
@@ -747,7 +801,7 @@ def create_n2n_configuration(
 
 def create_n2v_configuration(
     experiment_name: str,
-    data_type: Literal["array", "tiff", "custom"],
+    data_type: Literal["array", "tiff", "czi", "custom"],
     axes: str,
     patch_size: list[int],
     batch_size: int,
@@ -810,7 +864,7 @@ def create_n2v_configuration(
     ----------
     experiment_name : str
         Name of the experiment.
-    data_type : Literal["array", "tiff", "custom"]
+    data_type : Literal["array", "tiff", "czi", "custom"]
         Type of the data.
     axes : str
         Axes of the data (e.g. SYX).
@@ -941,6 +995,31 @@ def create_n2v_configuration(
     ...     num_epochs=100,
     ...     independent_channels=False,
     ...     n_channels=3
+    ... )
+
+    If you would like to train on CZI files, use `"czi"` as `data_type` and `"SCYX"` as
+    `axes` for 2-D or `"SCZYX"` for 3-D denoising. Note that `"SCYX"` can also be used
+    for 3-D data but spatial context along the Z dimension will then not be taken into
+    account.
+    >>> config_2d = create_n2v_configuration(
+    ...     experiment_name="n2v_experiment",
+    ...     data_type="czi",
+    ...     axes="SCYX",
+    ...     patch_size=[64, 64],
+    ...     batch_size=32,
+    ...     num_epochs=100,
+    ...     independent_channels=True,
+    ...     n_channels=1,
+    ... )
+    ... config_3d = create_n2v_configuration(
+    ...     experiment_name="n2v_experiment",
+    ...     data_type="czi",
+    ...     axes="SCZYX",
+    ...     patch_size=[16, 64, 64],
+    ...     batch_size=16,
+    ...     num_epochs=100,
+    ...     independent_channels=True,
+    ...     n_channels=1,
     ... )
     """
     # if there are channels, we need to specify their number

--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -563,20 +563,16 @@ def create_care_configuration(
     ...     patch_size=[64, 64],
     ...     batch_size=32,
     ...     num_epochs=100,
-    ...     independent_channels=True,
     ...     n_channels_in=1,
-    ...     n_channels_out=1,
     ... )
-    ... config_3d = create_care_configuration(
+    >>> config_3d = create_care_configuration(
     ...     experiment_name="care_experiment",
     ...     data_type="czi",
     ...     axes="SCZYX",
     ...     patch_size=[16, 64, 64],
     ...     batch_size=16,
     ...     num_epochs=100,
-    ...     independent_channels=True,
     ...     n_channels_in=1,
-    ...     n_channels_out=1,
     ... )
     """
     return Configuration(
@@ -761,20 +757,16 @@ def create_n2n_configuration(
     ...     patch_size=[64, 64],
     ...     batch_size=32,
     ...     num_epochs=100,
-    ...     independent_channels=True,
     ...     n_channels_in=1,
-    ...     n_channels_out=1,
     ... )
-    ... config_3d = create_n2n_configuration(
+    >>> config_3d = create_n2n_configuration(
     ...     experiment_name="n2n_experiment",
     ...     data_type="czi",
     ...     axes="SCZYX",
     ...     patch_size=[16, 64, 64],
     ...     batch_size=16,
     ...     num_epochs=100,
-    ...     independent_channels=True,
     ...     n_channels_in=1,
-    ...     n_channels_out=1,
     ... )
     """
     return Configuration(
@@ -1008,17 +1000,15 @@ def create_n2v_configuration(
     ...     patch_size=[64, 64],
     ...     batch_size=32,
     ...     num_epochs=100,
-    ...     independent_channels=True,
     ...     n_channels=1,
     ... )
-    ... config_3d = create_n2v_configuration(
+    >>> config_3d = create_n2v_configuration(
     ...     experiment_name="n2v_experiment",
     ...     data_type="czi",
     ...     axes="SCZYX",
     ...     patch_size=[16, 64, 64],
     ...     batch_size=16,
     ...     num_epochs=100,
-    ...     independent_channels=True,
     ...     n_channels=1,
     ... )
     """

--- a/src/careamics/config/data/data_model.py
+++ b/src/careamics/config/data/data_model.py
@@ -95,9 +95,9 @@ class DataConfig(BaseModel):
     )
 
     # Dataset configuration
-    data_type: Literal["array", "tiff", "custom"]
-    """Type of input data, numpy.ndarray (array) or paths (tiff and custom), as defined
-    in SupportedData."""
+    data_type: Literal["array", "tiff", "czi", "custom"]
+    """Type of input data, numpy.ndarray (array) or paths (tiff, czi, and custom), as
+    defined in SupportedData."""
 
     axes: str
     """Axes of the data, as defined in SupportedAxes."""

--- a/src/careamics/config/inference_model.py
+++ b/src/careamics/config/inference_model.py
@@ -15,8 +15,8 @@ class InferenceConfig(BaseModel):
 
     model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
 
-    data_type: Literal["array", "tiff", "custom"]  # As defined in SupportedData
-    """Type of input data: numpy.ndarray (array) or path (tiff or custom)."""
+    data_type: Literal["array", "tiff", "czi", "custom"]  # As defined in SupportedData
+    """Type of input data: numpy.ndarray (array) or path (tiff, czi, or custom)."""
 
     tile_size: Optional[Union[list[int]]] = Field(
         default=None, min_length=2, max_length=3

--- a/src/careamics/config/support/supported_data.py
+++ b/src/careamics/config/support/supported_data.py
@@ -16,12 +16,15 @@ class SupportedData(str, BaseEnum):
         Array data.
     TIFF : str
         TIFF image data.
+    CZI : str
+        CZI image data.
     CUSTOM : str
         Custom data.
     """
 
     ARRAY = "array"
     TIFF = "tiff"
+    CZI = "czi"
     CUSTOM = "custom"
     # ZARR = "zarr"
 
@@ -78,6 +81,8 @@ class SupportedData(str, BaseEnum):
             raise NotImplementedError(f"Data '{data_type}' is not loaded from a file.")
         elif data_type == cls.TIFF:
             return "*.tif*"
+        elif data_type == cls.CZI:
+            return "*.czi"
         elif data_type == cls.CUSTOM:
             return "*.*"
         else:
@@ -102,6 +107,8 @@ class SupportedData(str, BaseEnum):
             raise NotImplementedError(f"Data '{data_type}' is not loaded from a file.")
         elif data_type == cls.TIFF:
             return ".tiff"
+        elif data_type == cls.CZI:
+            return ".czi"
         elif data_type == cls.CUSTOM:
             # TODO: improve this message
             raise NotImplementedError("Custom extensions have to be passed elsewhere.")

--- a/src/careamics/dataset_ng/factory.py
+++ b/src/careamics/dataset_ng/factory.py
@@ -156,7 +156,7 @@ def create_dataset(
     Returns
     -------
     CareamicsDataset[ImageStack]
-        The CAREamicsDataset
+        The CAREamicsDataset.
 
     Raises
     ------
@@ -215,7 +215,7 @@ def create_array_dataset(
     Returns
     -------
     CareamicsDataset[InMemoryImageStack]
-        A CAREamicsDataset
+        A CAREamicsDataset.
     """
     input_extractor = create_array_extractor(source=inputs, axes=config.axes)
     target_extractor: Optional[PatchExtractor[InMemoryImageStack]]
@@ -249,7 +249,7 @@ def create_tiff_dataset(
     Returns
     -------
     CareamicsDataset[InMemoryImageStack]
-        A CAREamicsDataset
+        A CAREamicsDataset.
     """
     input_extractor = create_tiff_extractor(
         source=inputs,
@@ -287,7 +287,7 @@ def create_czi_dataset(
     Returns
     -------
     CareamicsDataset[CziImageStack]
-        A CAREamicsDataset
+        A CAREamicsDataset.
     """
 
     input_extractor = create_czi_extractor(source=inputs, axes=config.axes)
@@ -323,7 +323,7 @@ def create_ome_zarr_dataset(
     Returns
     -------
     CareamicsDataset[ZarrImageStack]
-        A CAREamicsDataset
+        A CAREamicsDataset.
     """
 
     input_extractor = create_ome_zarr_extractor(source=inputs, axes=config.axes)
@@ -368,7 +368,7 @@ def create_custom_file_dataset(
     Returns
     -------
     CareamicsDataset[InMemoryImageStack]
-        A CAREamicsDataset
+        A CAREamicsDataset.
     """
     input_extractor = create_custom_file_extractor(
         source=inputs, axes=config.axes, read_func=read_func, read_kwargs=read_kwargs
@@ -422,7 +422,7 @@ def create_custom_image_stack_dataset(
     Returns
     -------
     CareamicsDataset[GenericImageStack]
-        A CAREamicsDataset
+        A CAREamicsDataset.
     """
     input_extractor = create_custom_image_stack_extractor(
         inputs,

--- a/src/careamics/dataset_ng/factory.py
+++ b/src/careamics/dataset_ng/factory.py
@@ -10,6 +10,7 @@ from careamics.config import DataConfig, InferenceConfig
 from careamics.config.support import SupportedData
 from careamics.dataset_ng.patch_extractor import ImageStackLoader, PatchExtractor
 from careamics.dataset_ng.patch_extractor.image_stack import (
+    CziImageStack,
     GenericImageStack,
     ImageStack,
     InMemoryImageStack,
@@ -19,6 +20,7 @@ from careamics.dataset_ng.patch_extractor.patch_extractor_factory import (
     create_array_extractor,
     create_custom_file_extractor,
     create_custom_image_stack_extractor,
+    create_czi_extractor,
     create_ome_zarr_extractor,
     create_tiff_extractor,
 )
@@ -38,6 +40,7 @@ class DatasetType(Enum):
     LAZY_TIFF = "lazy_tiff"
     IN_MEM_CUSTOM_FILE = "in_mem_custom_file"
     OME_ZARR = "ome_zarr"
+    CZI = "czi"
     CUSTOM_IMAGE_STACK = "custom_image_stack"
 
 
@@ -58,7 +61,7 @@ def determine_dataset_type(
         Whether all the data should be loaded into memory. This is argument is ignored
         unless the `data_type` is "tiff" or "custom".
     read_func : ReadFunc, optional
-        A function that can that can be used to load custom data. This argument is
+        A function that can be used to load custom data. This argument is
         ignored unless the `data_type` is "custom".
     image_stack_loader : ImageStackLoader, optional
         A function for custom image stack loading. This argument is ignored unless the
@@ -87,6 +90,8 @@ def determine_dataset_type(
             return DatasetType.IN_MEM_TIFF
         else:
             return DatasetType.LAZY_TIFF
+    elif data_type == SupportedData.CZI:
+        return DatasetType.CZI
     elif data_type == SupportedData.CUSTOM:
         if read_func is not None:
             if in_memory:
@@ -167,6 +172,8 @@ def create_dataset(
     elif dataset_type == DatasetType.IN_MEM_TIFF:
         return create_tiff_dataset(config, mode, inputs, targets)
     # TODO: Lazy tiff
+    elif dataset_type == DatasetType.CZI:
+        return create_czi_dataset(config, mode, inputs, targets)
     elif dataset_type == DatasetType.IN_MEM_CUSTOM_FILE:
         if read_kwargs is None:
             read_kwargs = {}
@@ -251,6 +258,42 @@ def create_tiff_dataset(
     target_extractor: Optional[PatchExtractor[InMemoryImageStack]]
     if targets is not None:
         target_extractor = create_tiff_extractor(source=targets, axes=config.axes)
+    else:
+        target_extractor = None
+    dataset = CareamicsDataset(config, mode, input_extractor, target_extractor)
+    return dataset
+
+
+def create_czi_dataset(
+    config: Union[DataConfig, InferenceConfig],
+    mode: Mode,
+    inputs: Sequence[Path],
+    targets: Optional[Sequence[Path]],
+) -> CareamicsDataset[CziImageStack]:
+    """
+    Create a dataset from CZI files.
+
+    Parameters
+    ----------
+    config : DataConfig or InferenceConfig
+        The data configuration.
+    mode : Mode
+        Whether to create the dataset in "training", "validation" or "predicting" mode.
+    inputs : Any
+        The input sources to the dataset.
+    targets : Any, optional
+        The target sources to the dataset.
+
+    Returns
+    -------
+    CareamicsDataset[CziImageStack]
+        A CAREamicsDataset
+    """
+
+    input_extractor = create_czi_extractor(source=inputs, axes=config.axes)
+    target_extractor: Optional[PatchExtractor[CziImageStack]]
+    if targets is not None:
+        target_extractor = create_czi_extractor(source=targets, axes=config.axes)
     else:
         target_extractor = None
     dataset = CareamicsDataset(config, mode, input_extractor, target_extractor)

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/__init__.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/__init__.py
@@ -1,10 +1,12 @@
 __all__ = [
+    "CziImageStack",
     "GenericImageStack",
     "ImageStack",
     "InMemoryImageStack",
     "ZarrImageStack",
 ]
 
+from .czi_image_stack import CziImageStack
 from .image_stack_protocol import GenericImageStack, ImageStack
 from .in_memory_image_stack import InMemoryImageStack
 from .zarr_image_stack import ZarrImageStack

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/czi_image_stack.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/czi_image_stack.py
@@ -1,0 +1,297 @@
+import re
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+from numpy.typing import NDArray
+from pylibCZIrw.czi import CziReader, Rectangle, open_czi
+
+
+class CziImageStack:
+    """
+    A class for extracting patches from an image stack that is stored as a CZI file.
+
+    Parameters
+    ----------
+    data_path : str or Path
+        Path to the CZI file.
+
+    scene : int, optional
+        Index of the scene to extract. If not specified, the entire image covering
+        all scenes present in the CZI file will be extracted.
+        The scene can also be provided as part of `data_path` by appending an `"@"`
+        followed by the scene index to the filename.
+
+    depth_axis : {"none", "Z", "T", "auto"}, default: "auto"
+        Which axis to use as depth-axis for providing 3-D patches.
+
+        - `"none"`: Only provide 2-D patches. If a Z or T dimension is present in the
+          data, they will be combined into the sample dimension `S`.
+        - `"Z"`: Use the Z-axis as depth-axis. If a T axis is present as well, it will
+          be used as sample dimensions `S`.
+        - `"T"`: Use the T-axis as depth-axis. If a Z axis is present as well, it will
+          be used as sample dimensions `S`.
+        - `"auto"`: Automatically uses a Z or T axis present in the data as depth axis.
+          If both are present, the Z axis takes precedence.
+
+    Attributes
+    ----------
+    source : Path
+        Path to the CZI file, including the scene index if specified.
+    data_path : Path
+        Path to the CZI file without scene index.
+    scene : int or None
+        Index of the scene to extract, or None if not specified.
+    data_shape : Sequence[int]
+        The shape of the data in the order `(SC(Z)YX)`.
+    axes : str
+        The axes in the CZI file corresponding to the dimensions in `data_shape`.
+        Possible axes are `C`, `T`, `Z`, `Y`, `X`, and `S`. The axis `S` (sample)
+        is special and combines all remaining axes present in the data.
+    """
+
+    def __init__(
+        self,
+        data_path: str | Path,
+        scene: int | None = None,
+        depth_axis: Literal["none", "Z", "T", "auto"] = "auto",
+    ) -> None:
+        _data_path = Path(data_path)
+
+        # Check for scene encoded in filename.
+        # Normally, file path and scene should be provided as separate arguments but
+        # we would also like to support using the `source` property to re-create the
+        # CZI image stack. In this case, the scene index is encoded in the file path.
+        scene_matches = re.match(r"^(.*)@(\d+)$", _data_path.name)
+        if scene_matches:
+            if scene is not None:
+                raise ValueError(
+                    "Scene index is specified in the filename and as an argument. "
+                    "Please specify only one."
+                )
+            _data_path = _data_path.parent / scene_matches.group(1)
+            scene = int(scene_matches.group(2))
+
+        # Set variables
+        self.data_path = _data_path
+        self.scene = scene
+        self._depth_axis = depth_axis
+
+        # Open CZI file
+        self._czi = CziReader(str(self.data_path))
+
+        # Determine metadata
+        self.axes, self.data_shape, self._bounding_rectangle, self._sample_axes = (
+            self._get_shape()
+        )
+        self.data_dtype = np.float32
+
+    def __del__(self):
+        # Close CZI file
+        self._czi.close()
+
+    def __getstate__(self) -> dict[str, Any]:
+        # Remove CziReader object from state to avoid pickling issues
+        state = self.__dict__.copy()
+        del state["_czi"]
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        # Reopen CZI file after unpickling
+        self.__dict__.update(state)
+        self._czi = CziReader(str(self.data_path))
+
+    # TODO: we append the scene index to the file name
+    #       - not sure if this is a good approach
+    @property
+    def source(self) -> Path:
+        filename = self.data_path.name
+        if self.scene is not None:
+            filename = f"{filename}@{self.scene}"
+        return self.data_path.parent / filename
+
+    def extract_patch(
+        self, sample_idx: int, coords: Sequence[int], patch_size: Sequence[int]
+    ) -> NDArray:
+        # Determine 3rd dimension (T, Z or none)
+        if len(coords) == 3:
+            if len(self.axes) != 5:
+                raise ValueError(
+                    f"Requested a 3D patch from a 2D image stack with axes {self.axes}."
+                )
+            third_dim = self.axes[2]
+            third_dim_offset, third_dim_size = coords[0], patch_size[0]
+        else:
+            if len(self.axes) != 4:
+                raise ValueError(
+                    f"Requested a 2D patch from a 3D image stack with axes {self.axes}."
+                )
+            third_dim = None
+            third_dim_offset, third_dim_size = 0, 1
+
+        # Set up ROI to extract from each plane as (x, y, w, h)
+        roi = (
+            self._bounding_rectangle.x + coords[-1],
+            self._bounding_rectangle.y + coords[-2],
+            patch_size[-1],
+            patch_size[-2],
+        )
+
+        # Create output array of shape (C, Z, Y, X)
+        patch = np.empty(
+            (self.data_shape[1], third_dim_size, *patch_size[-2:]), dtype=np.float32
+        )
+
+        # Set up plane to index `sample_idx`
+        sample_shape = list(self._sample_axes.values())
+        sample_indices = np.unravel_index(sample_idx, sample_shape)
+        plane = {
+            dimension: int(index)
+            for dimension, index in zip(self._sample_axes.keys(), sample_indices)
+        }
+
+        # Read XY planes sequentially
+        for channel in range(self.data_shape[1]):
+            for third_dim_index in range(third_dim_size):
+                plane["C"] = channel
+                if third_dim is not None:
+                    plane[third_dim] = third_dim_offset + third_dim_index
+                extracted_roi = self._czi.read(roi=roi, plane=plane, scene=self.scene)
+                if extracted_roi.ndim == 3:
+                    if extracted_roi.shape[-1] > 1:
+                        raise ValueError(
+                            "CZI files with RGB channels are currently not supported."
+                        )
+                    extracted_roi = extracted_roi.squeeze(-1)
+                patch[channel, third_dim_index] = extracted_roi
+
+        # Remove dummy 3rd dimension for 2-D data
+        if third_dim is None:
+            patch = patch.squeeze(1)
+
+        return patch
+
+    def _get_shape(self) -> tuple[str, list[int], Rectangle, dict[str, int]]:
+        """Determines the shape of the selected scene.
+
+        Returns
+        -------
+        axes : str
+            String specifying the axis order. Examples:
+
+            - "SCZYX" for 3-D data if `depth_axis` is `"Z"`.
+            - "SCTYX" for 3-D data if `depth_axis` is `"T"`.
+            - "SCYX" for 2-D time-series if `depth_axis` is `"none"`.
+            - "SCTYX" for 2-D time-series if `depth_axis` is `"T"`.
+            - "SCYX" for 2-D images.
+
+            The axis `S` is the sample dimension and combines all remaining axes
+            present in the data.
+
+        shape : list[int]
+            The size of each axis, in the order listed in `axes`.
+
+        bounding_rectangle : Rectangle
+            The bounding rectangle of the scene in pixels. The rectangle is
+            defined by its top-left corner (x, y) and its width and height (w, h).
+
+        sample_axes : dict[str, int]
+            A dictionary with information about the remaining axes used for the
+            sample dimension.
+            The keys are the axis names (e.g., "T", "Z") and the values are their
+            respective sizes.
+        """
+        # Get CZI dimensions
+        total_bbox = self._czi.total_bounding_box_no_pyramid
+        if self.scene is None:
+            bounding_rectangle = self._czi.total_bounding_rectangle_no_pyramid
+        else:
+            bounding_rectangle = self._czi.scenes_bounding_rectangle_no_pyramid[
+                self.scene
+            ]
+
+        # Determine if T and Z axis are present
+        # Note: An axis of size 1 is as good as no axis since we cannot use it for 3-D
+        # denoising.
+        has_time = "T" in total_bbox and (total_bbox["T"][1] - total_bbox["T"][0]) > 1
+        has_depth = "Z" in total_bbox and (total_bbox["Z"][1] - total_bbox["Z"][0]) > 1
+
+        # Determine whether to use time as depth dimension
+        depth_axis = self._depth_axis
+        if depth_axis == "auto":
+            if has_depth:
+                depth_axis = "Z"
+            elif has_time:
+                depth_axis = "T"
+            else:
+                depth_axis = "none"
+
+        # Determine axis order depending on data type and `depth_axis`
+        if depth_axis == "Z" and has_depth:
+            axes = "SCZYX"
+        elif depth_axis == "T" and has_time:
+            axes = "SCTYX"
+        else:
+            axes = "SCYX"
+
+        # Calculcate size of sample dimension S, combining all axes not used elsewhere.
+        # This could, for example, be a time axis. If we only perform 2-D denoising, a
+        # potentially present Z axis would also be used as sample dimension. If both,
+        # T and Z, are present, both need to be combined into the sample dimension.
+        # The same needs to be done to any other potentially present axis in the CZI
+        # file which is not a spatial or channel axis.
+        # The following code calculates the size of the combined sample axis.
+        sample_axes = {}
+        sample_size = 1
+        for dimension, (start, end) in total_bbox.items():
+            if dimension not in axes:
+                sample_axes[dimension] = end - start
+                sample_size *= end - start
+
+        # Determine data shape
+        shape = []
+        for dimension in axes:
+            if dimension == "S":
+                shape.append(sample_size)
+            elif dimension == "Y":
+                shape.append(bounding_rectangle.h)
+            elif dimension == "X":
+                shape.append(bounding_rectangle.w)
+            elif dimension in total_bbox:
+                shape.append(total_bbox[dimension][1] - total_bbox[dimension][0])
+            else:
+                shape.append(1)
+
+        return axes, shape, bounding_rectangle, sample_axes
+
+    @classmethod
+    def get_bounding_rectangles(
+        cls, czi: Path | str | CziReader
+    ) -> dict[int | None, Rectangle]:
+        """Gets the bounding rectangles of all scenes in a CZI file.
+
+        Parameters
+        ----------
+        czi : Path or str or pyczi.CziReader
+            Path to the CZI file or an already opened file as CziReader object.
+
+        Returns
+        -------
+        dict[int | None, Rectangle]
+            A dictionary mapping scene indices to their bounding rectangles in the
+            format `(x, y, w, h)`.
+            If no scenes are present in the CZI file, the returned dictionary will
+            have only one entry with key `None`, whose bounding rectangle covers the
+            entire image.
+        """
+        if not isinstance(czi, CziReader):
+            with open_czi(str(czi)) as czi_reader:
+                return cls.get_bounding_rectangles(czi_reader)
+
+        scenes_bounding_rectangle = czi.scenes_bounding_rectangle_no_pyramid
+        if len(scenes_bounding_rectangle) >= 1:
+            # Ensure keys are int | None for type compatibility
+            return {int(k): v for k, v in scenes_bounding_rectangle.items()}
+        else:
+            return {None: czi.total_bounding_rectangle_no_pyramid}

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
@@ -113,20 +113,19 @@ def create_czi_extractor(
         The source files for the data.
     axes: str
         Specifies which axes of the data to use and how.
-        If this string ends with "ZYX", the data will consist of 3-D patches.
-        If the data has no Z axis but a T axis, the T axis will be used as
-        3rd dimension.
+        If this string ends with `"ZYX"` or `"TYX"`, the data will consist of 3-D
+        patches, using `Z` or `T` as third dimension, respectively.
         If the string does not end with "ZYX", the data will consist of 2-D patches.
 
     Returns
     -------
     PatchExtractor
     """
-    depth_axis: Literal["none", "Z", "T", "auto"] = "none"
+    depth_axis: Literal["none", "Z", "T"] = "none"
     if axes.endswith("TYX"):
         depth_axis = "T"
-    elif "Z" in axes:
-        depth_axis = "auto"
+    elif axes.endswith("ZYX"):
+        depth_axis = "Z"
 
     image_stacks: list[CziImageStack] = []
     for path in source:

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py
@@ -122,14 +122,13 @@ def create_czi_extractor(
     -------
     PatchExtractor
     """
+    depth_axis: Literal["none", "Z", "T", "auto"] = "none"
     if axes.endswith("TYX"):
         depth_axis = "T"
     elif "Z" in axes:
         depth_axis = "auto"
-    else:
-        depth_axis = "none"
 
-    image_stacks = []
+    image_stacks: list[CziImageStack] = []
     for path in source:
         scene_rectangles = CziImageStack.get_bounding_rectangles(path)
         image_stacks.extend(

--- a/src/careamics/lightning/dataset_ng/data_module.py
+++ b/src/careamics/lightning/dataset_ng/data_module.py
@@ -341,7 +341,7 @@ class CareamicsDataModule(L.LightningDataModule):
                 raise ValueError(
                     f"Unsupported input type for {self.data_type}: {type(input_data)}"
                 )
-        elif self.data_type == SupportedData.TIFF:
+        elif self.data_type in (SupportedData.TIFF, SupportedData.CZI):
             if isinstance(input_data, (str, Path)):
                 return self._validate_path_input(input_data, target_data)
             elif isinstance(input_data, list):

--- a/tests/dataset_ng/patch_extractor/image_stack/test_czi_image_stack.py
+++ b/tests/dataset_ng/patch_extractor/image_stack/test_czi_image_stack.py
@@ -47,7 +47,7 @@ def create_test_czi(file_path: Path, data: NDArray | list[NDArray]):
         ((8, 1, 1, 32, 48), "T", "SCTYX", [1, 1, 8, 32, 48], 0),
         ((8, 1, 1, 32, 48), "auto", "SCTYX", [1, 1, 8, 32, 48], 0),
         # 3-D Time-Series
-        ((8, 1, 16, 32, 48), "none", "SCYX", [8*16, 1, 32, 48], 35),
+        ((8, 1, 16, 32, 48), "none", "SCYX", [8 * 16, 1, 32, 48], 35),
         ((8, 1, 16, 32, 48), "Z", "SCZYX", [8, 1, 16, 32, 48], 7),
         ((8, 1, 16, 32, 48), "T", "SCTYX", [16, 1, 8, 32, 48], 12),
         ((8, 1, 16, 32, 48), "auto", "SCZYX", [8, 1, 16, 32, 48], 5),
@@ -84,7 +84,7 @@ def test_extract_patch(
             sample_idx=sample_idx, coords=coords, patch_size=patch_size
         )
 
-        data_ref = np.moveaxis(data, 2, 1) # (T, Z, C, Y, X)
+        data_ref = np.moveaxis(data, 2, 1)  # (T, Z, C, Y, X)
         data_ref = data_ref.reshape(-1, *data_ref.shape[-3:])
         patch_ref = data_ref[
             sample_idx,
@@ -124,10 +124,7 @@ def test_multiple_scenes(
     ]
 
     # reference data to compare against
-    data_ref = [
-        np.random.randn(*shape).astype(np.float32)
-        for shape in original_shapes
-    ]
+    data_ref = [np.random.randn(*shape).astype(np.float32) for shape in original_shapes]
 
     # save data as a czi file to ininitialise image stack with
     file_path = tmp_path / "test_czi.czi"

--- a/tests/dataset_ng/patch_extractor/image_stack/test_czi_image_stack.py
+++ b/tests/dataset_ng/patch_extractor/image_stack/test_czi_image_stack.py
@@ -1,0 +1,163 @@
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+from pylibCZIrw import czi as pyczi
+
+from careamics.dataset_ng.patch_extractor.image_stack import CziImageStack
+
+
+def create_test_czi(file_path: Path, data: NDArray | list[NDArray]):
+    if not isinstance(data, list):
+        data = [data]
+
+    with pyczi.create_czi(str(file_path)) as czi:
+        xoffs = 0
+        for scene_idx, scene_data in enumerate(data):
+            for t in range(scene_data.shape[0]):
+                for c in range(scene_data.shape[1]):
+                    for z in range(scene_data.shape[2]):
+                        czi.write(
+                            scene_data[t, c, z],
+                            plane={"C": c, "T": t, "Z": z},
+                            location=(xoffs, 0),
+                            scene=scene_idx,
+                        )
+            xoffs += scene_data.shape[-1] + 20
+
+
+@pytest.mark.parametrize(
+    "original_shape, depth_axis, expected_axes, expected_shape, sample_idx",
+    [
+        # 2-D Images
+        ((1, 1, 1, 32, 48), "none", "SCYX", [1, 1, 32, 48], 0),
+        ((1, 1, 1, 32, 48), "T", "SCYX", [1, 1, 32, 48], 0),
+        ((1, 1, 1, 32, 48), "Z", "SCYX", [1, 1, 32, 48], 0),
+        ((1, 1, 1, 32, 48), "auto", "SCYX", [1, 1, 32, 48], 0),
+        # 3-D Volumes
+        ((1, 1, 16, 32, 48), "none", "SCYX", [16, 1, 32, 48], 9),
+        ((1, 1, 16, 32, 48), "T", "SCYX", [16, 1, 32, 48], 9),
+        ((1, 1, 16, 32, 48), "Z", "SCZYX", [1, 1, 16, 32, 48], 0),
+        ((1, 1, 16, 32, 48), "auto", "SCZYX", [1, 1, 16, 32, 48], 0),
+        # 2-D Time-Series
+        ((8, 1, 1, 32, 48), "none", "SCYX", [8, 1, 32, 48], 3),
+        ((8, 1, 1, 32, 48), "Z", "SCYX", [8, 1, 32, 48], 3),
+        ((8, 1, 1, 32, 48), "T", "SCTYX", [1, 1, 8, 32, 48], 0),
+        ((8, 1, 1, 32, 48), "auto", "SCTYX", [1, 1, 8, 32, 48], 0),
+        # 3-D Time-Series
+        ((8, 1, 16, 32, 48), "none", "SCYX", [8*16, 1, 32, 48], 35),
+        ((8, 1, 16, 32, 48), "Z", "SCZYX", [8, 1, 16, 32, 48], 7),
+        ((8, 1, 16, 32, 48), "T", "SCTYX", [16, 1, 8, 32, 48], 12),
+        ((8, 1, 16, 32, 48), "auto", "SCZYX", [8, 1, 16, 32, 48], 5),
+        # Multiple channels
+        ((8, 3, 16, 32, 48), "auto", "SCZYX", [8, 3, 16, 32, 48], 2),
+    ],
+)
+def test_extract_patch(
+    tmp_path: Path,
+    original_shape: tuple[int, ...],
+    depth_axis: Literal["none", "Z", "T", "auto"],
+    expected_axes: str,
+    expected_shape: tuple[int, ...],
+    sample_idx: int,
+):
+    # reference data to compare against
+    data = np.random.randn(*original_shape).astype(np.float32)
+
+    # save data as a czi file to ininitialise image stack with
+    file_path = tmp_path / "test_czi.czi"
+    create_test_czi(file_path=file_path, data=data)
+
+    # initialise CziImageStack
+    image_stack = CziImageStack(data_path=file_path, depth_axis=depth_axis)
+    assert image_stack.axes == expected_axes
+    assert image_stack.data_shape == expected_shape
+
+    # test extracted patch matches patch from reference data
+    if len(expected_axes) < 5:
+        coords = (11, 4)
+        patch_size = (16, 9)
+
+        extracted_patch = image_stack.extract_patch(
+            sample_idx=sample_idx, coords=coords, patch_size=patch_size
+        )
+
+        data_ref = np.moveaxis(data, 2, 1) # (T, Z, C, Y, X)
+        data_ref = data_ref.reshape(-1, *data_ref.shape[-3:])
+        patch_ref = data_ref[
+            sample_idx,
+            :,
+            coords[0] : coords[0] + patch_size[0],
+            coords[1] : coords[1] + patch_size[1],
+        ]
+    else:
+        coords = (2, 11, 4)
+        patch_size = (4, 16, 9)
+
+        extracted_patch = image_stack.extract_patch(
+            sample_idx=sample_idx, coords=coords, patch_size=patch_size
+        )
+
+        if "T" in expected_axes and expected_axes.index("T") == 2:
+            data_ref = data.swapaxes(0, 2)
+        else:
+            data_ref = data
+        patch_ref = data_ref[
+            sample_idx,
+            ...,
+            coords[0] : coords[0] + patch_size[0],
+            coords[1] : coords[1] + patch_size[1],
+            coords[2] : coords[2] + patch_size[2],
+        ]
+    np.testing.assert_array_equal(extracted_patch, patch_ref)
+
+
+def test_multiple_scenes(
+    tmp_path: Path,
+):
+    original_shapes = [
+        [4, 1, 8, 16, 32],
+        [4, 1, 8, 24, 18],
+        [4, 1, 8, 45, 32],
+    ]
+
+    # reference data to compare against
+    data_ref = [
+        np.random.randn(*shape).astype(np.float32)
+        for shape in original_shapes
+    ]
+
+    # save data as a czi file to ininitialise image stack with
+    file_path = tmp_path / "test_czi.czi"
+    create_test_czi(file_path=file_path, data=data_ref)
+
+    # Test reading scene metadata
+    scene_rectangles = CziImageStack.get_bounding_rectangles(file_path)
+    assert len(scene_rectangles) == len(original_shapes)
+
+    scene_rectangle_sizes = [(rect.h, rect.w) for rect in scene_rectangles.values()]
+    expected_rectangle_sizes = [(shape[-2], shape[-1]) for shape in original_shapes]
+    assert scene_rectangle_sizes == expected_rectangle_sizes
+
+    # Test reading from individual scenes
+    for scene_idx, expected_shape in enumerate(original_shapes):
+        image_stack = CziImageStack(data_path=file_path, scene=scene_idx)
+        assert image_stack.data_shape == expected_shape
+
+        t = expected_shape[0] - scene_idx - 1
+        coords = (2, 9, 4)
+        patch_size = (4, 7, 13)
+
+        extracted_patch = image_stack.extract_patch(
+            sample_idx=t, coords=coords, patch_size=patch_size
+        )
+        patch_ref = data_ref[scene_idx][
+            t,
+            :,
+            coords[0] : coords[0] + patch_size[0],
+            coords[1] : coords[1] + patch_size[1],
+            coords[2] : coords[2] + patch_size[2],
+        ]
+        np.testing.assert_array_equal(extracted_patch, patch_ref)


### PR DESCRIPTION
## Description

Adds support for the CZI file format within the NextGen datasets framework.

### Background - why do we need this PR?

CZI is the image format used by ZEISS microscopes. Processing CZI files directly without having to convert them to a different format would streamline the denoising workflow of ZEISS microscope users significantly easier.

### Overview - what changed?

- Implement `CziImageStack` for reading patches from an individual scene of a single CZI file.
- Add a `create_czi_extractor` patch extractor factory function for creating a patch extractor for all scenes contained in a list of CZI files.
- Add a `create_czi_dataset` factory (similar to the functions present for other file formats).
- Add `czi` as supported format in enums and docstrings.


### Implementation - how did you implement the changes?

Added `CziImageStack` and `create_czi_extractor` factory function.

Regarding the user-facing API, one just needs to specify `data_type="czi"` in the config factory functions, e.g.:

```python
config_2d = create_n2v_configuration(
    experiment_name="n2v_experiment",
    data_type="czi",
    axes="SCYX",
    patch_size=[64, 64],
    batch_size=32,
    num_epochs=100,
    independent_channels=True,
    n_channels=1,
)
config_3d = create_n2v_configuration(
    experiment_name="n2v_experiment",
    data_type="czi",
    axes="SCZYX",
    patch_size=[16, 64, 64],
    batch_size=16,
    num_epochs=100,
    independent_channels=True,
    n_channels=1,
)
```

The `axes`  argument can be one of the following:

- `SCYX`: perform 2-D denoising (also works on time-series and Z-stacks).
- `SCZYX`: perform 3-D denoising. If no Z axis is present, the T (time) axis will be used as 3rd dimension instead.
- `SCTYX`: perform 3-D denoising, enforcing the T (time) axis to be used as 3rd dimension.


## Changes Made

<!-- This section highlights the important features and files that reviewers should
pay attention to when reviewing. Only list important features or files, this is useful for 
reviewers to correctly assess how deeply the modifications impact the code base.

For instance:

### New features or files
- `NewClass` added to `new_file.py`
- `new_function` added to `existing_file.py`

...
-->

### New features or files

<!-- List new features or files added. -->
- `CziImageStack` added to new file `src/careamics/dataset_ng/image_stack/czi_image_stack.py`
- `create_czi_extractor` added to existing file `src/careamics/dataset_ng/patch_extractor/patch_extractor_factory.py`

### Modified features or files

<!-- List important modified features or files. -->
- Support `"czi"` as data type in `src/careamics/dataset_ng/factory.py`

### Removed features or files

<!-- List removed features or files. -->

## How has this been tested?

<!-- Describe the tests that you ran to verify your changes. This can be a short 
description of the tests added to the PR or code snippet to reproduce the change
in behaviour. -->

- New unit test in `tests/dataset_ng/patch_extractor/image_stack/test_czi_image_stack.py` for testing `CziImageStack`. Random data is written to a new CZI file and then read back using `CziImageStack` with different `axes` modes.
- Training and inference with a N2V model on a CZI file ran successfully.


## Related Issues

<!-- Link to any related issues or discussions. Use keywords like "Fixes", "Resolves",
or "Closes" to link to issues automatically. -->

## Breaking changes

<!-- Describe any breaking changes introduced by this PR. -->

## Additional Notes and Examples

<!-- Provide any additional information that will help reviewers understand the
changes. This can be links to documentations, forum posts, past discussions etc. -->

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)


on-behalf-of: @zeiss <bjoern.barz@zeiss.com>