### PR TITLE
Fix: N2V masking bugs

### DIFF
--- a/src/careamics/config/configuration.py
+++ b/src/careamics/config/configuration.py
@@ -6,6 +6,7 @@ import re
 from pprint import pformat
 from typing import Any, Callable, Literal, Union
 
+import numpy as np
 from bioimageio.spec.generic.v0_3 import CiteEntry
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic.main import IncEx
@@ -182,6 +183,49 @@ class Configuration(BaseModel):
             )
 
         return name
+
+    @model_validator(mode="after")
+    def validate_n2v_mask_pixel_perc(self: Self) -> Self:
+        """
+        Validate that there will always be at least one blind-spot pixel in every patch.
+
+        The probability of creating a blind-spot pixel is a function of the chosen
+        masked pixel percentage and patch size.
+
+        Returns
+        -------
+        Self
+            Validated configuration.
+
+        Raises
+        ------
+        ValueError
+            If the probability of masking a pixel within a patch is less than 1 for the
+            chosen masked pixel percentage and patch size.
+        """
+        # No validation needed for non n2v algorithms
+        if not isinstance(self.algorithm_config, N2VAlgorithm):
+            return self
+
+        mask_pixel_perc = self.algorithm_config.n2v_config.masked_pixel_percentage
+        patch_size = self.data_config.patch_size
+        expected_area_per_pixel = 1 / (mask_pixel_perc / 100)
+
+        n_dims = 3 if self.algorithm_config.model.is_3D() else 2
+        required_patch_size = tuple(
+            int(np.ceil(expected_area_per_pixel ** (1 / n_dims))) for _ in range(n_dims)
+        )
+        required_mask_pixel_perc = (1 / np.prod(patch_size)) * 100
+        if expected_area_per_pixel > np.prod(patch_size):
+            raise ValueError(
+                "The probability of creating a blind-spot pixel is "
+                f"below 1, for a patch size of {patch_size} with a masked pixel "
+                f"percentage of {mask_pixel_perc}%. Either increase the patch size to "
+                f"{required_patch_size} or increase the masked pixel percentage to "
+                f"at least {required_mask_pixel_perc}."
+            )
+
+        return self
 
     @model_validator(mode="after")
     def validate_3D(self: Self) -> Self:

--- a/src/careamics/config/configuration.py
+++ b/src/careamics/config/configuration.py
@@ -212,17 +212,18 @@ class Configuration(BaseModel):
         expected_area_per_pixel = 1 / (mask_pixel_perc / 100)
 
         n_dims = 3 if self.algorithm_config.model.is_3D() else 2
+        patch_size_lower_bound = int(np.ceil(expected_area_per_pixel ** (1 / n_dims)))
         required_patch_size = tuple(
-            int(np.ceil(expected_area_per_pixel ** (1 / n_dims))) for _ in range(n_dims)
+            2 ** int(np.ceil(np.log2(patch_size_lower_bound))) for _ in range(n_dims)
         )
         required_mask_pixel_perc = (1 / np.prod(patch_size)) * 100
         if expected_area_per_pixel > np.prod(patch_size):
             raise ValueError(
-                "The probability of creating a blind-spot pixel is "
+                "The probability of creating a blind-spot pixel within a patch is "
                 f"below 1, for a patch size of {patch_size} with a masked pixel "
                 f"percentage of {mask_pixel_perc}%. Either increase the patch size to "
                 f"{required_patch_size} or increase the masked pixel percentage to "
-                f"at least {required_mask_pixel_perc}."
+                f"at least {required_mask_pixel_perc}%."
             )
 
         return self

--- a/src/careamics/transforms/n2v_manipulate_torch.py
+++ b/src/careamics/transforms/n2v_manipulate_torch.py
@@ -27,6 +27,8 @@ class N2VManipulateTorch:
         N2V manipulation configuration.
     seed : Optional[int], optional
         Random seed, by default None.
+    device : str
+        The device on which operations take place, e.g. "cuda", "cpu" or "mps".
 
     Attributes
     ----------
@@ -48,6 +50,7 @@ class N2VManipulateTorch:
         self,
         n2v_manipulate_config: N2VManipulateModel,
         seed: Optional[int] = None,
+        device: Optional[str] = None,
     ):
         """Constructor.
 
@@ -57,6 +60,8 @@ class N2VManipulateTorch:
             N2V manipulation configuration.
         seed : Optional[int], optional
             Random seed, by default None.
+        device : str
+            The device on which operations take place, e.g. "cuda", "cpu" or "mps".
         """
         self.masked_pixel_percentage = n2v_manipulate_config.masked_pixel_percentage
         self.roi_size = n2v_manipulate_config.roi_size
@@ -78,15 +83,16 @@ class N2VManipulateTorch:
 
         # PyTorch random generator
         # TODO refactor into careamics.utils.torch_utils.get_device
-        if torch.cuda.is_available():
-            device = "cuda"
-        elif torch.backends.mps.is_available() and platform.processor() in (
-            "arm",
-            "arm64",
-        ):
-            device = "mps"
-        else:
-            device = "cpu"
+        if device is None:
+            if torch.cuda.is_available():
+                device = "cuda"
+            elif torch.backends.mps.is_available() and platform.processor() in (
+                "arm",
+                "arm64",
+            ):
+                device = "mps"
+            else:
+                device = "cpu"
 
         self.rng = (
             torch.Generator(device=device).manual_seed(seed)

--- a/src/careamics/transforms/pixel_manipulation_torch.py
+++ b/src/careamics/transforms/pixel_manipulation_torch.py
@@ -83,7 +83,6 @@ def _get_stratified_coords_torch(
     """
     Generate coordinates of the pixels to mask.
 
-    # TODO add more details
     Randomly selects the coordinates of the pixels to mask in a stratified way, i.e.
     the distance between masked pixels is approximately the same. This is achieved by
     defining a grid and sampling a pixel in each grid square. The grid is defined such
@@ -118,7 +117,7 @@ def _get_stratified_coords_torch(
     expected_area_per_pixel = 1 / (mask_pixel_perc / 100)
     # TODO: validate in config that expected_area_per_pixel < prod(patch size)
 
-    grid_size = expected_area_per_pixel**0.5
+    grid_size = expected_area_per_pixel ** (1 / n_dims)
     grid_dims = torch.ceil(torch.tensor(spatial_shape) / grid_size).int()
 
     # coords on a fixed grid
@@ -126,6 +125,7 @@ def _get_stratified_coords_torch(
         torch.meshgrid(
             torch.arange(batch_size, dtype=torch.float),
             *[torch.arange(0, grid_dims[i].item()) * grid_size for i in range(n_dims)],
+            indexing="ij",
         ),
         -1,
     ).reshape(-1, n_dims + 1)
@@ -160,7 +160,7 @@ def uniform_manipulate_torch(
 
     # TODO add more details, especially about batch
 
-    Manipulated pixels are selected unformly selected in a subpatch, away from a grid
+    Manipulated pixels are selected uniformly selected in a subpatch, away from a grid
     with an approximate uniform probability to be selected across the whole patch.
     If `struct_params` is not None, an additional structN2V mask is applied to the
     data, replacing the pixels in the mask with random values (excluding the pixel
@@ -278,7 +278,7 @@ def median_manipulate_torch(
     struct_params : StructMaskParameters or None, optional
         Parameters for the structN2V mask (axis and span).
     rng : torch.default_generator or None, optional
-        Random number generato, by default None.
+        Random number generator, by default None.
 
     Returns
     -------

--- a/tests/config/test_configuration.py
+++ b/tests/config/test_configuration.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 
 from careamics.config import Configuration
 
@@ -51,3 +52,14 @@ def test_set_3D(minimum_supervised_configuration: dict):
     assert conf.data_config.axes == "SYX"
     assert conf.data_config.patch_size == [64, 64]
     assert conf.algorithm_config.model.conv_dims == 2
+
+
+def test_validate_n2v_mask_pixel_perc(minimum_n2v_configuration):
+
+    minimum_n2v_configuration["data_config"]["patch_size"] = [16, 16]
+    minimum_n2v_configuration["algorithm_config"]["n2v_config"][
+        "masked_pixel_percentage"
+    ] = 0.2
+
+    with pytest.raises(ValidationError):
+        Configuration(**minimum_n2v_configuration)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,8 +200,17 @@ def minimum_n2v_configuration(
     Returns
     -------
     dict
-        A minumum configuration example.
+        A minimum configuration example.
     """
+    if "n2v_config" not in minimum_algorithm_n2v:
+        minimum_algorithm_n2v["n2v_config"] = {}
+
+    mask_pixel_perc = 100 / np.prod(minimum_data["patch_size"])
+    mask_pixel_perc = np.ceil(mask_pixel_perc * 10) / 10
+    minimum_algorithm_n2v["n2v_config"]["masked_pixel_percentage"] = 100 / np.prod(
+        minimum_data["patch_size"]
+    )
+
     # create dictionary
     configuration = {
         "experiment_name": "LevitatingFrog",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,9 +202,9 @@ def minimum_n2v_configuration(
     dict
         A minimum configuration example.
     """
+    # update masked pixel percentage so config validation will pass
     if "n2v_config" not in minimum_algorithm_n2v:
         minimum_algorithm_n2v["n2v_config"] = {}
-
     mask_pixel_perc = 100 / np.prod(minimum_data["patch_size"])
     mask_pixel_perc = np.ceil(mask_pixel_perc * 10) / 10
     minimum_algorithm_n2v["n2v_config"]["masked_pixel_percentage"] = 100 / np.prod(

--- a/tests/transforms/test_manipulate_n2v.py
+++ b/tests/transforms/test_manipulate_n2v.py
@@ -45,7 +45,7 @@ def test_manipulate_n2v_torch(strategy):
         roi_size=5, masked_pixel_percentage=5, strategy=strategy.value
     )
     # Create augmentation
-    aug = N2VManipulateTorch(config)
+    aug = N2VManipulateTorch(config, device="cpu")
 
     # Apply augmentation
     augmented = aug(array)


### PR DESCRIPTION
## Description

> [!NOTE]  
> **tldr**: Some bugs were discovered in the n2v masking functions. This PR fixes said bugs. Additionally validation has been added to the configuration to make sure that every patch will have at least one blind-spot pixel.

### Background - why do we need this PR?

It seems the bugs were affecting training stability in some cases, hopefully these fixes will solve the problem.

### Overview - what changed?

- Replaced the `_get_stratified_coords_torch` function with a new simpler (still vectorised) implementation, that I think is actually closer to the original tensorflow implementation. 
- Modified how the replacement pixels are selected in `uniform_manipulate_torch`.
- Added new validation to the `Configuration`, to make sure there is always at least one masked pixel in each patch.
- Added optional `device` argument to `N2VManipulateTorch` to allow for local testing using the cpu when cuda is available.

### Implementation - how did you implement the changes?

The stratified coords func defines a grid of coordinates on the spatial dimensions which is the same for each sample in the batch. Then a random offset is added only in the spatial dimensions. Finally coordinates that lie outside of the patch dimensions are filtered, not clipped, this ensures that the average masked pixel percentage will converge to the chosen masked pixel percentage. See docs for a better explanation.

Made sure selected replacement pixels in `uniform_manipulate_torch` do not get mixed over a batch.

## Changes Made

### New features or files

<!-- List new features or files added. -->
- `Configuration.validate_n2v_mask_pixel_perc`

### Modified features or files

<!-- List important modified features or files. -->
- `_get_stratified_coords_torch`
- `uniform_manipulate_torch`
- `N2VManipulateTorch.__init__`

### Removed features or files

<!-- List removed features or files. -->
- `_odd_jitter_func_torch`

## How has this been tested?

Tested by observing results in notebooks, additional tests should be added. I will open an issue shortly

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)