### PR TITLE
chore: Ignore ruff errors on module import in CZI tests

### DIFF
--- a/tests/dataset_ng/patch_extractor/image_stack/test_czi_image_stack.py
+++ b/tests/dataset_ng/patch_extractor/image_stack/test_czi_image_stack.py
@@ -6,12 +6,12 @@ import numpy as np
 import pytest
 from numpy.typing import NDArray
 
+from careamics.dataset_ng.patch_extractor.image_stack import CziImageStack
+
 # skip if fail imports
 pylib = pytest.importorskip("pylibCZIrw")
 
-from pylibCZIrw import czi as pyczi
-
-from careamics.dataset_ng.patch_extractor.image_stack import CziImageStack
+from pylibCZIrw import czi as pyczi  # noqa: E402
 
 T_EXPR = "does not contain a T axis"
 Z_EXPR = "does not contain a Z axis"


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

Simply add `# noqa` on module imports in CZI tests to avoid `ruff` errors.