### PR TITLE
MicroSplit config for lightning api draft

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     'pydantic>=2.11,<=2.12',
     'pytorch_lightning>=2.2,<=2.5.5',
     'pyyaml<=6.0.2,!=6.0.0',
-    'typer>=0.12.3,<=0.17.4',
+    'typer>=0.12.3,<=0.17.3',
     'scikit-image<=0.25.2',
     'zarr<3.0.0',
     'pillow<=11.3.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     'pydantic>=2.11,<=2.12',
     'pytorch_lightning>=2.2,<=2.5.5',
     'pyyaml<=6.0.2,!=6.0.0',
-    'typer>=0.12.3,<=0.17.3',
+    'typer>=0.12.3,<=0.17.4',
     'scikit-image<=0.25.2',
     'zarr<3.0.0',
     'pillow<=11.3.0',

--- a/src/careamics/config/__init__.py
+++ b/src/careamics/config/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "HDNAlgorithm",
     "InferenceConfig",
     "LVAELossConfig",
+    "MicroSplitAlgorithm",
     "MultiChannelNMConfig",
     "N2NAlgorithm",
     "N2VAlgorithm",
@@ -24,6 +25,7 @@ __all__ = [
     "algorithm_factory",
     "create_care_configuration",
     "create_hdn_configuration",
+    "create_microsplit_configuration",
     "create_n2n_configuration",
     "create_n2v_configuration",
     "load_configuration",
@@ -33,6 +35,7 @@ __all__ = [
 from .algorithms import (
     CAREAlgorithm,
     HDNAlgorithm,
+    MicroSplitAlgorithm,
     N2NAlgorithm,
     N2VAlgorithm,
     UNetBasedAlgorithm,
@@ -44,6 +47,7 @@ from .configuration_factories import (
     algorithm_factory,
     create_care_configuration,
     create_hdn_configuration,
+    create_microsplit_configuration,
     create_n2n_configuration,
     create_n2v_configuration,
 )

--- a/src/careamics/config/algorithms/__init__.py
+++ b/src/careamics/config/algorithms/__init__.py
@@ -3,6 +3,7 @@
 __all__ = [
     "CAREAlgorithm",
     "HDNAlgorithm",
+    "MicroSplitAlgorithm",
     "N2NAlgorithm",
     "N2VAlgorithm",
     "UNetBasedAlgorithm",
@@ -11,6 +12,7 @@ __all__ = [
 
 from .care_algorithm_model import CAREAlgorithm
 from .hdn_algorithm_model import HDNAlgorithm
+from .microsplit_algorithm_model import MicroSplitAlgorithm
 from .n2n_algorithm_model import N2NAlgorithm
 from .n2v_algorithm_model import N2VAlgorithm
 from .unet_algorithm_model import UNetBasedAlgorithm

--- a/src/careamics/config/algorithms/microsplit_algorithm_model.py
+++ b/src/careamics/config/algorithms/microsplit_algorithm_model.py
@@ -1,0 +1,101 @@
+"""MicroSplit algorithm configuration."""
+
+from typing import Literal
+
+from bioimageio.spec.generic.v0_3 import CiteEntry
+from pydantic import ConfigDict
+
+from careamics.config.algorithms.vae_algorithm_model import VAEBasedAlgorithm
+from careamics.config.architectures import LVAEModel
+from careamics.config.loss_model import LVAELossConfig
+
+MICROSPLIT = "MicroSplit"
+
+MICROSPLIT_DESCRIPTION = """MicroSplit is a self-supervised deep learning method for
+microscopy image restoration that combines the strengths of both denoising and
+representation learning approaches."""
+
+MICROSPLIT_REF = CiteEntry(text='Prakash, M., Delbracio, M., Milanfar, P., Jug, F. 2022. "Interpretable '
+    'Unsupervised Diversity Denoising and Artefact Removal." The International '
+    "Conference on Learning Representations (ICLR).",
+    doi="10.1561/2200000056",)
+
+
+class MicroSplitAlgorithm(VAEBasedAlgorithm):
+    """MicroSplit algorithm configuration."""
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    algorithm: Literal["microsplit"] = "microsplit"
+
+    loss: LVAELossConfig
+
+    model: LVAEModel  # TODO add validators
+
+    is_supervised: bool = False
+
+    def get_algorithm_friendly_name(self) -> str:
+        """
+        Get the algorithm friendly name.
+
+        Returns
+        -------
+        str
+            Friendly name of the algorithm.
+        """
+        return MICROSPLIT
+
+    def get_algorithm_keywords(self) -> list[str]:
+        """
+        Get algorithm keywords.
+
+        Returns
+        -------
+        list[str]
+            List of keywords.
+        """
+        return [
+            "restoration",
+            "VAE",
+            "self-supervised",
+            "3D" if self.model.is_3D() else "2D",
+            "CAREamics",
+            "pytorch",
+        ]
+
+    def get_algorithm_references(self) -> str:
+        """
+        Get the algorithm references.
+
+        This is used to generate the README of the BioImage Model Zoo export.
+
+        Returns
+        -------
+        str
+            Algorithm references.
+        """
+        return MICROSPLIT_REF.text + " doi: " + MICROSPLIT_REF.doi
+
+    def get_algorithm_citations(self) -> list[CiteEntry]:
+        """
+        Return a list of citation entries of the current algorithm.
+
+        This is used to generate the model description for the BioImage Model Zoo.
+
+        Returns
+        -------
+        List[CiteEntry]
+            List of citation entries.
+        """
+        return [MICROSPLIT_REF]
+
+    def get_algorithm_description(self) -> str:
+        """
+        Get the algorithm description.
+
+        Returns
+        -------
+        str
+            Algorithm description.
+        """
+        return MICROSPLIT_DESCRIPTION

--- a/src/careamics/config/algorithms/microsplit_algorithm_model.py
+++ b/src/careamics/config/algorithms/microsplit_algorithm_model.py
@@ -12,7 +12,7 @@ from careamics.config.loss_model import LVAELossConfig
 MICROSPLIT = "MicroSplit"
 
 MICROSPLIT_DESCRIPTION = """MicroSplit is a self-supervised deep learning method for
-microscopy image restoration that combines the strengths of both denoising and
+microscopy image splitting that combines the strengths of both denoising and
 representation learning approaches."""
 
 MICROSPLIT_REF = CiteEntry(

--- a/src/careamics/config/algorithms/microsplit_algorithm_model.py
+++ b/src/careamics/config/algorithms/microsplit_algorithm_model.py
@@ -15,10 +15,12 @@ MICROSPLIT_DESCRIPTION = """MicroSplit is a self-supervised deep learning method
 microscopy image restoration that combines the strengths of both denoising and
 representation learning approaches."""
 
-MICROSPLIT_REF = CiteEntry(text='Prakash, M., Delbracio, M., Milanfar, P., Jug, F. 2022. "Interpretable '
+MICROSPLIT_REF = CiteEntry(
+    text='Prakash, M., Delbracio, M., Milanfar, P., Jug, F. 2022. "Interpretable '
     'Unsupervised Diversity Denoising and Artefact Removal." The International '
     "Conference on Learning Representations (ICLR).",
-    doi="10.1561/2200000056",)
+    doi="10.1561/2200000056",
+)
 
 
 class MicroSplitAlgorithm(VAEBasedAlgorithm):

--- a/src/careamics/config/algorithms/vae_algorithm_model.py
+++ b/src/careamics/config/algorithms/vae_algorithm_model.py
@@ -40,7 +40,7 @@ class VAEBasedAlgorithm(BaseModel):
     # defined in SupportedAlgorithm
     # TODO: Use supported Enum classes for typing?
     #   - values can still be passed as strings and they will be cast to Enum
-    algorithm: Literal["hdn", "musplit", "denoisplit"]
+    algorithm: Literal["hdn", "microsplit", "musplit", "denoisplit"]
 
     # NOTE: these are all configs (pydantic models)
     loss: LVAELossConfig
@@ -77,21 +77,16 @@ class VAEBasedAlgorithm(BaseModel):
             if self.model.multiscale_count > 1:
                 raise ValueError("Algorithm `hdn` does not support multiscale models.")
         # musplit
-        if self.algorithm == SupportedAlgorithm.MUSPLIT:
-            if self.loss.loss_type != SupportedLoss.MUSPLIT:
-                raise ValueError(
-                    f"Algorithm {self.algorithm} only supports loss `musplit`."
-                )
-
-        if self.algorithm == SupportedAlgorithm.DENOISPLIT:
+        if self.algorithm == SupportedAlgorithm.MICROSPLIT:
             if self.loss.loss_type not in [
+                SupportedLoss.MUSPLIT,
                 SupportedLoss.DENOISPLIT,
                 SupportedLoss.DENOISPLIT_MUSPLIT,
             ]:
                 raise ValueError(
-                    f"Algorithm {self.algorithm} only supports loss `denoisplit` "
-                    "or `denoisplit_musplit."
-                )
+                    f"Algorithm {self.algorithm} only supports loss `microsplit`."
+                )  # TODO Update losses configs
+
             if (
                 self.loss.loss_type == SupportedLoss.DENOISPLIT
                 and self.model.predict_logvar is not None
@@ -100,8 +95,10 @@ class VAEBasedAlgorithm(BaseModel):
                     "Algorithm `denoisplit` with loss `denoisplit` only supports "
                     "`predict_logvar` as `None`."
                 )
-
-            if self.noise_model is None:
+            if (
+                self.loss.loss_type == SupportedLoss.DENOISPLIT
+                and self.noise_model is None
+            ):
                 raise ValueError("Algorithm `denoisplit` requires a noise model.")
         # TODO: what if algorithm is not musplit or denoisplit
         return self
@@ -176,5 +173,4 @@ class VAEBasedAlgorithm(BaseModel):
         list of str
             List of compatible algorithms.
         """
-        # TODO revisit after there's more clarity with VAE algorithms structure
-        return ["hdn"]
+        return ["hdn", "microsplit"]

--- a/src/careamics/config/algorithms/vae_algorithm_model.py
+++ b/src/careamics/config/algorithms/vae_algorithm_model.py
@@ -40,7 +40,7 @@ class VAEBasedAlgorithm(BaseModel):
     # defined in SupportedAlgorithm
     # TODO: Use supported Enum classes for typing?
     #   - values can still be passed as strings and they will be cast to Enum
-    algorithm: Literal["hdn", "microsplit", "musplit", "denoisplit"]
+    algorithm: Literal["hdn", "microsplit"]
 
     # NOTE: these are all configs (pydantic models)
     loss: LVAELossConfig
@@ -82,7 +82,7 @@ class VAEBasedAlgorithm(BaseModel):
                 SupportedLoss.MUSPLIT,
                 SupportedLoss.DENOISPLIT,
                 SupportedLoss.DENOISPLIT_MUSPLIT,
-            ]:
+            ]:  # TODO Update losses configs, make loss just microsplit
                 raise ValueError(
                     f"Algorithm {self.algorithm} only supports loss `microsplit`."
                 )  # TODO Update losses configs

--- a/src/careamics/config/configuration.py
+++ b/src/careamics/config/configuration.py
@@ -16,6 +16,7 @@ from typing_extensions import Self
 from careamics.config.algorithms import (
     CAREAlgorithm,
     HDNAlgorithm,
+    MicroSplitAlgorithm,
     N2NAlgorithm,
     N2VAlgorithm,
 )
@@ -24,9 +25,10 @@ from careamics.config.training_model import TrainingConfig
 
 ALGORITHMS = Union[
     CAREAlgorithm,
+    HDNAlgorithm,
+    MicroSplitAlgorithm,
     N2NAlgorithm,
     N2VAlgorithm,
-    HDNAlgorithm,
 ]
 
 

--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -1358,7 +1358,7 @@ def _create_vae_configuration(
 
 
 def _create_vae_based_algorithm(
-    algorithm: Literal["hdn"],
+    algorithm: Literal["hdn", "microsplit"],
     loss: LVAELossConfig,
     input_shape: Sequence[int],
     encoder_conv_strides: tuple[int, ...],
@@ -1450,6 +1450,7 @@ def _create_vae_based_algorithm(
 
 def get_likelihood_config(
     loss_type: Literal["musplit", "denoisplit", "denoisplit_musplit"],
+    # TODO remove different microsplit loss types, refac
     predict_logvar: Literal["pixelwise"] | None = None,
     logvar_lowerbound: float = -5.0,
     nm_paths: list[str] | None = None,
@@ -1801,7 +1802,6 @@ def create_microsplit_configuration(
         nonlinearity=nonlinearity,
         predict_logvar=predict_logvar,
         analytical_kl=analytical_kl,
-        model_params=model_params,
     )
 
     # Create the MicroSplit algorithm configuration

--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -7,6 +7,7 @@ from pydantic import Field, TypeAdapter
 
 from careamics.config.algorithms import (
     CAREAlgorithm,
+    MicroSplitAlgorithm,
     N2NAlgorithm,
     N2VAlgorithm,
 )
@@ -17,6 +18,7 @@ from careamics.config.likelihood_model import (
     NMLikelihoodConfig,
 )
 from careamics.config.loss_model import LVAELossConfig
+from careamics.config.nm_model import GaussianMixtureNMConfig, MultiChannelNMConfig
 from careamics.config.support import (
     SupportedArchitecture,
     SupportedPixelManipulation,
@@ -1446,6 +1448,86 @@ def _create_vae_based_algorithm(
     }
 
 
+def get_likelihood_config(
+    loss_type: Literal["musplit", "denoisplit", "denoisplit_musplit"],
+    predict_logvar: Literal["pixelwise"] | None = None,
+    logvar_lowerbound: float = -5.0,
+    nm_paths: list[str] | None = None,
+    data_stats: tuple[float, float] | None = None,
+) -> tuple[
+    GaussianLikelihoodConfig | None,
+    MultiChannelNMConfig | None,
+    NMLikelihoodConfig | None,
+]:
+    """Get the likelihood configuration for split models.
+
+    Parameters
+    ----------
+    loss_type : Literal["musplit", "denoisplit", "denoisplit_musplit"]
+        The type of loss function to use.
+    predict_logvar : Literal["pixelwise"] | None, optional
+        Type of log variance prediction, by default None.
+        Required when loss_type is "musplit" or "denoisplit_musplit".
+    logvar_lowerbound : float, optional
+        Lower bound for the log variance, by default -5.0.
+        Used when loss_type is "musplit" or "denoisplit_musplit".
+    nm_paths : list[str] | None, optional
+        Paths to the noise model files, by default None.
+        Required when loss_type is "denoisplit" or "denoisplit_musplit".
+    data_stats : tuple[float, float] | None, optional
+        Data statistics (mean, std), by default None.
+        Required when loss_type is "denoisplit" or "denoisplit_musplit".
+
+    Returns
+    -------
+    tuple[GaussianLikelihoodConfig | None, MultiChannelNMConfig | None,
+    NMLikelihoodConfig | None]
+        The likelihoods and noise models configurations.
+
+    Raises
+    ------
+    ValueError
+        If required parameters are missing for the specified loss_type.
+    """
+    # gaussian likelihood
+    if loss_type in ["musplit", "denoisplit_musplit"]:
+        if predict_logvar is None:
+            raise ValueError(f"predict_logvar is required for loss_type '{loss_type}'")
+
+        gaussian_lik_config = GaussianLikelihoodConfig(
+            predict_logvar=predict_logvar,
+            logvar_lowerbound=logvar_lowerbound,
+        )
+    else:
+        gaussian_lik_config = None
+
+    # noise model likelihood
+    if loss_type in ["denoisplit", "denoisplit_musplit"]:
+        if nm_paths is None:
+            raise ValueError(f"nm_paths is required for loss_type '{loss_type}'")
+        if data_stats is None:
+            raise ValueError(f"data_stats is required for loss_type '{loss_type}'")
+
+        gmm_list = []
+        for NM_path in nm_paths:
+            gmm_list.append(
+                GaussianMixtureNMConfig(
+                    model_type="GaussianMixtureNoiseModel",
+                    path=NM_path,
+                )
+            )
+        noise_model_config = MultiChannelNMConfig(noise_models=gmm_list)
+        nm_lik_config = NMLikelihoodConfig(
+            data_mean=data_stats[0],
+            data_std=data_stats[1],
+        )
+    else:
+        noise_model_config = None
+        nm_lik_config = None
+
+    return gaussian_lik_config, noise_model_config, nm_lik_config
+
+
 # TODO wrap parameters into model, loss etc
 # TODO refac likelihood configs to make it 1. Can it be done ?
 def create_hdn_configuration(
@@ -1603,6 +1685,157 @@ def create_hdn_configuration(
     return Configuration(
         experiment_name=experiment_name,
         algorithm_config=algorithm_params,
+        data_config=data_params,
+        training_config=training_params,
+    )
+
+
+def create_microsplit_configuration(
+    experiment_name: str,
+    data_type: Literal["array", "tiff", "custom"],
+    axes: str,
+    patch_size: Sequence[int],
+    batch_size: int,
+    num_epochs: int,
+    encoder_conv_strides: tuple[int, ...] = (2, 2),
+    decoder_conv_strides: tuple[int, ...] = (2, 2),
+    multiscale_count: int = 1,
+    z_dims: tuple[int, ...] = (128, 128),
+    output_channels: int = 1,
+    encoder_n_filters: int = 32,
+    decoder_n_filters: int = 32,
+    encoder_dropout: float = 0.0,
+    decoder_dropout: float = 0.0,
+    nonlinearity: Literal[
+        "None", "Sigmoid", "Softmax", "Tanh", "ReLU", "LeakyReLU", "ELU"
+    ] = "ReLU",
+    analytical_kl: bool = False,
+    predict_logvar: Literal["pixelwise"] | None = None,
+    logvar_lowerbound: Union[float, None] = None,
+    logger: Literal["wandb", "tensorboard", "none"] = "none",
+    model_params: dict | None = None,
+    augmentations: list[Union[XYFlipModel, XYRandomRotate90Model]] | None = None,
+    nm_paths: list[str] | None = None,
+    data_stats: tuple[float, float] | None = None,
+    train_dataloader_params: dict[str, Any] | None = None,
+    val_dataloader_params: dict[str, Any] | None = None,
+):
+    """
+    Create_microsplit_configuration.
+
+    Parameters
+    ----------
+    input_shape : tuple, default=(1, 64, 64)
+        Shape of the input patch (channels, Y, X) or (channels, Z, Y, X) for 3D.
+    z_dims : tuple, default=(128, 128, 128, 128)
+        List of latent dimensions for each hierarchy level in the LVAE.
+    encoder_conv_strides : tuple, default=(2, 2)
+        Strides for the encoder convolutional layers.
+    decoder_conv_strides : tuple, default=(2, 2)
+        Strides for the decoder convolutional layers.
+    multiscale_count : int, default=0
+        Number of multiscale levels (0 disables multiscale).
+    output_channels : int, default=1
+        Number of output channels for the model.
+    encoder_n_filters : int, default=64
+        Number of filters in the encoder.
+    decoder_n_filters : int, default=64
+        Number of filters in the decoder.
+    encoder_dropout : float, default=0.1
+        Dropout rate for the encoder.
+    decoder_dropout : float, default=0.1
+        Dropout rate for the decoder.
+    nonlinearity : str, default="ELU"
+        Nonlinearity to use in the model (e.g., "ELU", "ReLU").
+    predict_logvar : str, default="pixelwise"
+        Type of log-variance prediction ("pixelwise" or None).
+    analytical_kl : bool, default=False
+        Whether to use analytical KL divergence.
+    optimizer : str, default="Adam"
+        Optimizer to use for training.
+    optimizer_params : dict, optional
+        Parameters for the optimizer.
+    lr_scheduler : str, default="ReduceLROnPlateau"
+        Learning rate scheduler to use.
+    lr_scheduler_params : dict, optional
+        Parameters for the learning rate scheduler.
+    loss_weights : dict, optional
+        Weights for different loss components.
+    **kwargs : dict
+        Additional keyword arguments for the configuration.
+
+    Returns
+    -------
+    Configuration
+        A configuration object for the microsplit algorithm.
+    """
+    transform_list = _list_spatial_augmentations(augmentations)
+
+    loss_config = LVAELossConfig(
+        loss_type="denoisplit_musplit", denoisplit_weight=0.9, musplit_weight=0.1
+    )  # TODO losses need to be refactored! This is just for example
+
+    # Create likelihood configurations
+    gaussian_likelihood_config, noise_model_config, nm_likelihood_config = (
+        get_likelihood_config(
+            loss_type="denoisplit_musplit",
+            predict_logvar=predict_logvar,
+            logvar_lowerbound=logvar_lowerbound,
+            nm_paths=nm_paths,
+            data_stats=data_stats,
+        )
+    )
+
+    # Create the LVAE model
+    network_model = _create_vae_configuration(
+        input_shape=patch_size,
+        encoder_conv_strides=encoder_conv_strides,
+        decoder_conv_strides=decoder_conv_strides,
+        multiscale_count=multiscale_count,
+        z_dims=z_dims,
+        output_channels=output_channels,
+        encoder_n_filters=encoder_n_filters,
+        decoder_n_filters=decoder_n_filters,
+        encoder_dropout=encoder_dropout,
+        decoder_dropout=decoder_dropout,
+        nonlinearity=nonlinearity,
+        predict_logvar=predict_logvar,
+        analytical_kl=analytical_kl,
+        model_params=model_params,
+    )
+
+    # Create the MicroSplit algorithm configuration
+    algorithm_params = {
+        "algorithm": "microsplit",
+        "loss": loss_config,
+        "model": network_model,
+        "gaussian_likelihood": gaussian_likelihood_config,
+        "noise_model_likelihood": nm_likelihood_config,
+    }
+
+    # Convert to MicroSplitAlgorithm instance
+    algorithm_config = MicroSplitAlgorithm(**algorithm_params)
+
+    # data
+    data_params = _create_data_configuration(
+        data_type=data_type,
+        axes=axes,
+        patch_size=patch_size,
+        batch_size=batch_size,
+        augmentations=transform_list,
+        train_dataloader_params=train_dataloader_params,
+        val_dataloader_params=val_dataloader_params,
+    )
+
+    # training
+    training_params = _create_training_configuration(
+        num_epochs=num_epochs,
+        logger=logger,
+    )
+
+    return Configuration(
+        experiment_name=experiment_name,
+        algorithm_config=algorithm_config,
         data_config=data_params,
         training_config=training_params,
     )

--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -1714,13 +1714,12 @@ def create_microsplit_configuration(
     predict_logvar: Literal["pixelwise"] | None = None,
     logvar_lowerbound: Union[float, None] = None,
     logger: Literal["wandb", "tensorboard", "none"] = "none",
-    model_params: dict | None = None,
     augmentations: list[Union[XYFlipModel, XYRandomRotate90Model]] | None = None,
     nm_paths: list[str] | None = None,
     data_stats: tuple[float, float] | None = None,
     train_dataloader_params: dict[str, Any] | None = None,
     val_dataloader_params: dict[str, Any] | None = None,
-):
+):  # TODO loss selection shouldn't be done here. Loss will become just microsplit
     """
     Create_microsplit_configuration.
 
@@ -1774,7 +1773,7 @@ def create_microsplit_configuration(
 
     loss_config = LVAELossConfig(
         loss_type="denoisplit_musplit", denoisplit_weight=0.9, musplit_weight=0.1
-    )  # TODO losses need to be refactored! This is just for example
+    )  # TODO losses need to be refactored! just for example. Add validator if sum to 1
 
     # Create likelihood configurations
     gaussian_likelihood_config, noise_model_config, nm_likelihood_config = (

--- a/src/careamics/config/loss_model.py
+++ b/src/careamics/config/loss_model.py
@@ -35,7 +35,7 @@ class LVAELossConfig(BaseModel):
         validate_assignment=True, validate_default=True, arbitrary_types_allowed=True
     )
 
-    loss_type: Literal["hdn", "musplit", "denoisplit", "denoisplit_musplit"]
+    loss_type: Literal["hdn", "microsplit", "musplit", "denoisplit", "denoisplit_musplit"]
     """Type of loss to use for LVAE."""
 
     reconstruction_weight: float = 1.0

--- a/src/careamics/config/loss_model.py
+++ b/src/careamics/config/loss_model.py
@@ -35,7 +35,9 @@ class LVAELossConfig(BaseModel):
         validate_assignment=True, validate_default=True, arbitrary_types_allowed=True
     )
 
-    loss_type: Literal["hdn", "microsplit", "musplit", "denoisplit", "denoisplit_musplit"]
+    loss_type: Literal[
+        "hdn", "microsplit", "musplit", "denoisplit", "denoisplit_musplit"
+    ]
     """Type of loss to use for LVAE."""
 
     reconstruction_weight: float = 1.0

--- a/src/careamics/config/support/supported_algorithms.py
+++ b/src/careamics/config/support/supported_algorithms.py
@@ -26,6 +26,9 @@ class SupportedAlgorithm(str, BaseEnum):
     MUSPLIT = "musplit"
     """An image splitting approach based on ladder VAE architectures."""
 
+    MICROSPLIT = "microsplit"
+    """A micro-level image splitting approach based on ladder VAE architectures."""
+
     DENOISPLIT = "denoisplit"
     """An image splitting and denoising approach based on ladder VAE architectures."""
 

--- a/src/careamics/config/support/supported_losses.py
+++ b/src/careamics/config/support/supported_losses.py
@@ -23,6 +23,7 @@ class SupportedLoss(str, BaseEnum):
     # PN2V = "pn2v"
     HDN = "hdn"
     MUSPLIT = "musplit"
+    MICROSPLIT = "microsplit"
     DENOISPLIT = "denoisplit"
     DENOISPLIT_MUSPLIT = "denoisplit_musplit"
     # CE = "ce"

--- a/src/careamics/config/support/supported_losses.py
+++ b/src/careamics/config/support/supported_losses.py
@@ -25,6 +25,6 @@ class SupportedLoss(str, BaseEnum):
     MUSPLIT = "musplit"
     MICROSPLIT = "microsplit"
     DENOISPLIT = "denoisplit"
-    DENOISPLIT_MUSPLIT = "denoisplit_musplit"
+    DENOISPLIT_MUSPLIT = "denoisplit_musplit" # TODO refac losses, leave only microsplit
     # CE = "ce"
     # DICE = "dice"

--- a/src/careamics/config/support/supported_losses.py
+++ b/src/careamics/config/support/supported_losses.py
@@ -25,6 +25,8 @@ class SupportedLoss(str, BaseEnum):
     MUSPLIT = "musplit"
     MICROSPLIT = "microsplit"
     DENOISPLIT = "denoisplit"
-    DENOISPLIT_MUSPLIT = "denoisplit_musplit" # TODO refac losses, leave only microsplit
+    DENOISPLIT_MUSPLIT = (
+        "denoisplit_musplit"  # TODO refac losses, leave only microsplit
+    )
     # CE = "ce"
     # DICE = "dice"

--- a/tests/config/test_vae_algorithm_model.py
+++ b/tests/config/test_vae_algorithm_model.py
@@ -5,6 +5,7 @@ import pytest
 
 from careamics.config import VAEBasedAlgorithm
 from careamics.config.architectures import LVAEModel
+from careamics.config.loss_model import LVAELossConfig
 from careamics.config.nm_model import (
     GaussianMixtureNMConfig,
     MultiChannelNMConfig,
@@ -67,3 +68,15 @@ def test_no_noise_model_error_denoisplit(minimum_algorithm_denoisplit):
     minimum_algorithm_denoisplit["noise_model"] = None
     with pytest.raises(ValueError):
         VAEBasedAlgorithm(**minimum_algorithm_denoisplit)
+
+
+def test_microsplit_algorithm(minimum_algorithm_microsplit):
+    """Test that the MicroSplit algorithm can be instantiated correctly."""
+    loss = LVAELossConfig(
+        loss_type="denoisplit_musplit", denoisplit_weight=0.9, musplit_weight=0.1
+    )  # TODO losses need to be refactored! This is just for example
+    minimum_algorithm_microsplit["loss"] = loss
+    config = VAEBasedAlgorithm(**minimum_algorithm_microsplit)
+    assert config.algorithm == "microsplit"
+    assert config.model.architecture == "LVAE"
+    assert config.likelihood is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,33 @@ def minimum_algorithm_denoisplit() -> dict:
 
 
 @pytest.fixture
+def minimum_algorithm_microsplit() -> dict:
+    """Create a minimum MicroSplit algorithm dictionary.
+
+    Returns
+    -------
+    dict
+        A minimum MicroSplit algorithm example.
+    """
+    # create dictionary
+    algorithm = {
+        "algorithm": "microsplit",
+        "loss": "microsplit",
+        "model": {
+            "architecture": "LVAE",
+            "z_dims": (128, 128, 128),
+            "multiscale_count": 2,
+            "predict_logvar": "pixelwise",
+        },
+        "likelihood": {
+            "type": "GaussianLikelihoodConfig",
+        },
+    }
+
+    return algorithm
+
+
+@pytest.fixture
 def minimum_data() -> dict:
     """Create a minimum data dictionary.
 

--- a/tests/lightning/test_LVAE_lightning_module.py
+++ b/tests/lightning/test_LVAE_lightning_module.py
@@ -166,7 +166,7 @@ def create_dummy_dloader(
     return DataLoader(dataset, batch_size=batch_size, shuffle=False)
 
 
-# TODO predict logvarr type ?
+# TODO predict logvar type ?
 @pytest.mark.parametrize(
     "multiscale_count, predict_logvar, ll_type, loss_type, output_channels, exp_error",
     [
@@ -178,7 +178,7 @@ def create_dummy_dloader(
         (1, None, "nm", "denoisplit", 1, pytest.raises(ValueError)),
     ],
 )
-def test_hdn_lightining_init(
+def test_hdn_lightning_init(
     multiscale_count: int,
     predict_logvar: str,
     ll_type: str,
@@ -227,61 +227,21 @@ def test_hdn_lightining_init(
 
 
 @pytest.mark.parametrize(
-    "multiscale_count, predict_logvar, loss_type, exp_error",
-    [
-        (1, None, "musplit", does_not_raise()),
-        (1, "pixelwise", "musplit", does_not_raise()),
-        (5, None, "musplit", does_not_raise()),
-        (5, "pixelwise", "musplit", does_not_raise()),
-        (1, None, "denoisplit", pytest.raises(ValueError)),
-    ],
-)
-def test_musplit_lightining_init(
-    multiscale_count: int,
-    predict_logvar: str,
-    loss_type: str,
-    exp_error: Callable,
-):
-    lvae_config = LVAEModel(
-        architecture="LVAE",
-        input_shape=(64, 64),
-        multiscale_count=multiscale_count,
-        z_dims=[128, 128, 128, 128],
-        output_channels=3,
-        predict_logvar=predict_logvar,
-    )
-
-    likelihood_config = GaussianLikelihoodConfig(
-        predict_logvar=predict_logvar,
-        logvar_lowerbound=0.0,
-    )
-
-    with exp_error:
-        vae_config = VAEBasedAlgorithm(
-            algorithm="musplit",
-            loss=LVAELossConfig(loss_type=loss_type),
-            model=lvae_config,
-            gaussian_likelihood=likelihood_config,
-        )
-        lightning_model = VAEModule(
-            algorithm_config=vae_config,
-        )
-        assert lightning_model is not None
-        assert isinstance(lightning_model.model, torch.nn.Module)
-        assert lightning_model.noise_model is None
-        assert lightning_model.noise_model_likelihood is None
-        assert isinstance(lightning_model.gaussian_likelihood, GaussianLikelihood)
-        assert lightning_model.loss_func == musplit_loss
-
-
-@pytest.mark.parametrize(
     "multiscale_count, predict_logvar, target_ch, nm_cnt, loss_type, exp_error",
     [
+        # musplit cases (target_ch=3, no noise model needed)
+        (1, None, 3, 0, "musplit", does_not_raise()),
+        (1, "pixelwise", 3, 0, "musplit", does_not_raise()),
+        (5, None, 3, 0, "musplit", does_not_raise()),
+        (5, "pixelwise", 3, 0, "musplit", does_not_raise()),
+        # denoisplit cases
         (1, None, 1, 1, "denoisplit", does_not_raise()),
         (5, None, 1, 1, "denoisplit", does_not_raise()),
         (1, None, 3, 3, "denoisplit", does_not_raise()),
         (5, None, 3, 3, "denoisplit", does_not_raise()),
         (1, None, 2, 4, "denoisplit", pytest.raises(ValidationError)),
+        (1, "pixelwise", 1, 1, "denoisplit", pytest.raises(ValidationError)),
+        # denoisplit_musplit cases
         (1, None, 1, 1, "denoisplit_musplit", does_not_raise()),
         (1, None, 3, 3, "denoisplit_musplit", does_not_raise()),
         (1, "pixelwise", 1, 1, "denoisplit_musplit", does_not_raise()),
@@ -291,11 +251,9 @@ def test_musplit_lightining_init(
         (5, "pixelwise", 1, 1, "denoisplit_musplit", does_not_raise()),
         (5, "pixelwise", 3, 3, "denoisplit_musplit", does_not_raise()),
         (5, "pixelwise", 2, 4, "denoisplit_musplit", pytest.raises(ValidationError)),
-        (1, "pixelwise", 1, 1, "denoisplit", pytest.raises(ValidationError)),
-        (1, None, 1, 1, "musplit", pytest.raises(ValueError)),
     ],
 )
-def test_denoisplit_lightining_init(
+def test_microsplit_lightning_init(
     tmp_path: Path,
     multiscale_count: int,
     predict_logvar: str,
@@ -315,26 +273,31 @@ def test_denoisplit_lightining_init(
     )
 
     # Create the likelihood config(s)
-    # gaussian
-    if loss_type == "denoisplit_musplit":
+    # gaussian likelihood
+    if loss_type in ["musplit", "denoisplit_musplit"]:
         gaussian_lik_config = GaussianLikelihoodConfig(
             predict_logvar=predict_logvar,
             logvar_lowerbound=0.0,
         )
     else:
         gaussian_lik_config = None
-    # noise model
-    create_dummy_noise_model(tmp_path, 3, 3)
-    gmm = GaussianMixtureNMConfig(
-        model_type="GaussianMixtureNoiseModel",
-        path=tmp_path / "dummy_noise_model.npz",
-    )
-    noise_model_config = MultiChannelNMConfig(noise_models=[gmm] * nm_cnt)
-    nm_lik_config = NMLikelihoodConfig()
+
+    # noise model likelihood
+    if loss_type in ["denoisplit", "denoisplit_musplit"]:
+        create_dummy_noise_model(tmp_path, 3, 3)
+        gmm = GaussianMixtureNMConfig(
+            model_type="GaussianMixtureNoiseModel",
+            path=tmp_path / "dummy_noise_model.npz",
+        )
+        noise_model_config = MultiChannelNMConfig(noise_models=[gmm] * nm_cnt)
+        nm_lik_config = NMLikelihoodConfig()
+    else:
+        noise_model_config = None
+        nm_lik_config = None
 
     with exp_error:
         vae_config = VAEBasedAlgorithm(
-            algorithm="denoisplit",
+            algorithm="microsplit",
             loss=LVAELossConfig(loss_type=loss_type),
             model=lvae_config,
             gaussian_likelihood=gaussian_lik_config,
@@ -346,14 +309,27 @@ def test_denoisplit_lightining_init(
         )
         assert lightning_model is not None
         assert isinstance(lightning_model.model, torch.nn.Module)
-        assert isinstance(lightning_model.noise_model, MultiChannelNoiseModel)
-        assert isinstance(lightning_model.noise_model_likelihood, NoiseModelLikelihood)
-        if loss_type == "denoisplit_musplit":
+
+        # Check specific configurations based on loss type
+        if loss_type == "musplit":
+            assert lightning_model.noise_model is None
+            assert lightning_model.noise_model_likelihood is None
             assert isinstance(lightning_model.gaussian_likelihood, GaussianLikelihood)
-            assert lightning_model.loss_func == denoisplit_musplit_loss
-        else:
+            assert lightning_model.loss_func == musplit_loss
+        elif loss_type == "denoisplit":
+            assert isinstance(lightning_model.noise_model, MultiChannelNoiseModel)
+            assert isinstance(
+                lightning_model.noise_model_likelihood, NoiseModelLikelihood
+            )
             assert lightning_model.gaussian_likelihood is None
             assert lightning_model.loss_func == denoisplit_loss
+        elif loss_type == "denoisplit_musplit":
+            assert isinstance(lightning_model.noise_model, MultiChannelNoiseModel)
+            assert isinstance(
+                lightning_model.noise_model_likelihood, NoiseModelLikelihood
+            )
+            assert isinstance(lightning_model.gaussian_likelihood, GaussianLikelihood)
+            assert lightning_model.loss_func == denoisplit_musplit_loss
 
 
 @pytest.mark.parametrize("batch_size", [1, 8])
@@ -415,20 +391,48 @@ def test_hdn_validation_step(
     lightning_model.validation_step(batch=batch, batch_idx=0)
 
 
-@pytest.mark.parametrize("batch_size", [1, 8])
-@pytest.mark.parametrize("multiscale_count", [1, 5])
-@pytest.mark.parametrize("predict_logvar", [None, "pixelwise"])
-@pytest.mark.parametrize("target_ch", [1, 3])
-def test_musplit_training_step(
+@pytest.mark.parametrize(
+    "batch_size, multiscale_count, predict_logvar, target_ch, loss_type",
+    [
+        # musplit cases
+        (1, 1, None, 3, "musplit"),
+        (1, 1, "pixelwise", 3, "musplit"),
+        (1, 5, None, 3, "musplit"),
+        (1, 5, "pixelwise", 3, "musplit"),
+        (8, 1, None, 3, "musplit"),
+        (8, 1, "pixelwise", 3, "musplit"),
+        (8, 5, None, 3, "musplit"),
+        (8, 5, "pixelwise", 3, "musplit"),
+        # denoisplit cases
+        (8, 1, None, 1, "denoisplit"),
+        (8, 5, None, 1, "denoisplit"),
+        (8, 1, None, 3, "denoisplit"),
+        (8, 5, None, 3, "denoisplit"),
+        # denoisplit_musplit cases
+        (8, 1, None, 1, "denoisplit_musplit"),
+        (8, 1, None, 3, "denoisplit_musplit"),
+        (8, 1, "pixelwise", 1, "denoisplit_musplit"),
+        (8, 1, "pixelwise", 3, "denoisplit_musplit"),
+        (8, 5, None, 1, "denoisplit_musplit"),
+        (8, 5, None, 3, "denoisplit_musplit"),
+        (8, 5, "pixelwise", 1, "denoisplit_musplit"),
+        (8, 5, "pixelwise", 3, "denoisplit_musplit"),
+    ],
+)
+def test_microsplit_training_step(
+    tmp_path: Path,
     batch_size: int,
     multiscale_count: int,
     predict_logvar: str,
     target_ch: int,
+    loss_type: str,
 ):
     lightning_model = create_vae_lightning_model(
-        tmp_path=None,
-        algorithm="musplit",
-        loss_type="musplit",
+        tmp_path=(
+            tmp_path if loss_type in ["denoisplit", "denoisplit_musplit"] else None
+        ),
+        algorithm="microsplit",
+        loss_type=loss_type,
         multiscale_count=multiscale_count,
         predict_logvar=predict_logvar,
         target_ch=target_ch,
@@ -450,20 +454,48 @@ def test_musplit_training_step(
     assert "kl_loss" in train_loss
 
 
-@pytest.mark.parametrize("batch_size", [1, 8])
-@pytest.mark.parametrize("multiscale_count", [1, 5])
-@pytest.mark.parametrize("predict_logvar", [None, "pixelwise"])
-@pytest.mark.parametrize("target_ch", [1, 3])
-def test_musplit_validation_step(
+@pytest.mark.parametrize(
+    "batch_size, multiscale_count, predict_logvar, target_ch, loss_type",
+    [
+        # musplit cases
+        (1, 1, None, 3, "musplit"),
+        (1, 1, "pixelwise", 3, "musplit"),
+        (1, 5, None, 3, "musplit"),
+        (1, 5, "pixelwise", 3, "musplit"),
+        (8, 1, None, 3, "musplit"),
+        (8, 1, "pixelwise", 3, "musplit"),
+        (8, 5, None, 3, "musplit"),
+        (8, 5, "pixelwise", 3, "musplit"),
+        # denoisplit cases
+        (8, 1, None, 1, "denoisplit"),
+        (8, 5, None, 1, "denoisplit"),
+        (8, 1, None, 3, "denoisplit"),
+        (8, 5, None, 3, "denoisplit"),
+        # denoisplit_musplit cases
+        (8, 1, None, 1, "denoisplit_musplit"),
+        (8, 1, None, 3, "denoisplit_musplit"),
+        (8, 1, "pixelwise", 1, "denoisplit_musplit"),
+        (8, 1, "pixelwise", 3, "denoisplit_musplit"),
+        (8, 5, None, 1, "denoisplit_musplit"),
+        (8, 5, None, 3, "denoisplit_musplit"),
+        (8, 5, "pixelwise", 1, "denoisplit_musplit"),
+        (8, 5, "pixelwise", 3, "denoisplit_musplit"),
+    ],
+)  # TODO refac losses, leave only microsplit
+def test_microsplit_validation_step(
+    tmp_path: Path,
     batch_size: int,
     multiscale_count: int,
     predict_logvar: str,
     target_ch: int,
+    loss_type: str,
 ):
     lightning_model = create_vae_lightning_model(
-        tmp_path=None,
-        algorithm="musplit",
-        loss_type="musplit",
+        tmp_path=(
+            tmp_path if loss_type in ["denoisplit", "denoisplit_musplit"] else None
+        ),
+        algorithm="microsplit",
+        loss_type=loss_type,
         multiscale_count=multiscale_count,
         predict_logvar=predict_logvar,
         target_ch=target_ch,
@@ -477,97 +509,6 @@ def test_musplit_validation_step(
     batch = next(iter(dloader))
     lightning_model.validation_step(batch=batch, batch_idx=0)
     # NOTE: `validation_step` does not return anything...
-
-
-@pytest.mark.parametrize(
-    "multiscale_count, predict_logvar, target_ch, loss_type",
-    [
-        (1, None, 1, "denoisplit"),
-        (5, None, 1, "denoisplit"),
-        (1, None, 3, "denoisplit"),
-        (5, None, 3, "denoisplit"),
-        (1, None, 1, "denoisplit_musplit"),
-        (1, None, 3, "denoisplit_musplit"),
-        (1, "pixelwise", 1, "denoisplit_musplit"),
-        (1, "pixelwise", 3, "denoisplit_musplit"),
-        (5, None, 1, "denoisplit_musplit"),
-        (5, None, 3, "denoisplit_musplit"),
-        (5, "pixelwise", 1, "denoisplit_musplit"),
-        (5, "pixelwise", 3, "denoisplit_musplit"),
-    ],
-)
-def test_denoisplit_training_step(
-    tmp_path: Path,
-    multiscale_count: int,
-    predict_logvar: str,
-    target_ch: int,
-    loss_type: str,
-):
-    lightning_model = create_vae_lightning_model(
-        tmp_path=tmp_path,
-        algorithm="denoisplit",
-        loss_type=loss_type,
-        multiscale_count=multiscale_count,
-        predict_logvar=predict_logvar,
-        target_ch=target_ch,
-    )
-    dloader = create_dummy_dloader(
-        batch_size=8,
-        img_size=64,
-        multiscale_count=multiscale_count,
-        target_ch=target_ch,
-    )
-    batch = next(iter(dloader))
-    train_loss = lightning_model.training_step(batch=batch, batch_idx=0)
-
-    # check outputs
-    assert train_loss is not None
-    assert isinstance(train_loss, dict)
-    assert "loss" in train_loss
-    assert "reconstruction_loss" in train_loss
-    assert "kl_loss" in train_loss
-
-
-@pytest.mark.parametrize(
-    "multiscale_count, predict_logvar, target_ch, loss_type",
-    [
-        (1, None, 1, "denoisplit"),
-        (5, None, 1, "denoisplit"),
-        (1, None, 3, "denoisplit"),
-        (5, None, 3, "denoisplit"),
-        (1, None, 1, "denoisplit_musplit"),
-        (1, None, 3, "denoisplit_musplit"),
-        (1, "pixelwise", 1, "denoisplit_musplit"),
-        (1, "pixelwise", 3, "denoisplit_musplit"),
-        (5, None, 1, "denoisplit_musplit"),
-        (5, None, 3, "denoisplit_musplit"),
-        (5, "pixelwise", 1, "denoisplit_musplit"),
-        (5, "pixelwise", 3, "denoisplit_musplit"),
-    ],
-)
-def test_denoisplit_validation_step(
-    tmp_path: Path,
-    multiscale_count: int,
-    predict_logvar: str,
-    target_ch: int,
-    loss_type: str,
-):
-    lightning_model = create_vae_lightning_model(
-        tmp_path=tmp_path,
-        algorithm="denoisplit",
-        loss_type=loss_type,
-        multiscale_count=multiscale_count,
-        predict_logvar=predict_logvar,
-        target_ch=target_ch,
-    )
-    dloader = create_dummy_dloader(
-        batch_size=8,
-        img_size=64,
-        multiscale_count=multiscale_count,
-        target_ch=target_ch,
-    )
-    batch = next(iter(dloader))
-    lightning_model.validation_step(batch=batch, batch_idx=0)
 
 
 @pytest.mark.parametrize("batch_size", [1, 8])
@@ -601,78 +542,56 @@ def test_training_loop_hdn(
         pytest.fail(f"Training routine failed with exception: {e}")
 
 
-@pytest.mark.parametrize("batch_size", [1, 8])
-@pytest.mark.parametrize("multiscale_count", [1, 5])
-@pytest.mark.parametrize("predict_logvar", [None, "pixelwise"])
-@pytest.mark.parametrize("target_ch", [1, 3])
-def test_training_loop_musplit(
-    batch_size: int,
-    multiscale_count: int,
-    predict_logvar: str,
-    target_ch: int,
-):
-    lightning_model = create_vae_lightning_model(
-        tmp_path=None,
-        algorithm="musplit",
-        loss_type="musplit",
-        multiscale_count=multiscale_count,
-        predict_logvar=predict_logvar,
-        target_ch=target_ch,
-    )
-    dloader = create_dummy_dloader(
-        batch_size=batch_size,
-        img_size=64,
-        multiscale_count=multiscale_count,
-        target_ch=target_ch,
-    )
-    trainer = Trainer(accelerator="cpu", max_epochs=2, logger=False, callbacks=[])
-
-    try:
-        trainer.fit(
-            model=lightning_model,
-            train_dataloaders=dloader,
-            val_dataloaders=dloader,
-        )
-    except Exception as e:
-        pytest.fail(f"Training routine failed with exception: {e}")
-
-
 @pytest.mark.parametrize(
-    "batch_size, predict_logvar, target_ch, loss_type",
+    "batch_size, multiscale_count, predict_logvar, target_ch, loss_type",
     [
-        (1, None, 1, "denoisplit"),
-        (4, None, 1, "denoisplit"),
-        (1, None, 3, "denoisplit"),
-        (4, None, 3, "denoisplit"),
-        (1, None, 1, "denoisplit_musplit"),
-        (1, None, 3, "denoisplit_musplit"),
-        (1, "pixelwise", 1, "denoisplit_musplit"),
-        (1, "pixelwise", 3, "denoisplit_musplit"),
-        (4, None, 1, "denoisplit_musplit"),
-        (4, None, 3, "denoisplit_musplit"),
-        (4, "pixelwise", 1, "denoisplit_musplit"),
-        (4, "pixelwise", 3, "denoisplit_musplit"),
+        # musplit cases
+        (1, 1, None, 3, "musplit"),
+        (1, 1, "pixelwise", 3, "musplit"),
+        (1, 5, None, 3, "musplit"),
+        (1, 5, "pixelwise", 3, "musplit"),
+        (8, 1, None, 3, "musplit"),
+        (8, 1, "pixelwise", 3, "musplit"),
+        (8, 5, None, 3, "musplit"),
+        (8, 5, "pixelwise", 3, "musplit"),
+        # denoisplit cases
+        (1, 1, None, 1, "denoisplit"),
+        (4, 1, None, 1, "denoisplit"),
+        (1, 1, None, 3, "denoisplit"),
+        (4, 1, None, 3, "denoisplit"),
+        # denoisplit_musplit cases
+        (1, 1, None, 1, "denoisplit_musplit"),
+        (1, 1, None, 3, "denoisplit_musplit"),
+        (1, 1, "pixelwise", 1, "denoisplit_musplit"),
+        (1, 1, "pixelwise", 3, "denoisplit_musplit"),
+        (4, 1, None, 1, "denoisplit_musplit"),
+        (4, 1, None, 3, "denoisplit_musplit"),
+        (4, 1, "pixelwise", 1, "denoisplit_musplit"),
+        (4, 1, "pixelwise", 3, "denoisplit_musplit"),
     ],
 )
-def test_training_loop_denoisplit(
+def test_training_loop_microsplit(
     tmp_path: Path,
     batch_size: int,
+    multiscale_count: int,
     predict_logvar: str,
     target_ch: int,
     loss_type: str,
 ):
     lightning_model = create_vae_lightning_model(
-        tmp_path=tmp_path,
-        algorithm="denoisplit",
+        tmp_path=(
+            tmp_path if loss_type in ["denoisplit", "denoisplit_musplit"] else None
+        ),
+        algorithm="microsplit",
         loss_type=loss_type,
-        multiscale_count=1,
+        multiscale_count=multiscale_count,
         predict_logvar=predict_logvar,
         target_ch=target_ch,
     )
     dloader = create_dummy_dloader(
         batch_size=batch_size,
         img_size=64,
-        multiscale_count=1,
+        multiscale_count=multiscale_count,
         target_ch=target_ch,
     )
     trainer = Trainer(accelerator="cpu", max_epochs=2, logger=False, callbacks=[])
@@ -695,7 +614,7 @@ def test_get_reconstructed_tensor(
 ):
     lightning_model = create_vae_lightning_model(
         tmp_path=None,
-        algorithm="musplit",
+        algorithm="microsplit",
         loss_type="musplit",
         multiscale_count=1,
         predict_logvar=predict_logvar,
@@ -721,7 +640,7 @@ def test_val_PSNR_computation(
 ):
     lightning_model = create_vae_lightning_model(
         tmp_path=None,
-        algorithm="musplit",
+        algorithm="microsplit",
         loss_type="musplit",
         multiscale_count=1,
         predict_logvar=predict_logvar,

--- a/tests/models/lvae/test_lvae_architecture.py
+++ b/tests/models/lvae/test_lvae_architecture.py
@@ -37,7 +37,7 @@ def create_LVAE_model(
 
     config = VAEBasedAlgorithm(
         algorithm_type="vae",
-        algorithm="musplit",
+        algorithm="microsplit",
         loss=LVAELossConfig(loss_type="musplit"),
         model=lvae_model_config,
         gaussian_likelihood=GaussianLikelihoodConfig(


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

> [!NOTE]  
> **tldr**: <!-- Write a one sentence summary. -->

Lighnting API config fucntion for MS, based on minimal example for HDN. Proposed structure repeats that one of Careamist API, but keeps the model, dataloader and trainer setup separate.


### Background - why do we need this PR?

<!-- What problem are you solving? Describe in a few sentences the state before
this PR. Use code examples if useful. -->
Extends on recently proposed configuration for HDN (#511 )
**Note: Example below contains CAREAmics style datamodule, which isn't a part of this PR. 
```
config = create_microsplit_configuration(
    experiment_name="ms_test",
    data_type="tiff",
    axes="SYX",
    z_dims=[32] * 4,
    patch_size=(128, 128),
    batch_size=64,
    num_epochs=5,
    predict_logvar="pixelwise",
    train_dataloader_params={"num_workers": 4},
    val_dataloader_params={"num_workers": 4},
    logger=None
)
model = VAEModule(config.algorithm_config)
data_module = create_train_datamodule(
    train_data=train_path,
    val_data=val_path,
    data_type=config.data_config.data_type,
    patch_size=config.data_config.patch_size,
    axes=config.data_config.axes,
    batch_size=config.data_config.batch_size,
    transforms=[],
    train_dataloader_params=config.data_config.train_dataloader_params,
    val_dataloader_params=config.data_config.val_dataloader_params,
)
trainer = Trainer()
trainer.fit()
```
### Overview - what changed?

<!-- What aspects and mechanisms of the code base changed? Describe only the general 
idea and overarching features. -->

Reuses configuration function from Careamist API, but creates all modules separately.

## How has this been tested?

<!-- Describe the tests that you ran to verify your changes. This can be a short 
description of the tests added to the PR or code snippet to reproduce the change
in behaviour. -->

Performance haven't been tested

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)