### PR TITLE
Chore: Remove py310 and add newer versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         platform: [ubuntu-latest, windows-latest] # macos-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13"]
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-        platform: [ubuntu-latest, windows-latest] # macos-latest
+        platform: [ubuntu-latest, windows-latest] # macos-latest  
 
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         platform: [macos-latest]
 

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13"]
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         platform: [macos-latest]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: ruff
         exclude: "^src/careamics/lvae_training/.*|^src/careamics/models/lvae/.*|^scripts/.*"
-        args: [--fix, --target-version, py310]
+        args: [--fix, --target-version, py311]
 
   - repo: https://github.com/psf/black
     rev: 25.1.0
@@ -33,7 +33,7 @@ repos:
         exclude: "^src/careamics/lvae_training/.*|^src/careamics/models/lvae/.*|^src/careamics/config/likelihood_model.py|^src/careamics/losses/loss_factory.py|^src/careamics/losses/lvae/losses.py"
         args: ["--config-file", "mypy.ini"]
         additional_dependencies:
-          - numpy<2.0.0
+          - numpy
           - pydantic
           - types-PyYAML
           - types-setuptools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         exclude: "^src/careamics/lvae_training/.*|^src/careamics/models/lvae/.*|^src/careamics/config/likelihood_model.py|^src/careamics/losses/loss_factory.py|^src/careamics/losses/lvae/losses.py"
         args: ["--config-file", "mypy.ini"]
         additional_dependencies:
-          - numpy
+          - numpy<2.0.0
           - pydantic
           - types-PyYAML
           - types-setuptools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ name = "careamics"
 dynamic = ["version"]
 description = "Toolbox for running N2V and friends."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = { text = "BSD-3-Clause" }
 authors = [
     { name = 'CAREamics team', email = 'rse@fht.org' },
@@ -34,9 +34,10 @@ authors = [
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: BSD License",
     "Typing :: Typed",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: BSD License",
     "Typing :: Typed",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
 
     # libraries used in some tests
     "onnx",
-    "ml_dtypes>=0.5.0" # otherwise fails on python 3.13
+    "ml_dtypes>=0.5.0" # otherwise fails on python 3.13, used in onnx tests
 ]
 
 # notebooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     'pyyaml<=6.0.2,!=6.0.0',
     'typer>=0.12.3,<=0.17.4',
     'scikit-image<=0.25.2',
-    'zarr<3.0.0',
+    'zarr>3.0.0a0,<4.0.0',
     'pillow<=11.3.0',
     'matplotlib<=3.10.6',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,11 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "onnx",
     "sybil",      # doctesting
+
+    # libraries used in some tests
+    "onnx",
+    "ml_dtypes>=0.5.0" # otherwise fails on python 3.13
 ]
 
 # notebooks

--- a/src/careamics/config/algorithms/n2v_algorithm_model.py
+++ b/src/careamics/config/algorithms/n2v_algorithm_model.py
@@ -1,10 +1,9 @@
 """N2V Algorithm configuration."""
 
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Self
 
 from bioimageio.spec.generic.v0_3 import CiteEntry
 from pydantic import AfterValidator, ConfigDict, model_validator
-from typing_extensions import Self
 
 from careamics.config.architectures import UNetModel
 from careamics.config.support import SupportedPixelManipulation, SupportedStructAxis

--- a/src/careamics/config/algorithms/vae_algorithm_model.py
+++ b/src/careamics/config/algorithms/vae_algorithm_model.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from pprint import pformat
-from typing import Literal
+from typing import Literal, Self
 
 from pydantic import BaseModel, ConfigDict, model_validator
-from typing_extensions import Self
 
 from careamics.config.architectures import LVAEModel
 from careamics.config.likelihood_model import (

--- a/src/careamics/config/architectures/lvae_model.py
+++ b/src/careamics/config/architectures/lvae_model.py
@@ -1,9 +1,8 @@
 """LVAE Pydantic model."""
 
-from typing import Literal
+from typing import Literal, Self
 
 from pydantic import ConfigDict, Field, field_validator, model_validator
-from typing_extensions import Self
 
 from .architecture_model import ArchitectureModel
 

--- a/src/careamics/config/configuration.py
+++ b/src/careamics/config/configuration.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import re
 from collections.abc import Callable
 from pprint import pformat
-from typing import Any, Literal, Union
+from typing import Any, Literal, Self, Union
 
 import numpy as np
 from bioimageio.spec.generic.v0_3 import CiteEntry
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic.main import IncEx
-from typing_extensions import Self
 
 from careamics.config.algorithms import (
     CAREAlgorithm,

--- a/src/careamics/config/data/data_model.py
+++ b/src/careamics/config/data/data_model.py
@@ -6,7 +6,7 @@ import os
 import sys
 from collections.abc import Sequence
 from pprint import pformat
-from typing import Annotated, Any, Literal, Union
+from typing import Annotated, Any, Literal, Self, Union
 from warnings import warn
 
 import numpy as np
@@ -19,7 +19,6 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from typing_extensions import Self
 
 from ..transformations import XYFlipModel, XYRandomRotate90Model
 from ..validators import check_axes_validity, patch_size_ge_than_8_power_of_2

--- a/src/careamics/config/data/ng_data_model.py
+++ b/src/careamics/config/data/ng_data_model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pprint import pformat
-from typing import Annotated, Any, Literal, Union
+from typing import Annotated, Any, Literal, Self, Union
 from warnings import warn
 
 import numpy as np
@@ -17,7 +17,6 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from typing_extensions import Self
 
 from ..transformations import XYFlipModel, XYRandomRotate90Model
 from ..validators import check_axes_validity

--- a/src/careamics/config/inference_model.py
+++ b/src/careamics/config/inference_model.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, Union
+from typing import Any, Literal, Self, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-from typing_extensions import Self
 
 from .validators import check_axes_validity, patch_size_ge_than_8_power_of_2
 

--- a/src/careamics/config/optimizer_models.py
+++ b/src/careamics/config/optimizer_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, Self
 
 from pydantic import (
     BaseModel,
@@ -13,7 +13,6 @@ from pydantic import (
     model_validator,
 )
 from torch import optim
-from typing_extensions import Self
 
 from careamics.utils.torch_utils import filter_parameters
 

--- a/src/careamics/config/transformations/normalize_model.py
+++ b/src/careamics/config/transformations/normalize_model.py
@@ -1,9 +1,8 @@
 """Pydantic model for the Normalize transform."""
 
-from typing import Literal
+from typing import Literal, Self
 
 from pydantic import ConfigDict, Field, model_validator
-from typing_extensions import Self
 
 from .transform_model import TransformModel
 

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/in_memory_image_stack.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/in_memory_image_stack.py
@@ -1,9 +1,8 @@
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Literal, Union
+from typing import Any, Literal, Self, Union
 
 from numpy.typing import DTypeLike, NDArray
-from typing_extensions import Self
 
 from careamics.dataset.dataset_utils import reshape_array
 from careamics.file_io.read import ReadFunc, read_tiff

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/zarr_image_stack.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/zarr_image_stack.py
@@ -1,11 +1,10 @@
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Union
+from typing import Self, Union
 
 import zarr
 import zarr.storage
 from numpy.typing import NDArray
-from typing_extensions import Self
 
 from careamics.dataset.dataset_utils import reshape_array
 


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

Zarr v3 is unfortunately not compatible with python 3.10. Since Zarr is so central to the future developments of CAREamics, we can hardly ignore that and unfortunately I think we should already drop 3.10, one year in advance.

This PR simply changes the metadata of the package, CIs and pre-commits to enforce >py310.