### PR TITLE
A fix for loading careamist from a checkpoint (`pytorch >= 2.6` strictness)

### DIFF
--- a/src/careamics/model_io/model_io_utils.py
+++ b/src/careamics/model_io/model_io_utils.py
@@ -71,7 +71,7 @@ def _load_checkpoint(
     # here we might run into issues between devices
     # see https://pytorch.org/tutorials/recipes/recipes/save_load_across_devices.html
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    checkpoint: dict = torch.load(path, map_location=device)
+    checkpoint: dict = torch.load(path, map_location=device, weights_only=False)
 
     # attempt to load configuration
     try:


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

> [!NOTE]  
> **tldr**: When loading a checkpoint using a more recent `pytorch` version, we have to set `weight_only` to `False`.


### Background - why do we need this PR?

When creating a `CAREamist` object using a previously saved checkpoint, the `pytorch` throws an error: 
```
Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
        (1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
        (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
        WeightsUnpickler error: Unsupported global: GLOBAL pathlib.PosixPath was not an allowed global by default. Please use `torch.serialization.add_safe_globals([pathlib.PosixPath])` or the `torch.serialization.safe_globals([pathlib.PosixPath])` context manager to allowlist this global if you trust this class/function.
```

### Overview - what changed?

I just changed the `weights_only` flag to `False` in `torch.load` inside the `_load_checkpoint` function in *src/careamics/model_io/model_io_utils.py*.

### Implementation - how did you implement the changes?

`checkpoint: dict = torch.load(path, map_location=device, weights_only=False)`

### Modified features or files

<!-- List important modified features or files. -->
- src/careamics/model_io/model_io_utils.py

## How has this been tested?

Tested by the careamics-napari plugin.


**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)