### PR TITLE
Fix: fix publish CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Python 3.12
-        run: uv python install 3.12
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          # Install a specific version of uv.
+          version: "0.9.0"
+          enable-cache: true
+          python-version: 3.12
 
       - name: Build
         run: uv build


### PR DESCRIPTION
## Description

Publish CI is failing due to missing `uv` installation. This fixes it.