### PR TITLE
Feature(Next-Gen Dataset): Pad patches queried outside of data range

### DIFF
--- a/src/careamics/dataset_ng/patch_extractor/image_stack/in_memory_image_stack.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/in_memory_image_stack.py
@@ -8,6 +8,8 @@ from numpy.typing import DTypeLike, NDArray
 from careamics.dataset.dataset_utils import reshape_array
 from careamics.file_io.read import ReadFunc, read_tiff
 
+from .utils import pad_patch
+
 
 class InMemoryImageStack:
     """
@@ -31,13 +33,6 @@ class InMemoryImageStack:
             )
         # TODO: test for 2D or 3D?
 
-        patch = np.zeros((self.data_shape[1], *patch_size), dtype=self._data.dtype)
-        patch_start = np.clip(np.array(coords), 0, None) - np.array(coords)
-        patch_end = np.array(coords) + np.array(patch_size)
-        patch_end = np.clip(patch_end, None, np.array(self.data_shape[2:])) - np.clip(
-            np.array(coords), None, np.array(self.data_shape[2:])
-        )
-
         patch_data = self._data[
             (
                 sample_idx,  # type: ignore
@@ -51,14 +46,7 @@ class InMemoryImageStack:
                 ],  # type: ignore
             )  # type: ignore
         ]
-        patch[
-            (
-                slice(None, None, None),
-                *tuple(
-                    slice(s, t) for s, t in zip(patch_start, patch_end, strict=False)
-                ),
-            )
-        ] = patch_data
+        patch = pad_patch(coords, patch_size, self.data_shape, patch_data)
 
         return patch
 

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/utils.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/utils.py
@@ -13,16 +13,43 @@ def pad_patch(
     data_shape: Sequence[int],
     patch_data: NDArray[T],
 ) -> NDArray[T]:
+    """
+    Pad patch data with zeros where it is outside the bounds of it's source image.
+
+    This ensures the patch data is contained in an array with the expected patch size.
+
+    If `coords` are negative, the start of the patch will be padded with zeros up until
+    where the start of the image would be, and this is where the patch data starts.
+
+    If the `coords + patch_size` are greater than the bounds of the image then the
+    end of the patch will be filled with zeros.
+
+    Parameters
+    ----------
+    coords : Sequence[int]
+        The coordinates that describe where the patch starts in the spatial dimension of
+        the image
+    patch_size : Sequence[int]
+        The size of the patch in the spatial dimensions.
+    data_shape : Sequence[int]
+        The shape of the image the patch originates from, must be in the format SC(Z)YX.
+    patch_data : NDArray[T]
+        The patch data to be padded.
+
+    Returns
+    -------
+    NDArray[T]
+        The resulting padded patch.
+    """
+    coords_ = np.array(coords)
     patch = np.zeros((data_shape[1], *patch_size), dtype=patch_data.dtype)
-    patch_start = np.clip(np.array(coords), 0, None) - np.array(coords)
-    patch_end = np.array(coords) + np.array(patch_size)
-    patch_end = np.clip(patch_end, None, np.array(data_shape[2:])) - np.clip(
-        np.array(coords), None, np.array(data_shape[2:])
-    )
+    # data start will be zero unless coords are negative
+    data_start = np.clip(coords_, 0, None) - coords_
+    data_end = data_start + np.array(patch_data.shape[1:])
     patch[
         (
-            slice(None, None, None),
-            *tuple(slice(s, t) for s, t in zip(patch_start, patch_end, strict=False)),
+            slice(None, None, None),  # channel slice
+            *tuple(slice(s, t) for s, t in zip(data_start, data_end, strict=False)),
         )
     ] = patch_data
     return patch

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/utils.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/utils.py
@@ -1,0 +1,28 @@
+from collections.abc import Sequence
+from typing import TypeVar
+
+import numpy as np
+from numpy.typing import NDArray
+
+T = TypeVar("T", bound=np.generic)
+
+
+def pad_patch(
+    coords: Sequence[int],
+    patch_size: Sequence[int],
+    data_shape: Sequence[int],
+    patch_data: NDArray[T],
+) -> NDArray[T]:
+    patch = np.zeros((data_shape[1], *patch_size), dtype=patch_data.dtype)
+    patch_start = np.clip(np.array(coords), 0, None) - np.array(coords)
+    patch_end = np.array(coords) + np.array(patch_size)
+    patch_end = np.clip(patch_end, None, np.array(data_shape[2:])) - np.clip(
+        np.array(coords), None, np.array(data_shape[2:])
+    )
+    patch[
+        (
+            slice(None, None, None),
+            *tuple(slice(s, t) for s, t in zip(patch_start, patch_end, strict=False)),
+        )
+    ] = patch_data
+    return patch

--- a/src/careamics/dataset_ng/patching_strategies/random_patching.py
+++ b/src/careamics/dataset_ng/patching_strategies/random_patching.py
@@ -300,7 +300,7 @@ def _generate_random_coords(
     return tuple(
         rng.integers(
             np.zeros(len(patch_size), dtype=int),
-            np.array(spatial_shape) - np.array(patch_size),
+            np.clip(np.array(spatial_shape) - np.array(patch_size), 0, None),
             endpoint=True,
             dtype=int,
         ).tolist()

--- a/src/careamics/dataset_ng/patching_strategies/tiling_strategy.py
+++ b/src/careamics/dataset_ng/patching_strategies/tiling_strategy.py
@@ -148,8 +148,11 @@ class TilingStrategy:
                 coords.append(i)
                 crop_coords.append(0)
                 stitch_coords.append(0)
-                crop_size.append(tile_size - overlap // 2)
-            elif (i > 0) and (i + tile_size < axis_size):
+                if axis_size <= tile_size:
+                    crop_size.append(axis_size)
+                else:
+                    crop_size.append(tile_size - overlap // 2)
+            elif (0 < i) and (i + tile_size < axis_size):
                 coords.append(i)
                 crop_coords.append(overlap // 2)
                 stitch_coords.append(coords[-1] + crop_coords[-1])

--- a/tests/dataset_ng/dataset/test_dataset.py
+++ b/tests/dataset_ng/dataset/test_dataset.py
@@ -23,6 +23,7 @@ from careamics.dataset_ng.factory import (
         ((256, 256), (32, 32), 64),
         ((512, 512), (64, 64), 64),
         ((128, 128), (32, 32), 16),
+        ((24, 24), (32, 32), 1),  # data smaller than patch
     ],
 )
 def test_from_array(data_shape, patch_size, expected_dataset_len):
@@ -67,6 +68,7 @@ def test_from_array(data_shape, patch_size, expected_dataset_len):
         ((256, 256), (32, 32), 64),
         ((512, 512), (64, 64), 64),
         ((128, 128), (32, 32), 16),
+        ((24, 24), (32, 32), 1),  # data smaller than patch
     ],
 )
 def test_from_tiff(tmp_path: Path, data_shape, patch_size, expected_dataset_len):
@@ -159,6 +161,7 @@ def test_prediction_from_array(data_shape, tile_size, tile_overlap):
         ((32, 32), (256, 256)),
         ((64, 64), (512, 512)),
         ((16, 16), (128, 128)),
+        ((32, 32), (24, 24)),  # data smaller than patch
     ],
 )
 def test_from_custom_data_type(patch_size, data_shape):

--- a/tests/dataset_ng/patch_extractor/image_stack/test_image_stack_utils.py
+++ b/tests/dataset_ng/patch_extractor/image_stack/test_image_stack_utils.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pytest
+
+from careamics.dataset_ng.patch_extractor.image_stack.utils import pad_patch
+
+data = np.array(
+    [
+        [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+        ]
+    ]
+)
+
+
+@pytest.mark.parametrize(
+    "data_source",
+    [data.copy()],
+)
+@pytest.mark.parametrize(
+    "coords, patch_size, expected_patch",
+    [
+        ((-1, 0), (2, 2), np.array([[[0, 0], [1, 2]]])),
+        ((1, 1), (3, 3), np.array([[[5, 6, 0], [8, 9, 0], [0, 0, 0]]])),
+        ((0, 0), (3, 3), data.copy()),
+        ((-4, 5), (2, 2), np.zeros((1, 2, 2), dtype=data.dtype)),
+        (
+            (-1, -1),
+            (3, 5),
+            np.array([[[0, 0, 0, 0, 0], [0, 1, 2, 3, 0], [0, 4, 5, 6, 0]]]),
+        ),
+    ],
+)
+def test_pad_patch(data_source, coords, patch_size, expected_patch):
+    patch = data_source[
+        (
+            slice(None, None, None),  # channel axis
+            *[
+                slice(np.clip(c, 0, s), np.clip(c + ps, 0, s), None)
+                for c, ps, s in zip(
+                    coords, patch_size, data_source.shape[1:], strict=False
+                )
+            ],
+        )
+    ]
+    patch_padded = pad_patch(coords, patch_size, (1, *data_source.shape), patch)
+    np.testing.assert_equal(patch_padded, expected_patch)

--- a/tests/dataset_ng/patch_extractor/image_stack/test_zarr_image_stack.py
+++ b/tests/dataset_ng/patch_extractor/image_stack/test_zarr_image_stack.py
@@ -30,6 +30,7 @@ def create_test_zarr(file_path: Path, data_path: str, data: NDArray):
         ("YX", (32, 48), (1, 1, 32, 48), 0),
         ("XYS", (48, 32, 3), (3, 1, 32, 48), 1),
         ("SXYC", (3, 48, 32, 2), (3, 2, 32, 48), 1),
+        ("SXYC", (3, 8, 8, 2), (3, 2, 8, 8), 1),  # spatial dims smaller that patch size
         ("CYXT", (2, 32, 48, 3), (3, 2, 32, 48), 2),
         ("CXYTS", (2, 48, 32, 3, 2), (6, 2, 32, 48), 4),
         ("XCSYT", (48, 1, 2, 32, 3), (6, 1, 32, 48), 5),  # crazy one

--- a/tests/dataset_ng/patch_extractor/image_stack/test_zarr_image_stack.py
+++ b/tests/dataset_ng/patch_extractor/image_stack/test_zarr_image_stack.py
@@ -7,6 +7,7 @@ from numpy.typing import NDArray
 
 from careamics.dataset.dataset_utils import reshape_array
 from careamics.dataset_ng.patch_extractor.image_stack import ZarrImageStack
+from careamics.dataset_ng.patch_extractor.image_stack.utils import pad_patch
 
 
 def create_test_zarr(file_path: Path, data_path: str, data: NDArray):
@@ -71,6 +72,7 @@ def test_extract_patch_2D(
         coords[0] : coords[0] + patch_size[0],
         coords[1] : coords[1] + patch_size[1],
     ]
+    patch_ref = pad_patch(coords, patch_size, image_stack.data_shape, patch_ref)
     np.testing.assert_array_equal(extracted_patch, patch_ref)
 
 

--- a/tests/dataset_ng/patching_strategies/test_tiling_strategy.py
+++ b/tests/dataset_ng/patching_strategies/test_tiling_strategy.py
@@ -59,15 +59,15 @@ def _test_tiling_output(
     samples = [sample for d in data for sample in np.split(d, d.shape[0])]
 
     for sample, stitched_sample in zip(samples, stitched_samples, strict=False):
-        np.testing.assert_array_equal(sample, stitched_sample)
+        np.testing.assert_array_equal(stitched_sample, sample)
 
 
 @pytest.mark.parametrize("overlaps", [(2, 2), (3, 4), (6, 3)])
 @pytest.mark.parametrize(
     "data_shapes,patch_size",
     [
-        [[(2, 1, 32, 32), (1, 1, 19, 37), (3, 1, 14, 9)], (8, 8)],
-        [[(2, 1, 32, 32), (1, 1, 19, 37), (3, 1, 14, 9)], (8, 5)],
+        [[(2, 1, 32, 32), (1, 1, 19, 37), (3, 1, 14, 9), (2, 1, 6, 5)], (8, 8)],
+        [[(2, 1, 32, 32), (1, 1, 19, 37), (3, 1, 14, 9), (2, 1, 6, 5)], (8, 5)],
     ],
 )
 def test_tiling_output_2D(
@@ -82,8 +82,24 @@ def test_tiling_output_2D(
 @pytest.mark.parametrize(
     "data_shapes,patch_size",
     [
-        [[(2, 1, 32, 32, 32), (1, 1, 19, 37, 23), (3, 1, 14, 9, 12)], (8, 8, 8)],
-        [[(2, 1, 32, 32, 32), (1, 1, 19, 37, 23), (3, 1, 14, 9, 12)], (8, 5, 7)],
+        [
+            [
+                (2, 1, 32, 32, 32),
+                (1, 1, 19, 37, 23),
+                (3, 1, 14, 9, 12),
+                (2, 1, 6, 5, 4),
+            ],
+            (8, 8, 8),
+        ],
+        [
+            [
+                (2, 1, 32, 32, 32),
+                (1, 1, 19, 37, 23),
+                (3, 1, 14, 9, 12),
+                (2, 1, 6, 5, 4),
+            ],
+            (8, 5, 7),
+        ],
     ],
 )
 def test_tiling_output_3D(


### PR DESCRIPTION
## Description

> [!NOTE]  
> **tldr**: An `ImageStack` might be given coords and a patch size that go over the bounds of the image. Previously in the `InMemoryImageStack` and the `ZarrImageStack` this was handled in the default numpy slicing way, which is that the resulting patch may have smaller dimensions than the specified patch size. This PR modifies the behaviour so that the patch returned will always be the same size and the missing data is filled with zeros.

### Background - why do we need this PR?

This is mostly a useful feature during inference. Someone might have a dataset with one image smaller than the rest and choosing a smaller patch size to accommodate this will make the process slower. Or maybe if a dataset is comprised of many small images of different sizes, padding them makes inference quicker as they can be processed in batches.

However, this feature probably shouldn't be used during training because then the model will see only zeros in some areas of patches. ~~I will add a guard against images being smaller than the patch size shortly.~~

EDIT: A guard to prevent data smaller than the patch size during training has been added to the dataset initialisation.

### Overview - what changed?

- `InMemoryImageStack` and `ZarrImageStack` will return zeros from the method `extract_patch` when the patch is outside the range of the data. (`CziImageStack` already did this.)
- `TilingStrategy` has been updated to handle the case for when an image is smaller than the tile size.
- The range the random strategies sample from has also been updated to clip to [0, image_size].
- Test cases have been added to existing tests for image sizes being smaller than the patch size.

### Implementation - how did you implement the changes?

Padding is done by inserting the extracted patch data into a zero array of the patch size.

## Changes Made

### New features or files

<!-- List new features or files added. -->
- `pad_patch` function added to new `careamics/dataset_ng/patch_extractor/image_stack/utils.py`

### Modified features or files

- `InMemoryImageStack`
- `ZarrImageStack`
- `TilingStrategy`
- `_generate_random_coords` in `src/careamics/dataset_ng/patching_strategies/random_patching.py`
- Relevant tests

## How has this been tested?

Existing tests have had parametrisations added for the case that the image is smaller than the patch size.

## Related Issues

<!-- Link to any related issues or discussions. Use keywords like "Fixes", "Resolves",
or "Closes" to link to issues automatically. -->

- Resolves #496 

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)