### PR TITLE
Typo: configuration docstring

### DIFF
--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -654,7 +654,7 @@ def create_care_configuration(
     """
     Create a configuration for training CARE.
 
-    If "Z" is present in `axes`, then `path_size` must be a list of length 3, otherwise
+    If "Z" is present in `axes`, then `patch_size` must be a list of length 3, otherwise
     2.
 
     If "C" is present in `axes`, then you need to set `n_channels_in` to the number of
@@ -891,7 +891,7 @@ def create_n2n_configuration(
     """
     Create a configuration for training Noise2Noise.
 
-    If "Z" is present in `axes`, then `path_size` must be a list of length 3, otherwise
+    If "Z" is present in `axes`, then `patch_size` must be a list of length 3, otherwise
     2.
 
     If "C" is present in `axes`, then you need to set `n_channels_in` to the number of
@@ -1139,7 +1139,7 @@ def create_n2v_configuration(
     or horizontal correlations are present in the noise; it applies an additional mask
     to the manipulated pixel neighbors.
 
-    If "Z" is present in `axes`, then `path_size` must be a list of length 3, otherwise
+    If "Z" is present in `axes`, then `patch_size` must be a list of length 3, otherwise
     2.
 
     If "C" is present in `axes`, then you need to set `n_channels` to the number of
@@ -1722,7 +1722,7 @@ def create_hdn_configuration(
     """
     Create a configuration for training HDN.
 
-    If "Z" is present in `axes`, then `path_size` must be a list of length 3, otherwise
+    If "Z" is present in `axes`, then `patch_size` must be a list of length 3, otherwise
     2.
 
     If "C" is present in `axes`, then you need to set `n_channels_in` to the number of


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

> [!NOTE]  
> **tldr**: Minor typo in docstring `path_size` instead of `patch_size`.

### Overview - what changed?

<!-- What aspects and mechanisms of the code base changed? Describe only the general 
idea and overarching features. -->
Docstring of 4 functions in `configuration_factories.py`

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)