### PR TITLE
Feature(Next-Gen Dataset): Lateral context patch construction for MicroSplit

### DIFF
--- a/src/careamics/dataset_ng/patch_extractor/limit_file_extractor.py
+++ b/src/careamics/dataset_ng/patch_extractor/limit_file_extractor.py
@@ -3,24 +3,28 @@ from collections.abc import Sequence
 from numpy.typing import NDArray
 
 from .image_stack import FileImageStack
+from .patch_construction import PatchConstructor, basic_patch_constr
 from .patch_extractor import PatchExtractor
 
 
-class LimitFilesPatchExtractor(PatchExtractor):
+class LimitFilesPatchExtractor(PatchExtractor[FileImageStack]):
     """
     A patch extractor that limits the number of files that have their data loaded.
 
     This is useful for when not all of the data will fit into memory.
     """
 
-    def __init__(self, image_stacks: Sequence[FileImageStack]):
+    def __init__(
+        self,
+        image_stacks: Sequence[FileImageStack],
+        patch_constructor: PatchConstructor = basic_patch_constr,
+    ):
         """
         Parameters
         ----------
         image_stacks: Sequence of `FileImageStack`
         """
-        self.image_stacks: list[FileImageStack]
-        super().__init__(image_stacks)
+        super().__init__(image_stacks, patch_constructor)
         self.loaded_stacks: list[int] = []
 
     def extract_patch(

--- a/src/careamics/dataset_ng/patch_extractor/patch_construction.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_construction.py
@@ -114,17 +114,17 @@ def lateral_context_patch_constr(
             pad_after = lc_end - end_clipped
             pad_width = np.concat(
                 [
+                    # zeros to not pad the channel axis
                     np.zeros((1, 2), dtype=int),
                     np.stack([pad_before, pad_after], axis=-1),
                 ]
             )
             lc_patch = np.pad(
-                # zeros to not pad the channel axis
                 lc_patch,
                 pad_width,
                 mode=padding_mode,
             )
-            # TODO: test different downscaling, could try max pooling?
+            # TODO: test different downscaling? skimage suggests downscale_local_mean
             lc_patch = resize(lc_patch, (n_channels, *patch_size))
             patch[scale] = lc_patch
         return patch

--- a/src/careamics/dataset_ng/patch_extractor/patch_construction.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_construction.py
@@ -9,6 +9,7 @@ from .image_stack import ImageStack
 
 
 class PatchConstructor(Protocol):
+    """A patch constructor function creates a patch from a given ImageStack."""
 
     def __call__(
         self,
@@ -16,7 +17,26 @@ class PatchConstructor(Protocol):
         sample_idx: int,
         coords: Sequence[int],
         patch_size: Sequence[int],
-    ) -> NDArray[Any]: ...
+    ) -> NDArray[Any]:
+        """
+        Parameters
+        ----------
+        image_stack: ImageStack
+            The image stack to construct a patch from.
+        sample_idx: int
+            Sample index. The first dimension of the image data will be indexed at this
+            value.
+        coords: Sequence of int
+            The coordinates that define the start of a patch.
+        patch_size: Sequence of int
+            The size of the patch in each spatial dimension.
+
+        Returns
+        -------
+        numpy.ndarray
+            The patch.
+        """
+        ...
 
 
 def basic_patch_constr(
@@ -30,9 +50,34 @@ def basic_patch_constr(
     )
 
 
+# closure to create constructor funcs with particular multiscale_count and padding mode
 def lateral_context_patch_constr(
-    multiscale_count: int, padding_mode: Literal["reflect", "wrap"]
+    # TODO: will we stick with this as the parameter name
+    multiscale_count: int,
+    # TODO: add other modes?
+    padding_mode: Literal["reflect", "wrap"],
 ) -> PatchConstructor:
+    """
+    Create a lateral context `PatchConstructor` for MicroSplit.
+
+    Parameters
+    ----------
+    multiscale_count : int
+        The number of multiscale inputs that will be created including the original
+        image size.
+    padding_mode : {"reflect", "wrap"}
+        How lateral context inputs will be padded at the edge of the image. See
+        [`numpy.pad`](https://numpy.org/devdocs/reference/generated/numpy.pad.html) for
+        more information.
+
+    Returns
+    -------
+    PatchConstructor
+        The patch constructor function. It will return patches with the dimensions
+        (L, C, (Z), Y, X) where L will be equal to `multiscale_count`, C is the number
+        of channels in the image, and (Z), Y, X are the patch size.
+    """
+
     def constructor_func(
         image_stack: ImageStack,
         sample_idx: int,
@@ -43,6 +88,11 @@ def lateral_context_patch_constr(
         spatial_shape = shape[2:]
         n_channels = shape[1]
 
+        # There will now be an additional lc dimension,
+        # this has to be handled correctly by the dataset
+        # TODO: maybe we want to limit this constructor to only images with 1 channel
+        #   then we can put LCs in the channel dimension
+        #   but not sure if this artificially limits potential use-cases
         patch = np.zeros((multiscale_count, n_channels, *patch_size))
         for scale in range(multiscale_count):
             lc_patch_size = np.array(patch_size) * (2**scale)
@@ -74,6 +124,7 @@ def lateral_context_patch_constr(
                 pad_width,
                 mode=padding_mode,
             )
+            # TODO: test different downscaling, could try max pooling?
             lc_patch = resize(lc_patch, (n_channels, *patch_size))
             patch[scale] = lc_patch
         return patch

--- a/src/careamics/dataset_ng/patch_extractor/patch_construction.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_construction.py
@@ -1,0 +1,81 @@
+from collections.abc import Sequence
+from typing import Any, Literal, Protocol
+
+import numpy as np
+from numpy.typing import NDArray
+from skimage.transform import resize
+
+from .image_stack import ImageStack
+
+
+class PatchConstructor(Protocol):
+
+    def __call__(
+        self,
+        image_stack: ImageStack,
+        sample_idx: int,
+        coords: Sequence[int],
+        patch_size: Sequence[int],
+    ) -> NDArray[Any]: ...
+
+
+def basic_patch_constr(
+    image_stack: ImageStack,
+    sample_idx: int,
+    coords: Sequence[int],
+    patch_size: Sequence[int],
+) -> NDArray[Any]:
+    return image_stack.extract_patch(
+        sample_idx=sample_idx, coords=coords, patch_size=patch_size
+    )
+
+
+def lateral_context_patch_constr(
+    multiscale_count: int, padding_mode: Literal["reflect", "wrap"]
+) -> PatchConstructor:
+    def constructor_func(
+        image_stack: ImageStack,
+        sample_idx: int,
+        coords: Sequence[int],
+        patch_size: Sequence[int],
+    ) -> NDArray[Any]:
+        shape = image_stack.data_shape
+        spatial_shape = shape[2:]
+        n_channels = shape[1]
+
+        patch = np.zeros((multiscale_count, n_channels, *patch_size))
+        for scale in range(multiscale_count):
+            lc_patch_size = np.array(patch_size) * (2**scale)
+            lc_start = np.array(coords) + np.array(patch_size) // 2 - lc_patch_size // 2
+            lc_end = lc_start + np.array(lc_patch_size)
+
+            start_clipped = np.clip(
+                lc_start, np.zeros_like(spatial_shape), np.array(spatial_shape)
+            )
+            end_clipped = np.clip(
+                lc_end, np.zeros_like(spatial_shape), np.array(spatial_shape)
+            )
+            size_clipped = end_clipped - start_clipped
+
+            lc_patch = image_stack.extract_patch(
+                sample_idx, start_clipped, size_clipped
+            )
+            pad_before = start_clipped - lc_start
+            pad_after = lc_end - end_clipped
+            pad_width = np.concat(
+                [
+                    np.zeros((1, 2), dtype=int),
+                    np.stack([pad_before, pad_after], axis=-1),
+                ]
+            )
+            lc_patch = np.pad(
+                # zeros to not pad the channel axis
+                lc_patch,
+                pad_width,
+                mode=padding_mode,
+            )
+            lc_patch = resize(lc_patch, (n_channels, *patch_size))
+            patch[scale] = lc_patch
+        return patch
+
+    return constructor_func

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor.py
@@ -4,6 +4,7 @@ from typing import Generic
 from numpy.typing import NDArray
 
 from .image_stack import GenericImageStack
+from .patch_construction import PatchConstructor, basic_patch_constr
 
 
 class PatchExtractor(Generic[GenericImageStack]):
@@ -11,7 +12,12 @@ class PatchExtractor(Generic[GenericImageStack]):
     A class for extracting patches from multiple image stacks.
     """
 
-    def __init__(self, image_stacks: Sequence[GenericImageStack]):
+    def __init__(
+        self,
+        image_stacks: Sequence[GenericImageStack],
+        patch_constructor: PatchConstructor = basic_patch_constr,
+    ):
+        self.patch_constructor = patch_constructor
         self.image_stacks: list[GenericImageStack] = list(image_stacks)
 
     def extract_patch(
@@ -21,8 +27,11 @@ class PatchExtractor(Generic[GenericImageStack]):
         coords: Sequence[int],
         patch_size: Sequence[int],
     ) -> NDArray:
-        return self.image_stacks[data_idx].extract_patch(
-            sample_idx=sample_idx, coords=coords, patch_size=patch_size
+        return self.patch_constructor(
+            self.image_stacks[data_idx],
+            sample_idx=sample_idx,
+            coords=coords,
+            patch_size=patch_size,
         )
 
     @property

--- a/tests/dataset_ng/patch_extractor/test_lateral_context_construction.py
+++ b/tests/dataset_ng/patch_extractor/test_lateral_context_construction.py
@@ -1,0 +1,65 @@
+from typing import Any
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+from skimage.transform import resize
+
+from careamics.dataset_ng.patch_extractor.image_stack import InMemoryImageStack
+from careamics.dataset_ng.patch_extractor.patch_construction import (
+    lateral_context_patch_constr,
+)
+
+
+def _assert_lc_centralized(lc_input: NDArray[Any]):
+    multiscale_count = lc_input.shape[0]
+    n_channels = lc_input.shape[1]
+    patch_size = lc_input.shape[2:]
+
+    primary_patch = lc_input[0]
+    for scale in range(1, multiscale_count):
+        lc_patch = lc_input[scale]
+
+        scale_factor = 2**scale
+        equiv_size = tuple(ps // scale_factor for ps in patch_size)
+
+        scaled = resize(primary_patch, (n_channels, *equiv_size))
+
+        central_patch = lc_patch[
+            :,
+            *(
+                slice(ps // 2 - es // 2, ps // 2 + es // 2, None)
+                for ps, es in zip(patch_size, equiv_size, strict=True)
+            ),
+        ]
+
+        border_crop = (..., *(slice(2, -2, None) for _ in patch_size))
+        # there are some border differences since resize won't interpolate the same way
+        np.testing.assert_allclose(scaled[border_crop], central_patch[border_crop])
+
+
+@pytest.mark.parametrize(
+    ["data_shape", "patch_size", "axes"],
+    [
+        ((512, 496), (64, 64), "YX"),
+        ((451, 501, 2), (64, 64), "YXC"),
+        ((512, 512, 64), (32, 64, 64), "YXZ"),
+        ((2, 512, 496, 65), (32, 64, 64), "CYXZ"),
+    ],
+)
+@pytest.mark.parametrize("multiscale_count", [2, 3, 4])
+def test_lateral_context_constructor(
+    data_shape: tuple[int, ...],
+    patch_size: tuple[int, ...],
+    axes: str,
+    multiscale_count: int,
+):
+    rng = np.random.default_rng(seed=42)
+    data = rng.random(data_shape)
+    image_stack = InMemoryImageStack.from_array(data, axes)
+
+    constructor_func = lateral_context_patch_constr(multiscale_count, "reflect")
+    coords = [tuple(0 for _ in patch_size), tuple(ps // 2 for ps in (patch_size))]
+    for coord in coords:
+        lc_input = constructor_func(image_stack, 0, coord, patch_size)
+        _assert_lc_centralized(lc_input)


### PR DESCRIPTION
## Description

> [!NOTE]  
> **tldr**: This PR adds support for lateral context patch construction as the first step in implementing data loading requirements for MicroSplit.


### Background - why do we need this PR?

The Next-Gen Dataset framework needs to be used by all algorithms supported by CAREamics, including MicroSplit, which requires lateral context patch construction.

### Overview - what changed?

The `PatchExtractor` classes are now injected with a `PatchConstructor` method; there are two implemented patch construction methods: the "basic" constructor which has the original behaviour, and the "lateral context" constructor which creates patches with a lateral context dimension. The correct patch constructor will be selected at dataset initialisation according to config parameters (future dev), this will require refactoring of all the patch extractor factory functions. 

The reason to use injection here is that, since #596, there are two patch extractors: the regular extractor and now the `LimitFilesPatchExtractor`. We want MicroSplit to be able to take advantage of the iterable file loading mechanism, so this way both extractors can produce lateral context patches, and we don't have a subclass explosion.

The basic constructor is the default, this way the rest of the code doesn't have to change.

### Implementation - how did you implement the changes?

Because the lateral context construction is also parametrised — it needs to know how many lateral context levels to create and what padding mode to use — I implemented this as a closure.

The lateral context construction itself simply: 
1. iterates through the lateral context scales, 
2. calculates the lateral context patch size (`patch_size * 2^scale`), 
3. calculates the lateral context patch start and end
4. clips the lateral context to the boundary of the data (we don't use the image stack padding, introduced in #587, because we want to use padding modes),
5. pads the lateral context with the chosen mode using `numpy.pad`
6. resizes the lateral context with `skimage.transform.resize`
7. stacks the LC patches and returns

## Changes Made

### New features or files

- `PatchConstructor` protocol
- `basic_patch_constr` function
- `lateral_context_patch_constr` function

### Modified features or files

- `PatchConstructor`
- `LimitFilesPatchConstructor`


## How has this been tested?

Two new tests added:
- `test_lateral_context_constructor`
- `test_patch_extractor_lc_injection`

## Related Issues

- Resolves #607 
- This is part of the proposal outlined in https://github.com/CAREamics/careamics/issues/407#issuecomment-3490510392

## Additional Notes and Examples

1. The original LC dataset [creates all the LC scaled data at initialisation](https://github.com/CAREamics/careamics/blob/e640e3a74b5895c1ed90e1f7442a530140ee4605/src/careamics/lvae_training/dataset/lc_dataset.py#L63-L82), this new implementation rescales each patch individually. This might mean that the new implementation is slower, however creating each scale at the start won't be compatible with very large data, and it won't be compatible with zarr loading, which is why I went for the on fly scaling.
2. I used `skimage.transform.resize` because that's what the original dataset uses but The [sci-kit image docs](https://scikit-image.org/docs/0.25.x/api/skimage.transform.html#skimage.transform.resize) suggest using `downscale_local_mean` for integer downscaling. And we might want to benchmark other methods in the future such as max pooling?
3. There is this note in the original dataset which I did not implement https://github.com/CAREamics/careamics/blob/e640e3a74b5895c1ed90e1f7442a530140ee4605/src/careamics/lvae_training/dataset/lc_dataset.py#L70

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)