### PR TITLE
Feature(Next-Gen Dataset): MicroSplit Input and Target Generation (Proof of Principle)

### DIFF
--- a/src/careamics/dataset_ng/microsplit_input_synth.py
+++ b/src/careamics/dataset_ng/microsplit_input_synth.py
@@ -1,0 +1,44 @@
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .patch_extractor import PatchExtractor
+from .patching_strategies import PatchingStrategy
+
+
+def create_uncorrelated_channel_patch(
+    idx: int,
+    patch_extractor: PatchExtractor,
+    patching_strategy: PatchingStrategy,
+    alphas: list[float],
+    rng: np.random.Generator | None,
+) -> NDArray[Any]:
+    if rng is None:
+        rng = np.random.default_rng()
+
+    n_channels = len(alphas)
+
+    # in the original dataset, new random indices are chosen for each channel
+    # the other channels can come from anywhere in the entire dataset
+    indices = (idx, *rng.integers(patching_strategy.n_patches, size=(n_channels - 1)))
+
+    patch_specs = [patching_strategy.get_patch_spec(i) for i in indices]
+    # dimensions C(L)(Z)YX - there may or may not be an L (lateral context) dimension
+    patches = np.concat(
+        [
+            patch_extractor.extract_channel_patch(
+                data_idx=patch_spec["data_idx"],
+                sample_idx=patch_spec["sample_idx"],
+                channel_idx=c,
+                coords=patch_spec["coords"],
+                patch_size=patch_spec["patch_size"],
+            )
+            for c, patch_spec in enumerate(patch_specs)
+        ],
+        axis=0,
+    )
+
+    ndims = len(patches.shape) - 1
+    alpha_broadcast = np.array(alphas)[:, *(np.newaxis for _ in range(ndims))]
+    return (alpha_broadcast * patches).sum(axis=0)

--- a/src/careamics/dataset_ng/microsplit_input_synth.py
+++ b/src/careamics/dataset_ng/microsplit_input_synth.py
@@ -1,31 +1,43 @@
-from typing import Any
+from collections.abc import Callable, Sequence
+from typing import Any, Literal, NamedTuple
 
 import numpy as np
 from numpy.typing import NDArray
 
 from .patch_extractor import PatchExtractor
-from .patching_strategies import PatchingStrategy
+from .patch_extractor.image_stack import ImageStack
+from .patch_filter import PatchFilterProtocol
+from .patching_strategies import PatchingStrategy, PatchSpecs
 
 
-def create_uncorrelated_channel_patch(
-    idx: int,
-    patch_extractor: PatchExtractor,
-    patching_strategy: PatchingStrategy,
-    alphas: list[float],
-    rng: np.random.Generator | None,
+# TODO: better name
+# mirrors format of ImageRegionData
+class UncorrelatedRegionData(NamedTuple):
+    data: NDArray
+    source: Sequence[str | Literal["array"]]
+    data_shape: Sequence[Sequence[int]]
+    dtype: Sequence[str]  # dtype should be str for collate
+    # axes: Sequence[str]
+    region_spec: Sequence[PatchSpecs]
+
+
+def is_empty(filter: PatchFilterProtocol) -> Callable[[NDArray[Any]], bool]:
+    def is_empty_check(patch: NDArray[Any]) -> bool:
+        return filter.filter_out(patch)
+
+    return is_empty_check
+
+
+def is_not_empty(filter: PatchFilterProtocol) -> Callable[[NDArray[Any]], bool]:
+    def is_not_empty_check(patch: NDArray[Any]) -> bool:
+        return not filter.filter_out(patch)
+
+    return is_not_empty_check
+
+
+def create_microsplit_patch(
+    patch_extractor: PatchExtractor[ImageStack], patch_specs: list[PatchSpecs]
 ) -> NDArray[Any]:
-    if rng is None:
-        rng = np.random.default_rng()
-
-    n_channels = len(alphas)
-
-    # in the original dataset, new random indices are chosen for each channel
-    # the other channels can come from anywhere in the entire dataset
-    indices = (idx, *rng.integers(patching_strategy.n_patches, size=(n_channels - 1)))
-
-    patch_specs = [patching_strategy.get_patch_spec(i) for i in indices]
-    # dimensions C(L)(Z)YX - there may or may not be an L (lateral context) dimension
-    # this depends on whether the PatchExtractor uses the lc patch constructor
     patches = np.concat(
         [
             patch_extractor.extract_channel_patch(
@@ -39,9 +51,139 @@ def create_uncorrelated_channel_patch(
         ],
         axis=0,
     )
+    # Add L dimension if not present
+    # TODO: make this more robust: maybe PatchExtractor should have an ndim attribute
+    n_spatial_dims = len(patch_specs[0]["patch_size"])
+    lateral_context_present = len(patches.shape) - n_spatial_dims == 2
+    if not lateral_context_present:
+        # insert a L dim
+        patches = patches[:, np.newaxis]
 
+    return patches
+
+
+def get_random_channel_patches(
+    idx: int,
+    patching_strategy: PatchingStrategy,
+    patch_extractor: PatchExtractor[ImageStack],
+    rng: np.random.Generator | None,
+) -> tuple[NDArray[Any], list[PatchSpecs]]:
+    if rng is None:
+        rng = np.random.default_rng()
+
+    n_channels = patch_extractor.n_channels
+
+    # in the original dataset, new random indices are chosen for each channel
+    # the other channels can come from anywhere in the entire dataset
+    indices = (idx, *rng.integers(patching_strategy.n_patches, size=(n_channels - 1)))
+
+    # get n different patch specs for n different channels
+    patch_specs = [patching_strategy.get_patch_spec(i) for i in indices]
+    patches = create_microsplit_patch(patch_extractor, patch_specs)
+
+    return patches, patch_specs
+
+
+def get_empty_channel_patches(
+    idx: int,
+    patching_strategy: PatchingStrategy,
+    patch_extractor: PatchExtractor,
+    filled_channels: dict[int, PatchFilterProtocol],
+    empty_channels: dict[int, PatchFilterProtocol],
+    patience: int,
+    rng: np.random.Generator | None,
+) -> tuple[NDArray[Any], list[PatchSpecs]]:
+    if rng is None:
+        rng = np.random.default_rng()
+
+    # if a channel is not selected to be empty or filled it will from idx
+    filled = set(filled_channels.keys())
+    empty = set(empty_channels.keys())
+    if len(intersect := filled.intersection(empty)) != 0:
+        raise ValueError(
+            "Channels cannot be selected as both empty and filled, the following "
+            f"channels were selected as both {intersect}."
+        )
+
+    n_channels = patch_extractor.n_channels
+    patch_spec = patching_strategy.get_patch_spec(idx)
+    patch_specs = [patch_spec for _ in range(n_channels)]
+    # initial patches
+    patches = create_microsplit_patch(patch_extractor, patch_specs)  # CL(Z)YX
+
+    # for each channel sample patches until they are empty or not empty
+    for c in range(n_channels):
+
+        # criterion for the while loop
+        criterion: Callable[[NDArray[Any]], bool]
+        filter_: PatchFilterProtocol
+        if c in empty_channels:
+            filter_ = empty_channels[c]
+            criterion = is_not_empty(filter_)
+        elif c in filled_channels:
+            filter_ = filled_channels[c]
+            criterion = is_empty(filter_)
+        else:
+            break
+
+        patch = patches[c]
+        patience_ = patience
+        # only check if primary input is empty
+        while criterion(patch[0]) and patience_ > 0:
+            # sample random indices from anywhere in the dataset
+            new_idx = rng.integers(patching_strategy.n_patches)
+            patch_spec = patching_strategy.get_patch_spec(new_idx.item())
+            patch = patch_extractor.extract_channel_patch(
+                data_idx=patch_spec["data_idx"],
+                sample_idx=patch_spec["sample_idx"],
+                channel_idx=c,
+                coords=patch_spec["coords"],
+                patch_size=patch_spec["patch_size"],
+            )[0]
+            # ^ removing channel dim
+            patience_ -= 1
+        if patience <= 0:
+            print(f"Out of patience finding patch for channel {c}")
+
+        patches[c] = patch
+        patch_specs[c] = patch_spec
+
+    return patches, patch_specs
+
+
+def create_microsplit_input_target(
+    patches: NDArray[Any],
+    patch_specs: list[PatchSpecs],
+    alphas: list[float],
+    patch_extractor: PatchExtractor[ImageStack],
+):
     ndims = len(patches.shape) - 1
     alpha_broadcast = np.array(alphas)[:, *(np.newaxis for _ in range(ndims))]
     # weight channels by alphas then sum on the channel axis
-    # output dims will be (L)(Z)YX - TODO: this might be annoying later
-    return (alpha_broadcast * patches).sum(axis=0)
+    # input dims will be L(Z)YX
+    input_patch = (alpha_broadcast * patches).sum(axis=0)
+    target_patch = patches[:, 0, ...]  # first L patch
+
+    input_stacks = [
+        patch_extractor.image_stacks[patch_spec["data_idx"]]
+        for patch_spec in patch_specs
+    ]
+    source = [str(stack.source) for stack in input_stacks]
+    data_shape = [stack.data_shape for stack in input_stacks]
+    dtype = [str(stack.data_dtype) for stack in input_stacks]
+
+    input_region = UncorrelatedRegionData(
+        data=input_patch,
+        source=source,
+        data_shape=data_shape,
+        dtype=dtype,
+        region_spec=patch_specs,
+    )
+    target_region = UncorrelatedRegionData(
+        data=target_patch,
+        source=source,
+        data_shape=data_shape,
+        dtype=dtype,
+        region_spec=patch_specs,
+    )
+    return input_region, target_region

--- a/src/careamics/dataset_ng/microsplit_input_synth.py
+++ b/src/careamics/dataset_ng/microsplit_input_synth.py
@@ -25,6 +25,7 @@ def create_uncorrelated_channel_patch(
 
     patch_specs = [patching_strategy.get_patch_spec(i) for i in indices]
     # dimensions C(L)(Z)YX - there may or may not be an L (lateral context) dimension
+    # this depends on whether the PatchExtractor uses the lc patch constructor
     patches = np.concat(
         [
             patch_extractor.extract_channel_patch(
@@ -41,4 +42,6 @@ def create_uncorrelated_channel_patch(
 
     ndims = len(patches.shape) - 1
     alpha_broadcast = np.array(alphas)[:, *(np.newaxis for _ in range(ndims))]
+    # weight channels by alphas then sum on the channel axis
+    # output dims will be (L)(Z)YX - TODO: this might be annoying later
     return (alpha_broadcast * patches).sum(axis=0)

--- a/src/careamics/dataset_ng/microsplit_input_synth.py
+++ b/src/careamics/dataset_ng/microsplit_input_synth.py
@@ -226,6 +226,7 @@ def get_random_channel_patches(
     return patches, patch_specs
 
 
+# TODO: better name
 def get_empty_channel_patches(
     idx: int,
     patch_extractor: PatchExtractor,
@@ -281,10 +282,11 @@ def get_empty_channel_patches(
         )
 
     n_channels = patch_extractor.n_channels
-    patch_spec = patching_strategy.get_patch_spec(idx)
-    patch_specs = [patch_spec for _ in range(n_channels)]
-    # initial patches
-    patches = extract_microsplit_patch(patch_extractor, patch_specs)  # CL(Z)YX
+
+    # start with random initial patches
+    patches, patch_specs = get_random_channel_patches(
+        idx, patch_extractor, patching_strategy, rng
+    )
 
     # for each channel sample patches until they are empty or not empty
     for c in range(n_channels):

--- a/src/careamics/dataset_ng/microsplit_input_synth.py
+++ b/src/careamics/dataset_ng/microsplit_input_synth.py
@@ -304,6 +304,7 @@ def get_empty_channel_patches(
             break
 
         patch = patches[c]
+        patch_spec = patch_specs[c]
         patience_ = patience
         # only check if primary input is empty
         while criterion(patch[0]) and patience_ > 0:

--- a/src/careamics/dataset_ng/microsplit_input_synth.py
+++ b/src/careamics/dataset_ng/microsplit_input_synth.py
@@ -1,3 +1,8 @@
+"""MicroSplit patch synthesis."""
+
+# --- PROOF OF PRINCIPLE ---
+
+
 from collections.abc import Callable, Sequence
 from typing import Any, Literal, NamedTuple
 
@@ -18,11 +23,11 @@ class UncorrelatedRegionData(NamedTuple):
     source: Sequence[str | Literal["array"]]
     data_shape: Sequence[Sequence[int]]
     dtype: Sequence[str]  # dtype should be str for collate
-    # axes: Sequence[str]
+    axes: Sequence[str]
     region_spec: Sequence[PatchSpecs]
 
 
-# --- for empty channel loop
+# --- for finding empty / signal channel patches in loop
 def is_empty(filter: PatchFilterProtocol) -> Callable[[NDArray[Any]], bool]:
     def is_empty_check(patch: NDArray[Any]) -> bool:
         return filter.filter_out(patch)
@@ -37,6 +42,9 @@ def is_not_empty(filter: PatchFilterProtocol) -> Callable[[NDArray[Any]], bool]:
     return is_not_empty_check
 
 
+# ---
+
+
 def create_default_input_target(
     idx: int,
     patch_extractor: PatchExtractor[ImageStack],
@@ -45,7 +53,7 @@ def create_default_input_target(
     axes: str,  # annoyingly have to supply this to image region
 ) -> tuple[ImageRegionData, ImageRegionData]:
     """
-    Create a default MicroSplit patch.
+    Create a default MicroSplit patch with synthetically summed input.
 
     Parameters
     ----------
@@ -114,9 +122,10 @@ def create_uncorrelated_input_target(
     patch_specs: list[PatchSpecs],
     alphas: list[float],
     patch_extractor: PatchExtractor[ImageStack],  # for metadata
+    axes: str,  # mirroring imageregion
 ) -> tuple[UncorrelatedRegionData, UncorrelatedRegionData]:
     """
-    Create MicroSplit target and synthetic input with metadata.
+    Create MicroSplit target and synthetically summed input with metadata.
 
     Parameters
     ----------
@@ -159,6 +168,7 @@ def create_uncorrelated_input_target(
         data_shape=data_shape,
         dtype=dtype,
         region_spec=patch_specs,
+        axes=axes,
     )
     target_region = UncorrelatedRegionData(
         data=target_patch,
@@ -166,6 +176,7 @@ def create_uncorrelated_input_target(
         data_shape=data_shape,
         dtype=dtype,
         region_spec=patch_specs,
+        axes=axes,
     )
     return input_region, target_region
 

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/czi_image_stack.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/czi_image_stack.py
@@ -175,18 +175,9 @@ class CziImageStack:
     def extract_patch(
         self, sample_idx: int, coords: Sequence[int], patch_size: Sequence[int]
     ) -> NDArray:
-        return self._extract_patch(sample_idx, None, coords, patch_size)
+        return self.extract_channel_patch(sample_idx, None, coords, patch_size)
 
     def extract_channel_patch(
-        self,
-        sample_idx: int,
-        channel_idx: int,
-        coords: Sequence[int],
-        patch_size: Sequence[int],
-    ) -> NDArray:
-        return self._extract_patch(sample_idx, channel_idx, coords, patch_size)
-
-    def _extract_patch(
         self,
         sample_idx: int,
         channel_idx: int | None,  # `channel_idx = None` to select all channels

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/file_image_stack.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/file_image_stack.py
@@ -40,6 +40,24 @@ class FileImageStack:
     def extract_patch(
         self, sample_idx: int, coords: Sequence[int], patch_size: Sequence[int]
     ) -> NDArray:
+        return self._extract_patch(sample_idx, None, coords, patch_size)
+
+    def extract_channel_patch(
+        self,
+        sample_idx: int,
+        channel_idx: int,
+        coords: Sequence[int],
+        patch_size: Sequence[int],
+    ) -> NDArray:
+        return self._extract_patch(sample_idx, channel_idx, coords, patch_size)
+
+    def _extract_patch(
+        self,
+        sample_idx: int,
+        channel_idx: int | None,  # `channel_idx = None` to select all channels
+        coords: Sequence[int],
+        patch_size: Sequence[int],
+    ) -> NDArray:
         if self._data is None:
             raise ValueError(
                 "Cannot extract patch because data has not been loaded from "
@@ -55,7 +73,8 @@ class FileImageStack:
         patch_data = self._data[
             (
                 sample_idx,  # type: ignore
-                ...,  # type: ignore
+                # use channel slice so that channel dimension is kept
+                ... if channel_idx is None else slice(channel_idx, channel_idx + 1),  # type: ignore
                 *[
                     slice(
                         np.clip(c, 0, self.data_shape[2 + i]),

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/file_image_stack.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/file_image_stack.py
@@ -40,18 +40,9 @@ class FileImageStack:
     def extract_patch(
         self, sample_idx: int, coords: Sequence[int], patch_size: Sequence[int]
     ) -> NDArray:
-        return self._extract_patch(sample_idx, None, coords, patch_size)
+        return self.extract_channel_patch(sample_idx, None, coords, patch_size)
 
     def extract_channel_patch(
-        self,
-        sample_idx: int,
-        channel_idx: int,
-        coords: Sequence[int],
-        patch_size: Sequence[int],
-    ) -> NDArray:
-        return self._extract_patch(sample_idx, channel_idx, coords, patch_size)
-
-    def _extract_patch(
         self,
         sample_idx: int,
         channel_idx: int | None,  # `channel_idx = None` to select all channels

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/image_stack_protocol.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/image_stack_protocol.py
@@ -56,7 +56,7 @@ class ImageStack(Protocol):
     def extract_channel_patch(
         self,
         sample_idx: int,
-        channel_idx: int,
+        channel_idx: int | None,
         coords: Sequence[int],
         patch_size: Sequence[int],
     ) -> NDArray:

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/image_stack_protocol.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/image_stack_protocol.py
@@ -33,13 +33,43 @@ class ImageStack(Protocol):
         self, sample_idx: int, coords: Sequence[int], patch_size: Sequence[int]
     ) -> NDArray:
         """
-        Extracts a patch for a given sample within the image stack.
+        Extract a patch for a given sample within the image stack.
 
         Parameters
         ----------
         sample_idx: int
             Sample index. The first dimension of the image data will be indexed at this
             value.
+        coords: Sequence of int
+            The coordinates that define the start of a patch.
+        patch_size: Sequence of int
+            The size of the patch in each spatial dimension.
+
+        Returns
+        -------
+        numpy.ndarray
+            A patch of the image data from a particlular sample. It will have the
+            dimensions C(Z)YX.
+        """
+        ...
+
+    def extract_channel_patch(
+        self,
+        sample_idx: int,
+        channel_idx: int,
+        coords: Sequence[int],
+        patch_size: Sequence[int],
+    ) -> NDArray:
+        """
+        Extract a patch of a single channel for a given sample within the image stack.
+
+        Parameters
+        ----------
+        sample_idx: int
+            Sample index. The first dimension of the image data will be indexed at this
+            value.
+        channel_idx: int
+            Channel index. The channel to extract a patch from.
         coords: Sequence of int
             The coordinates that define the start of a patch.
         patch_size: Sequence of int

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/in_memory_image_stack.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/in_memory_image_stack.py
@@ -26,6 +26,24 @@ class InMemoryImageStack:
     def extract_patch(
         self, sample_idx: int, coords: Sequence[int], patch_size: Sequence[int]
     ) -> NDArray:
+        return self._extract_patch(sample_idx, None, coords, patch_size)
+
+    def extract_channel_patch(
+        self,
+        sample_idx: int,
+        channel_idx: int,
+        coords: Sequence[int],
+        patch_size: Sequence[int],
+    ) -> NDArray:
+        return self._extract_patch(sample_idx, channel_idx, coords, patch_size)
+
+    def _extract_patch(
+        self,
+        sample_idx: int,
+        channel_idx: int | None,  # `channel_idx = None` to select all channels
+        coords: Sequence[int],
+        patch_size: Sequence[int],
+    ) -> NDArray:
         if (coord_dims := len(coords)) != (patch_dims := len(patch_size)):
             raise ValueError(
                 "Patch coordinates and patch size must have the same dimensions but "
@@ -36,7 +54,7 @@ class InMemoryImageStack:
         patch_data = self._data[
             (
                 sample_idx,  # type: ignore
-                ...,  # type: ignore
+                ... if channel_idx is None else slice(channel_idx, channel_idx + 1),  # type: ignore
                 *[
                     slice(
                         np.clip(c, 0, self.data_shape[2 + i]),

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/in_memory_image_stack.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/in_memory_image_stack.py
@@ -26,18 +26,9 @@ class InMemoryImageStack:
     def extract_patch(
         self, sample_idx: int, coords: Sequence[int], patch_size: Sequence[int]
     ) -> NDArray:
-        return self._extract_patch(sample_idx, None, coords, patch_size)
+        return self.extract_channel_patch(sample_idx, None, coords, patch_size)
 
     def extract_channel_patch(
-        self,
-        sample_idx: int,
-        channel_idx: int,
-        coords: Sequence[int],
-        patch_size: Sequence[int],
-    ) -> NDArray:
-        return self._extract_patch(sample_idx, channel_idx, coords, patch_size)
-
-    def _extract_patch(
         self,
         sample_idx: int,
         channel_idx: int | None,  # `channel_idx = None` to select all channels
@@ -54,6 +45,7 @@ class InMemoryImageStack:
         patch_data = self._data[
             (
                 sample_idx,  # type: ignore
+                # use channel slice so that channel dimension is kept
                 ... if channel_idx is None else slice(channel_idx, channel_idx + 1),  # type: ignore
                 *[
                     slice(

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/utils.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/utils.py
@@ -63,7 +63,7 @@ def pad_patch(
         The resulting padded patch.
     """
     coords_ = np.array(coords)
-    patch = np.zeros((data_shape[1], *patch_size), dtype=patch_data.dtype)
+    patch = np.zeros((patch_data.shape[0], *patch_size), dtype=patch_data.dtype)
     # data start will be zero unless coords are negative
     data_start = np.clip(coords_, 0, None) - coords_
     data_end = data_start + np.array(patch_data.shape[1:])

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/zarr_image_stack.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/zarr_image_stack.py
@@ -20,11 +20,13 @@ class ZarrImageStack:
 
         self._group = group
         self._store = str(group.store_path)
-        self._array = group[data_path]
-        if not isinstance(self._array, zarr.Array):
-            raise TypeError(
+        try:
+            self._array = group[data_path]
+        except KeyError as e:
+            raise ValueError(
                 f"Did not find array at '{data_path}' in store '{self._store}'."
-            )
+            ) from e
+
         self._source = self._array.store_path
 
         # TODO: validate axes

--- a/src/careamics/dataset_ng/patch_extractor/image_stack/zarr_image_stack.py
+++ b/src/careamics/dataset_ng/patch_extractor/image_stack/zarr_image_stack.py
@@ -49,18 +49,9 @@ class ZarrImageStack:
     def extract_patch(
         self, sample_idx: int, coords: Sequence[int], patch_size: Sequence[int]
     ) -> NDArray:
-        return self._extract_patch(sample_idx, None, coords, patch_size)
+        return self.extract_channel_patch(sample_idx, None, coords, patch_size)
 
     def extract_channel_patch(
-        self,
-        sample_idx: int,
-        channel_idx: int,
-        coords: Sequence[int],
-        patch_size: Sequence[int],
-    ) -> NDArray:
-        return self._extract_patch(sample_idx, channel_idx, coords, patch_size)
-
-    def _extract_patch(
         self,
         sample_idx: int,
         channel_idx: int | None,  # `channel_idx = None` to select all channels,

--- a/src/careamics/dataset_ng/patch_extractor/limit_file_extractor.py
+++ b/src/careamics/dataset_ng/patch_extractor/limit_file_extractor.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from numpy.typing import NDArray
 
 from .image_stack import FileImageStack
-from .patch_construction import PatchConstructor, basic_patch_constr
+from .patch_construction import PatchConstructor, default_patch_constr
 from .patch_extractor import PatchExtractor
 
 
@@ -17,7 +17,7 @@ class LimitFilesPatchExtractor(PatchExtractor[FileImageStack]):
     def __init__(
         self,
         image_stacks: Sequence[FileImageStack],
-        patch_constructor: PatchConstructor = basic_patch_constr,
+        patch_constructor: PatchConstructor = default_patch_constr,
     ):
         """
         Parameters

--- a/src/careamics/dataset_ng/patch_extractor/limit_file_extractor.py
+++ b/src/careamics/dataset_ng/patch_extractor/limit_file_extractor.py
@@ -27,10 +27,11 @@ class LimitFilesPatchExtractor(PatchExtractor[FileImageStack]):
         super().__init__(image_stacks, patch_constructor)
         self.loaded_stacks: list[int] = []
 
-    def extract_patch(
+    def extract_channel_patch(
         self,
         data_idx: int,
         sample_idx: int,
+        channel_idx: int | None,
         coords: Sequence[int],
         patch_size: Sequence[int],
     ) -> NDArray:
@@ -44,4 +45,6 @@ class LimitFilesPatchExtractor(PatchExtractor[FileImageStack]):
             self.image_stacks[data_idx].load()
             self.loaded_stacks.append(data_idx)
 
-        return super().extract_patch(data_idx, sample_idx, coords, patch_size)
+        return super().extract_channel_patch(
+            data_idx, sample_idx, channel_idx, coords, patch_size
+        )

--- a/src/careamics/dataset_ng/patch_extractor/patch_construction.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_construction.py
@@ -15,6 +15,7 @@ class PatchConstructor(Protocol):
         self,
         image_stack: ImageStack,
         sample_idx: int,
+        channel_idx: int | None,  # `channel_idx = None` to select all channels
         coords: Sequence[int],
         patch_size: Sequence[int],
     ) -> NDArray[Any]:
@@ -42,11 +43,15 @@ class PatchConstructor(Protocol):
 def basic_patch_constr(
     image_stack: ImageStack,
     sample_idx: int,
+    channel_idx: int | None,  # `channel_idx = None` to select all channels
     coords: Sequence[int],
     patch_size: Sequence[int],
 ) -> NDArray[Any]:
-    return image_stack.extract_patch(
-        sample_idx=sample_idx, coords=coords, patch_size=patch_size
+    return image_stack.extract_channel_patch(
+        sample_idx=sample_idx,
+        channel_idx=channel_idx,
+        coords=coords,
+        patch_size=patch_size,
     )
 
 
@@ -81,6 +86,7 @@ def lateral_context_patch_constr(
     def constructor_func(
         image_stack: ImageStack,
         sample_idx: int,
+        channel_idx: int | None,  # `channel_idx = None` to select all channels
         coords: Sequence[int],
         patch_size: Sequence[int],
     ) -> NDArray[Any]:
@@ -107,8 +113,8 @@ def lateral_context_patch_constr(
             )
             size_clipped = end_clipped - start_clipped
 
-            lc_patch = image_stack.extract_patch(
-                sample_idx, start_clipped, size_clipped
+            lc_patch = image_stack.extract_channel_patch(
+                sample_idx, channel_idx, start_clipped, size_clipped
             )
             pad_before = start_clipped - lc_start
             pad_after = lc_end - end_clipped

--- a/src/careamics/dataset_ng/patch_extractor/patch_construction.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_construction.py
@@ -74,7 +74,7 @@ def lateral_context_patch_constr(
     -------
     PatchConstructor
         The patch constructor function. It will return patches with the dimensions
-        (L, C, (Z), Y, X) where L will be equal to `multiscale_count`, C is the number
+        (C, L, (Z), Y, X) where L will be equal to `multiscale_count`, C is the number
         of channels in the image, and (Z), Y, X are the patch size.
     """
 
@@ -93,7 +93,7 @@ def lateral_context_patch_constr(
         # TODO: maybe we want to limit this constructor to only images with 1 channel
         #   then we can put LCs in the channel dimension
         #   but not sure if this artificially limits potential use-cases
-        patch = np.zeros((multiscale_count, n_channels, *patch_size))
+        patch = np.zeros((n_channels, multiscale_count, *patch_size))
         for scale in range(multiscale_count):
             lc_patch_size = np.array(patch_size) * (2**scale)
             lc_start = np.array(coords) + np.array(patch_size) // 2 - lc_patch_size // 2
@@ -126,7 +126,7 @@ def lateral_context_patch_constr(
             )
             # TODO: test different downscaling? skimage suggests downscale_local_mean
             lc_patch = resize(lc_patch, (n_channels, *patch_size))
-            patch[scale] = lc_patch
+            patch[:, scale, ...] = lc_patch
         return patch
 
     return constructor_func

--- a/src/careamics/dataset_ng/patch_extractor/patch_construction.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_construction.py
@@ -9,7 +9,13 @@ from .image_stack import ImageStack
 
 
 class PatchConstructor(Protocol):
-    """A patch constructor function creates a patch from a given ImageStack."""
+    """
+    A callable that modifies how patches are constructed in the PatchExtractor.
+
+    This protocol defines the signature of a callable that is passed as an argument to
+    the `PatchExtractor`. It can be used to modify how patches are constructed, for
+    example creating patches with multiple lateral context levels for MicroSplit.
+    """
 
     def __call__(
         self,
@@ -40,7 +46,7 @@ class PatchConstructor(Protocol):
         ...
 
 
-def basic_patch_constr(
+def default_patch_constr(
     image_stack: ImageStack,
     sample_idx: int,
     channel_idx: int | None,  # `channel_idx = None` to select all channels

--- a/src/careamics/dataset_ng/patch_extractor/patch_construction.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_construction.py
@@ -92,7 +92,7 @@ def lateral_context_patch_constr(
     ) -> NDArray[Any]:
         shape = image_stack.data_shape
         spatial_shape = shape[2:]
-        n_channels = shape[1]
+        n_channels = shape[1] if channel_idx is None else 1
 
         # There will now be an additional lc dimension,
         # this has to be handled correctly by the dataset

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor.py
@@ -4,7 +4,7 @@ from typing import Generic
 from numpy.typing import NDArray
 
 from .image_stack import GenericImageStack
-from .patch_construction import PatchConstructor, basic_patch_constr
+from .patch_construction import PatchConstructor, default_patch_constr
 
 
 class PatchExtractor(Generic[GenericImageStack]):
@@ -15,7 +15,7 @@ class PatchExtractor(Generic[GenericImageStack]):
     def __init__(
         self,
         image_stacks: Sequence[GenericImageStack],
-        patch_constructor: PatchConstructor = basic_patch_constr,
+        patch_constructor: PatchConstructor = default_patch_constr,
     ):
         self.patch_constructor = patch_constructor
         self.image_stacks: list[GenericImageStack] = list(image_stacks)

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor.py
@@ -20,6 +20,25 @@ class PatchExtractor(Generic[GenericImageStack]):
         self.patch_constructor = patch_constructor
         self.image_stacks: list[GenericImageStack] = list(image_stacks)
 
+        # check all image stacks have the same number of dimensions
+        # check all image stacks have the same number of channels
+        self.n_spatial_dims = len(self.image_stacks[0].data_shape) - 2  # SC(Z)YX
+        self.n_channels = self.image_stacks[0].data_shape[1]
+        for i, image_stack in enumerate(image_stacks):
+            if (ndims := len(image_stack.data_shape) - 2) != self.n_spatial_dims:
+                raise ValueError(
+                    "All `ImageStack` objects in a `PatchExtractor` must have the same "
+                    "number of spatial dimensions. The first image stack is "
+                    f"{self.n_spatial_dims}D but found a {ndims}D image stack at index "
+                    f"{i}."
+                )
+            if (n_channels := image_stack.data_shape[1]) != self.n_channels:
+                raise ValueError(
+                    "All `ImageStack` objects in a `PatchExtractor` must have the same "
+                    f"number of channels. The first image stack has {self.n_channels} "
+                    f"but found an image stack with {n_channels} at index {i}."
+                )
+
     def extract_patch(
         self,
         data_idx: int,

--- a/src/careamics/dataset_ng/patch_extractor/patch_extractor.py
+++ b/src/careamics/dataset_ng/patch_extractor/patch_extractor.py
@@ -27,9 +27,26 @@ class PatchExtractor(Generic[GenericImageStack]):
         coords: Sequence[int],
         patch_size: Sequence[int],
     ) -> NDArray:
+        return self.extract_channel_patch(
+            data_idx=data_idx,
+            sample_idx=sample_idx,
+            channel_idx=None,
+            coords=coords,
+            patch_size=patch_size,
+        )
+
+    def extract_channel_patch(
+        self,
+        data_idx: int,
+        sample_idx: int,
+        channel_idx: int | None,
+        coords: Sequence[int],
+        patch_size: Sequence[int],
+    ) -> NDArray:
         return self.patch_constructor(
             self.image_stacks[data_idx],
             sample_idx=sample_idx,
+            channel_idx=channel_idx,
             coords=coords,
             patch_size=patch_size,
         )

--- a/tests/dataset_ng/patch_extractor/test_lateral_context_construction.py
+++ b/tests/dataset_ng/patch_extractor/test_lateral_context_construction.py
@@ -21,17 +21,17 @@ def _assert_lc_centralized(lc_patch: NDArray[Any]):
     Parameters
     ----------
     lc_input : NDArray[Any]
-        The lateral context input with the dimensions LC(Z)YX, where L is the lateral
+        The lateral context input with the dimensions CL(Z)YX, where L is the lateral
         context inputs. The first patch in L is the primary patch at the original
         image scale.
     """
-    multiscale_count = lc_patch.shape[0]
-    n_channels = lc_patch.shape[1]
+    multiscale_count = lc_patch.shape[1]
+    n_channels = lc_patch.shape[0]
     patch_size = lc_patch.shape[2:]
 
-    primary_patch = lc_patch[0]
+    primary_patch = lc_patch[:, 0, ...]
     for scale in range(1, multiscale_count):
-        lc_scale = lc_patch[scale]
+        lc_scale = lc_patch[:, scale, ...]
 
         scale_factor = 2**scale
         # size of the data in the primary patch at this scale
@@ -79,7 +79,7 @@ def test_lateral_context_constructor(
     coords = [tuple(0 for _ in patch_size), tuple(ps // 2 for ps in (patch_size))]
     for coord in coords:
         lc_patch = constructor_func(image_stack, 0, coord, patch_size)
-        assert lc_patch.shape[0] == multiscale_count
+        assert lc_patch.shape[1] == multiscale_count
         _assert_lc_centralized(lc_patch)
 
 
@@ -103,5 +103,5 @@ def test_patch_extractor_lc_injection():
     for idx in range(patching_strat.n_patches):
         patch_spec = patching_strat.get_patch_spec(idx)
         lc_patch = patch_extractor.extract_patch(**patch_spec)
-        assert lc_patch.shape[0] == multiscale_count
+        assert lc_patch.shape[1] == multiscale_count
         _assert_lc_centralized(lc_patch)

--- a/tests/dataset_ng/patch_extractor/test_lateral_context_construction.py
+++ b/tests/dataset_ng/patch_extractor/test_lateral_context_construction.py
@@ -63,9 +63,11 @@ def _assert_lc_centralized(lc_patch: NDArray[Any]):
         ((2, 512, 497, 129), (32, 64, 64), "CYXZ"),
     ],
 )
+@pytest.mark.parametrize("channel_idx", [0, None])
 def test_lateral_context_constructor(
     data_shape: tuple[int, ...],
     patch_size: tuple[int, ...],
+    channel_idx: int | None,
     axes: str,
 ):
     """Test the lateral context patch constructor function."""
@@ -78,7 +80,7 @@ def test_lateral_context_constructor(
     # test coord at edge (which will have padded lc) and coord at centre
     coords = [tuple(0 for _ in patch_size), tuple(ps // 2 for ps in (patch_size))]
     for coord in coords:
-        lc_patch = constructor_func(image_stack, 0, coord, patch_size)
+        lc_patch = constructor_func(image_stack, 0, channel_idx, coord, patch_size)
         assert lc_patch.shape[1] == multiscale_count
         _assert_lc_centralized(lc_patch)
 

--- a/tests/dataset_ng/patch_extractor/zarr/test_zarr_image_stack.py
+++ b/tests/dataset_ng/patch_extractor/zarr/test_zarr_image_stack.py
@@ -83,7 +83,7 @@ def test_extract_patch_2D(
 def test_ome_zarr(ome_zarr_url):
     """Test that ZarrImageStack can be initialised from an OME-Zarr URL."""
     # instantiate zarr image stack
-    group = zarr.open(ome_zarr_url, mode="r")
+    group = zarr.open_group(ome_zarr_url, mode="r")
     path, axes = _extract_metadata_from_ome_zarr(group)
     image_stack = ZarrImageStack(group=group, data_path=path, axes=axes)
 
@@ -95,3 +95,11 @@ def test_ome_zarr(ome_zarr_url):
     )
     assert isinstance(patch, np.ndarray)  # make sure patch is numpy
     assert patch.shape == (n_channels, *patch_size)  # extracted patch has expected size
+
+
+def test_no_array_error(tmp_path):
+    file_path = tmp_path / "test_zarr.zarr"
+    group = zarr.create_group(file_path.resolve())
+
+    with pytest.raises(ValueError):
+        _ = ZarrImageStack(group=group, data_path="no/array", axes="YX")


### PR DESCRIPTION
## Description

> [!NOTE]  
> **tldr**: This PR implements MicroSplit input and target patch synthesis using the Next-Gen Dataset components. Please note this is a proof of principle and will need refactoring to integrate the functions into a Dataset class. 

### Background - why do we need this PR?

The MicroSplit algorithm has the option to synthesis the input by summing the target channels, with some given weights. Optionally — to augment the data, if the channels are spatially uncorrelated — the channels of the target patch can come from different spatial locations. The content of the channels can also be chosen to be empty or have signal by using the patch filtering implemented in #532.

### Overview - what changed?

Added a new module `dataset_ng/microsplit_input_synth.py` containing the MicroSplit patching function. These will need refactoring in future development, possibly being converted to methods on a dataset class, but they demonstrate how the Next-Gen Dataset components can be used for MicroSplit patching.

New method `extract_channel_patch` has been added to the image stacks and patch extractor.

### Implementation - how did you implement the changes?

New functions in `microsplit_input_synth.py` are as follows:

- **`extract_microsplit_patch`**: This function makes sure the resulting patch always has the dimensions `LC(Z)YX` adding an additional L dimension where necessary (we have no knowledge whether the patch extractor is using LC patch construction - I find this a bit annoying but I don't have another solution right now). It can also accept one `PatchSpec` for spatially correlated channels or a list with one for each channel.
- **`get_random_channel_patches`**: gets patch specs and patches where each channel is from a random spatial location anywhere in the dataset.
- **`get_empty_channel_patches`** (needs to be renamed): whether a channel should have signal or be empty can be specified by providing a dict of `PatchFilterProtocol`. The function will randomly select patches until it finds a patch with signal / a patch that is empty or until the patience runs out. Only the primary input is checked for signal/emptyness.
- **`create_uncorrelated_input_target`**: this takes the results of `get_random_channel_patches` or `get_empty_channel_patches` and constructs input and target patches with metadata attached in an `UncorrelatedRegionData` named tuple.
- **`create_default_input_target`**: Creates input and target patches with metadata in an `ImageRegionData` named tuple (which is also used by the `CareamicsDataset`).


## Changes Made

### New features or files

- new function `extract_microsplit_patch`
- new function `get_random_channel_patches`
- new function `get_empty_channel_patches`
- new function `create_default_input_target`
- new class `UncorrelatedRegionData`

### Modified features or files

<!-- List important modified features or files. -->
- new method `extract_channel_patch` in `PatchExtractor`
- new method `extract_channel_patch` in `ImageStack`


## How has this been tested?

Tested in notebooks and scripts only so far, see gist in Notes section below.

## Related Issues

- Resolves #613 

## Future work / Potential issues

- If uncorrelated channel data comes from images with different spatial dimension then we need to create a separate patch extractor and patching strategy for each channel, these could be given a list to all the functions.
- `UncorrelatedRegionData` mirrors `ImageRegionData` but has a list instead of a single item for most of the metadata. This might be annoying later and we might have to come up with a better solution.
- Choosing which construction method is used based on probabilities set in the config.

## Additional Notes and Examples

The script in the gist below can be downloaded and run with `uv run demo_microsplit_patches_PoP.py` and it should produce figures similar to those attached below. This demonstrates the possible outputs of `get_empty_channel_patches` on the BioSR data (which does have correlated channels but this is just for demo purposes).

The gist also demonstrates the lateral context patch construction introduced in #612.

The patch filter thresholds where chosen empirically.

Example 3 is how the empty patch replacement worked in the original dataset.

https://gist.github.com/melisande-c/cdacdba731706c8ef89105f386891e0f

<img width="900" height="800" alt="MicroSplit_patch_example1" src="https://github.com/user-attachments/assets/a6dfb7b2-d970-4ee5-a0be-d8a6c094c910" />
<img width="900" height="800" alt="MicroSplit_patch_example2" src="https://github.com/user-attachments/assets/5d7d02ee-c831-43e7-8754-8c2cdd1cd16b" />
<img width="900" height="800" alt="MicroSplit_patch_example3" src="https://github.com/user-attachments/assets/0addc83f-ecaf-41ef-9bdc-ade9e1ffa25d" />

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)