### PR TITLE
Refac: Rename `test` to `pred` in NG Dataset Config

### DIFF
--- a/src/careamics/config/configuration_factories.py
+++ b/src/careamics/config/configuration_factories.py
@@ -362,7 +362,7 @@ def _create_ng_data_configuration(
     patch_overlaps: Sequence[int] | None = None,
     train_dataloader_params: dict[str, Any] | None = None,
     val_dataloader_params: dict[str, Any] | None = None,
-    test_dataloader_params: dict[str, Any] | None = None,
+    pred_dataloader_params: dict[str, Any] | None = None,
     seed: int | None = None,
 ) -> NGDataConfig:
     """
@@ -389,7 +389,7 @@ def _create_ng_data_configuration(
         Parameters for the training dataloader, see PyTorch notes, by default None.
     val_dataloader_params : dict
         Parameters for the validation dataloader, see PyTorch notes, by default None.
-    test_dataloader_params : dict
+    pred_dataloader_params : dict
         Parameters for the test dataloader, see PyTorch notes, by default None.
     seed : int, default=None
         Random seed for reproducibility. If `None`, no seed is set.
@@ -419,8 +419,8 @@ def _create_ng_data_configuration(
     if val_dataloader_params is not None:
         data["val_dataloader_params"] = val_dataloader_params
 
-    if test_dataloader_params is not None:
-        data["test_dataloader_params"] = test_dataloader_params
+    if pred_dataloader_params is not None:
+        data["pred_dataloader_params"] = pred_dataloader_params
 
     # add training patching
     data["patching"] = {

--- a/src/careamics/config/data/ng_data_model.py
+++ b/src/careamics/config/data/ng_data_model.py
@@ -180,8 +180,8 @@ class NGDataConfig(BaseModel):
     val_dataloader_params: dict[str, Any] = Field(default={})
     """Dictionary of PyTorch validation dataloader parameters."""
 
-    test_dataloader_params: dict[str, Any] = Field(default={})
-    """Dictionary of PyTorch test dataloader parameters."""
+    pred_dataloader_params: dict[str, Any] = Field(default={})
+    """Dictionary of PyTorch prediction dataloader parameters."""
 
     seed: int | None = Field(default_factory=generate_random_seed, gt=0)
     """Random seed for reproducibility. If not specified, a random seed is generated."""

--- a/src/careamics/lightning/dataset_ng/data_module.py
+++ b/src/careamics/lightning/dataset_ng/data_module.py
@@ -527,5 +527,5 @@ class CareamicsDataModule(L.LightningDataModule):
             self.predict_dataset,
             batch_size=self.batch_size,
             collate_fn=default_collate,
-            **self.config.test_dataloader_params,
+            **self.config.pred_dataloader_params,
         )


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

Simple parameter change to stick to our naming conventions elsewhere in the code (`pred` and `prediction`, rather than `tests`).