### PR TITLE
Chore: update tests to prevent writing files outside of tmp folders

### DIFF
--- a/tests/lightning/test_LVAE_lightning_module.py
+++ b/tests/lightning/test_LVAE_lightning_module.py
@@ -554,7 +554,13 @@ def test_training_loop_hdn(
         multiscale_count=1,
         target_ch=1,
     )
-    trainer = Trainer(accelerator="cpu", max_epochs=2, logger=False, callbacks=[])
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        accelerator="cpu",
+        max_epochs=2,
+        logger=False,
+        callbacks=[],
+    )
 
     try:
         trainer.fit(
@@ -624,7 +630,13 @@ def test_training_loop_microsplit(
         data_std = torch.zeros(1, target_ch, 1, 1)
         lightning_model.set_data_stats(data_mean, data_std)
 
-    trainer = Trainer(accelerator="cpu", max_epochs=2, logger=False, callbacks=[])
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        accelerator="cpu",
+        max_epochs=2,
+        logger=False,
+        callbacks=[],
+    )
 
     try:
         trainer.fit(

--- a/tests/lightning/test_lightning_module.py
+++ b/tests/lightning/test_lightning_module.py
@@ -312,7 +312,9 @@ def test_fcn_module_unet_depth_3_channels_3D(n_channels):
 
 @pytest.mark.mps_gh_fail
 @pytest.mark.parametrize("tiled", [False, True])
-def test_prediction_callback_during_training(minimum_n2v_configuration, tiled):
+def test_prediction_callback_during_training(
+    tmp_path, minimum_n2v_configuration, tiled
+):
     import numpy as np
     from pytorch_lightning import Callback, Trainer
 
@@ -370,7 +372,9 @@ def test_prediction_callback_during_training(minimum_n2v_configuration, tiled):
     predict_after_val_callback = CustomPredictAfterValidationCallback(
         pred_datamodule=pred_datamodule
     )
-    engine = CAREamist(config, callbacks=[predict_after_val_callback])
+    engine = CAREamist(
+        config, work_dir=tmp_path, callbacks=[predict_after_val_callback]
+    )
     engine.train(train_source=array)
 
     assert not np.allclose(array, predict_after_val_callback.data)


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

Following https://github.com/CAREamics/careamics/issues/601, I identified a few tests that create a `checkpoint` and `csv_logger` folders in the working directory rather than in a `tmp_path` during testing. I updated the tests to prevent that.

Closes https://github.com/CAREamics/careamics/issues/601