### PR TITLE
Chore(config): Add imports to `__init__`

### DIFF
--- a/src/careamics/config/__init__.py
+++ b/src/careamics/config/__init__.py
@@ -8,14 +8,17 @@ __all__ = [
     "GaussianMixtureNMConfig",
     "HDNAlgorithm",
     "InferenceConfig",
+    "LVAEConfig",
     "LVAELossConfig",
     "MicroSplitAlgorithm",
     "MultiChannelNMConfig",
     "N2NAlgorithm",
     "N2VAlgorithm",
+    "NGDataConfig",
     "PN2VAlgorithm",
     "TrainingConfig",
     "UNetBasedAlgorithm",
+    "UNetConfig",
     "VAEBasedAlgorithm",
     "algorithm_factory",
     "create_care_configuration",
@@ -38,6 +41,7 @@ from .algorithms import (
     UNetBasedAlgorithm,
     VAEBasedAlgorithm,
 )
+from .architectures import LVAEConfig, UNetConfig
 from .configuration import Configuration
 from .configuration_factories import (
     algorithm_factory,
@@ -48,12 +52,12 @@ from .configuration_factories import (
     create_n2v_configuration,
     create_pn2v_configuration,
 )
-from .data import DataConfig
+from .data import DataConfig, NGDataConfig
 from .data.inference_config import InferenceConfig
-from .lightning.callbacks.callback_config import CheckpointConfig
+from .lightning.callbacks import CheckpointConfig
 from .lightning.training_config import TrainingConfig
 from .losses.loss_config import LVAELossConfig
-from .noise_model.noise_model_config import (
+from .noise_model import (
     GaussianMixtureNMConfig,
     MultiChannelNMConfig,
 )

--- a/src/careamics/config/data/__init__.py
+++ b/src/careamics/config/data/__init__.py
@@ -2,8 +2,26 @@
 
 __all__ = [
     "DataConfig",
+    "MaskFilterConfig",
+    "MaxFilterConfig",
+    "MeanSTDFilterConfig",
     "NGDataConfig",
+    "RandomPatchingConfig",
+    "ShannonFilterConfig",
+    "TiledPatchingConfig",
+    "WholePatchingConfig",
 ]
 
 from .data_config import DataConfig
 from .ng_data_config import NGDataConfig
+from .patch_filter import (
+    MaskFilterConfig,
+    MaxFilterConfig,
+    MeanSTDFilterConfig,
+    ShannonFilterConfig,
+)
+from .patching_strategies import (
+    RandomPatchingConfig,
+    TiledPatchingConfig,
+    WholePatchingConfig,
+)

--- a/src/careamics/config/lightning/__init__.py
+++ b/src/careamics/config/lightning/__init__.py
@@ -1,1 +1,15 @@
 """Training and lightning related Pydantic configurations."""
+
+__all__ = [
+    "CheckpointConfig",
+    "EarlyStoppingConfig",
+    "LrSchedulerConfig",
+    "OptimizerConfig",
+    "TrainerConfig",
+    "TrainingConfig",
+]
+
+
+from .callbacks import CheckpointConfig, EarlyStoppingConfig
+from .optimizer_configs import LrSchedulerConfig, OptimizerConfig
+from .training_config import TrainingConfig

--- a/src/careamics/config/lightning/callbacks/__init__.py
+++ b/src/careamics/config/lightning/callbacks/__init__.py
@@ -1,1 +1,8 @@
 """Callbacks Pydantic configurations."""
+
+__all__ = [
+    "CheckpointConfig",
+    "EarlyStoppingConfig",
+]
+
+from .callback_config import CheckpointConfig, EarlyStoppingConfig

--- a/src/careamics/config/losses/__init__.py
+++ b/src/careamics/config/losses/__init__.py
@@ -1,1 +1,8 @@
 """Losses Pydantic configurations."""
+
+__all__ = [
+    "KLLossConfig",
+    "LVAELossConfig",
+]
+
+from .loss_config import KLLossConfig, LVAELossConfig

--- a/src/careamics/config/noise_model/__init__.py
+++ b/src/careamics/config/noise_model/__init__.py
@@ -3,9 +3,10 @@
 __all__ = [
     "GaussianLikelihoodConfig",
     "GaussianMixtureNMConfig",
+    "MultiChannelNMConfig",
     "NMLikelihoodConfig",
 ]
 
 
 from .likelihood_config import GaussianLikelihoodConfig, NMLikelihoodConfig
-from .noise_model_config import GaussianMixtureNMConfig
+from .noise_model_config import GaussianMixtureNMConfig, MultiChannelNMConfig

--- a/src/careamics/config/utils/__init__.py
+++ b/src/careamics/config/utils/__init__.py
@@ -1,1 +1,8 @@
 """Configuration utilities."""
+
+__all__ = [
+    "load_configuration",
+    "save_configuration",
+]
+
+from .configuration_io import load_configuration, save_configuration


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

The config models can be deeply buried, this PR brings about more reasonable import levels in the config modules.

I have not updated the imports throughout the code, this can be done progressively. This was motivated by fixing imports in the example CI.