### PR TITLE
Fix: Struct N2V 3D

### DIFF
--- a/src/careamics/transforms/pixel_manipulation_torch.py
+++ b/src/careamics/transforms/pixel_manipulation_torch.py
@@ -64,12 +64,13 @@ def _apply_struct_mask_torch(
     )
     mix = mix[valid_indices]
 
-    mins = patch.min(-1)[0].min(-1)[0]
-    maxs = patch.max(-1)[0].max(-1)[0]
+    # flatten in spatial dims to find min and max for each patch in the batch
+    batch_mins = patch.view(patch.shape[0], -1).min(dim=-1).values
+    batch_maxs = patch.view(patch.shape[0], -1).max(dim=-1).values
     for i in range(patch.shape[0]):
         batch_coords = mix[mix[:, 0] == i]
-        min_ = mins[i].item()
-        max_ = maxs[i].item()
+        min_ = batch_mins[i].item()
+        max_ = batch_maxs[i].item()
         random_values = torch.empty(len(batch_coords), device=patch.device).uniform_(
             min_, max_, generator=rng
         )


### PR DESCRIPTION
## Description

> [!NOTE]  
> **tldr**: This PR fixes struct N2V masking for 3D data.


### Background - why do we need this PR?

The case of 3D data was not taken into consideration when calculating the min and max of the patch, in the `_apply_struct_mask_torch` function. The min and max is used to create the uniform distribution for pixel masking.

Additionally the test named `test_apply_struct_mask_3D_torch` was not testing 3D data but instead 2D data.

### Implementation - how did you implement the changes?

Fixed the problem by taking the min and max of a view of the patch, with the batch dimension remaining as the first dimension and then all the spatial dimensions are flattened together. This is because in torch you cannot take the min and max over multiple dimensions.

To cover the 3D case in the tests, I removed the old `test_apply_struct_mask_3D_torch` and instead added the 3D cases to `test_apply_struct_mask_torch`. The test had to be modified slightly so that it would work with both 2D and 3D data.

## Changes Made

### Modified features or files

- `_apply_struct_mask_torch` 
- `test_apply_struct_mask_torch`

### Removed features or files

- `test_apply_struct_mask_3D_torch`

## How has this been tested?

Added 3D cases to `test_apply_struct_mask_3D_torch`


## Related Issues


- Resolves #676

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)