### PR TITLE
Fix: add zero padding to 3rd dimension in CZI

### DIFF
--- a/src/careamics/dataset_ng/image_stack/czi_image_stack.py
+++ b/src/careamics/dataset_ng/image_stack/czi_image_stack.py
@@ -222,7 +222,7 @@ class CziImageStack:
 
         # Create output array of shape (C, Z, Y, X)
         n_channels = self.data_shape[1] if channels is None else len(channels)
-        patch = np.empty(
+        patch = np.zeros(
             (n_channels, third_dim_size, *patch_size[-2:]), dtype=np.float32
         )
 
@@ -251,12 +251,17 @@ class CziImageStack:
                 if third_dim is not None:
                     plane[third_dim] = third_dim_offset + third_dim_index
 
+                    # check if in bounds
+                    if 0 > plane[third_dim] or plane[third_dim] >= self.data_shape[-3]:
+                        continue
+
                 # read plane
                 extracted_roi = self._czi.read(roi=roi, plane=plane, scene=self.scene)
                 if extracted_roi.ndim == 3:
                     if extracted_roi.shape[-1] > 1:
                         raise ValueError(
-                            "CZI files with RGB channels are currently not supported."
+                            "CZI files with RGB channels are currently not "
+                            "supported."
                         )
 
                     # remove channel dimension


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

> [!NOTE]  
> **tldr**: CZI format does not support padding the `Z` dimension (which may be "T" or "Z").

### Background - why do we need this PR?

<!-- What problem are you solving? Describe in a few sentences the state before
this PR. Use code examples if useful. -->

In the case where images may be smaller in `Z` than the patch size or tile size, the current default is to zero-pad (in the future we may reflect-pad), except in the CZI image stack.

### Overview - what changed?

<!-- What aspects and mechanisms of the code base changed? Describe only the general 
idea and overarching features. -->

Adding zero-padding to the third dimension in CZI image stack.

### Implementation - how did you implement the changes?

<!-- How did you solve the issue technically? Explain why you chose this approach and 
provide code examples if applicable (e.g. change in the API for users). -->

In `CziImageStack`, `np.empty` has been replaced by `np.zeros` and request out of the `third_dim` bounds are skipped in the for loop, leading to zero padding.

## How has this been tested?

<!-- Describe the tests that you ran to verify your changes. This can be a short 
description of the tests added to the PR or code snippet to reproduce the change
in behaviour. -->

Added a test and tried the following:

```python
from pathlib import Path
from numpy.typing import NDArray
import numpy as np

from careamics.lightning.dataset_ng.data_module import CareamicsDataModule
from careamics.config.ng_factories import create_ng_data_configuration

from pylibCZIrw import czi as pyczi

def create_test_czi(file_path: Path, data: NDArray | list[NDArray]):
    if not isinstance(data, list):
        data = [data]

    if not file_path.exists():
        with pyczi.create_czi(str(file_path)) as czi:
            xoffs = 0
            for scene_idx, scene_data in enumerate(data):
                for t in range(scene_data.shape[0]):
                    for c in range(scene_data.shape[1]):
                        for z in range(scene_data.shape[2]):
                            czi.write(
                                scene_data[t, c, z],
                                plane={"C": c, "T": t, "Z": z},
                                location=(xoffs, 0),
                                scene=scene_idx,
                            )
                xoffs += scene_data.shape[-1] + 20

# config
data_cfg = create_ng_data_configuration(
    data_type="czi",
    axes="SCZYX",
    patch_size=(16, 32, 32),
    batch_size=2,
)
data_cfg.normalization.set_input_stats(means=[0.0, 0.0], stds=[1.0, 1.0]) # no normalization

pred_cfg = data_cfg.convert_mode(
    "predicting", 
    new_patch_size=(16, 64, 64),
    overlap_size=(4, 8, 8), 
    new_batch_size=1
)

# create data
root = Path("czi_test")
root.mkdir(exist_ok=True)

data_large = np.random.randn(5, 2, 32, 64, 64).astype(np.float32)
data_large_2 = np.random.randn(2, 2, 32, 128, 128).astype(np.float32)
data_small = np.random.randn(3, 2, 14, 64, 64).astype(np.float32)
data = [data_large, data_small, data_large_2]

paths = []
for i, d in enumerate(data):
    file_path = root / f"test_czi_{i}.czi"
    paths.append(file_path)
    create_test_czi(file_path=file_path, data=d)

data_module = CareamicsDataModule(
    data_config=pred_cfg,
    pred_data=paths
)

data_module.setup("predict")
pred_data = data_module.predict_dataset

for i in range(len(pred_data)):
    sample = pred_data[i][0]
    print(f"Sample {i}: shape {sample.data.shape}, source {sample.source}, sample idx {sample.region_spec['sample_idx']}")
    print(f"--- coords {sample.region_spec['coords']}")

    if "czi_test/test_czi_1.czi" in sample.source: # data_small
        empty_slice = 0
        for j in range(sample.data.shape[1]):  # Z dimension
            if np.all(sample.data[:, j, :, :] == 0):
                empty_slice += 1
        assert empty_slice == 2, f"Expected 2 empty slices, got {empty_slice}"
```

## Related Issues

<!-- Link to any related issues or discussions. Use keywords like "Fixes", "Resolves",
or "Closes" to link to issues automatically. -->

- Resolves https://github.com/CAREamics/careamics/issues/687

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)