### PR TITLE
Bug: Check whether model_desc.root is a dir or a zip before extraction

### DIFF
--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Union
 
 import numpy as np
-from pydantic import DirectoryPath
 from bioimageio.spec._internal.io import extract
 from bioimageio.spec.model.v0_5 import (
     ArchitectureFromLibraryDescr,
@@ -27,6 +26,7 @@ from bioimageio.spec.model.v0_5 import (
     Version,
     WeightsDescr,
 )
+from pydantic import DirectoryPath
 
 from careamics.config import Configuration, DataConfig
 

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Union
 
 import numpy as np
+from pydantic import DirectoryPath
 from bioimageio.spec._internal.io import extract
 from bioimageio.spec.model.v0_5 import (
     ArchitectureFromLibraryDescr,
@@ -322,8 +323,12 @@ def extract_model_path(model_desc: ModelDescr) -> tuple[Path, Path]:
     if model_desc.weights.pytorch_state_dict is None:
         raise ValueError("No model weights found in model description.")
 
-    # extract the zip model and return the directory
-    model_dir = extract(model_desc.root)
+    # get the model directory
+    if isinstance(model_desc.root, Path) and model_desc.root.is_dir():
+        model_dir: DirectoryPath = model_desc.root
+    else:
+        # extract the zip model
+        model_dir = extract(model_desc.root)
 
     weights_path = model_dir.joinpath(model_desc.weights.pytorch_state_dict.source.path)
 


### PR DESCRIPTION
On bioimageio CI, the models are loaded from a folder and not a `zip` file. So we need to check whether the `model_desc.root` is a *directory* or a *zip file* before trying to extract it [here](https://github.com/CAREamics/careamics/blob/d5062351b6c222177662e9329fbdce365509c5ef/src/careamics/model_io/bioimage/model_description.py#L326C5-L326C41):
```python
# extract the zip model and return the directory
model_dir = extract(model_desc.root)
```

## Changes Made
Checking the `model_desc.root` if it is a directory or a zip file:
```python
# get the model directory
if isinstance(model_desc.root, Path) and model_desc.root.is_dir():
    model_dir: DirectoryPath = model_desc.root
else:
    # extract the zip model
    model_dir = extract(model_desc.root)
```

### Modified features or files
- `model_description.py`

## How has this been tested?
I tested it by running our bmz tests as well as running the bioimageio collection script: [scripts/check_compatibility_careamics.py](https://github.com/bioimage-io/collection/blob/main/scripts/check_compatibility_careamics.py)


## Related Issues

<!-- Link to any related issues or discussions. Use keywords like "Fixes", "Resolves",
or "Closes" to link to issues automatically. -->

- Resolves #712 