### PR TITLE
Feat: add default value for `TrainingConfig` in `NGConfiguration`

### DIFF
--- a/src/careamics/config/ng_configs/ng_configuration.py
+++ b/src/careamics/config/ng_configs/ng_configuration.py
@@ -95,7 +95,7 @@ class NGConfiguration(BaseModel):
     """Data configuration, holding all parameters required to configure the training
     data loader."""
 
-    training_config: TrainingConfig
+    training_config: TrainingConfig = TrainingConfig()
     """Training configuration, holding all parameters required to configure the
     training process."""
 


### PR DESCRIPTION
## Description

Simply add a default value for the `TrainingConfig` since it is not often modified and can be a problem when loading checkpoints. All `TrainingConfig` already had a default value, and therefore `TrainingConfig()` is directly validated.


Closes https://github.com/CAREamics/careamics/issues/722