### PR TITLE
Feat: split convenience function into standard and advanced.

### DIFF
--- a/src/careamics/config/ng_factories/__init__.py
+++ b/src/careamics/config/ng_factories/__init__.py
@@ -1,9 +1,15 @@
 """Convenience functions to create coherent configurations for CAREamics."""
 
 __all__ = [
-    "create_n2v_configuration",
+    "create_advanced_n2v_config",
+    "create_n2v_config",
     "create_ng_data_configuration",
+    "create_structn2v_config",
 ]
 
 from .data_factory import create_ng_data_configuration
-from .n2v_factory import create_n2v_configuration
+from .n2v_factory import (
+    create_advanced_n2v_config,
+    create_n2v_config,
+    create_structn2v_config,
+)

--- a/src/careamics/config/ng_factories/n2v_factory.py
+++ b/src/careamics/config/ng_factories/n2v_factory.py
@@ -32,7 +32,6 @@ def create_n2v_config(
     augmentations: Sequence[Literal["x_flip", "y_flip", "rotate_90"]] | None = None,
     use_n2v2: bool = False,
     n_channels: int | None = None,
-    n_workers: int = 0,
 ) -> N2VConfiguration:
     """
     Create a configuration for training N2V.
@@ -61,8 +60,6 @@ def create_n2v_config(
         Whether to use N2V2.
     n_channels : int or None, default=None
         Number of channels (in and out).
-    n_workers : int, default=0
-        Number of workers for data loading.
 
     Returns
     -------
@@ -80,7 +77,6 @@ def create_n2v_config(
         augmentations=augmentations,
         use_n2v2=use_n2v2,
         n_channels=n_channels,
-        n_workers=n_workers,
     )
 
 
@@ -101,7 +97,6 @@ def create_structn2v_config(
     augmentations: Sequence[Literal["x_flip", "y_flip"]] | None = None,
     use_n2v2: bool = False,
     n_channels: int | None = None,
-    n_workers: int = 0,
 ) -> N2VConfiguration:
     """
     Create a configuration for training structN2V.
@@ -134,8 +129,6 @@ def create_structn2v_config(
         Whether to use N2V2.
     n_channels : int or None, default=None
         Number of channels (in and out).
-    n_workers : int, default=0
-        Number of workers for data loading.
 
     Returns
     -------
@@ -156,7 +149,6 @@ def create_structn2v_config(
         augmentations=augmentations,
         use_n2v2=use_n2v2,
         n_channels=n_channels,
-        n_workers=n_workers,
         struct_n2v_axis=struct_n2v_axis,
         struct_n2v_span=struct_n2v_span,
     )
@@ -178,7 +170,6 @@ def create_advanced_n2v_config(
     in_memory: bool | None = None,
     channels: Sequence[int] | None = None,
     independent_channels: bool = True,
-    n_workers: int = 0,
     # - N2V specific
     use_n2v2: bool = False,
     roi_size: int = 11,
@@ -187,6 +178,7 @@ def create_advanced_n2v_config(
     struct_n2v_axis: Literal["horizontal", "vertical", "none"] = "none",
     struct_n2v_span: int = 5,
     # - Lightning parameters
+    n_workers: int = 0,
     trainer_params: dict | None = None,
     model_params: dict | None = None,
     optimizer: Literal["Adam", "Adamax", "SGD"] = "Adam",
@@ -276,8 +268,6 @@ def create_advanced_n2v_config(
         List of channels to use. If `None`, all channels are used.
     independent_channels : bool, default=True
         Whether to train all channels independently.
-    n_workers : int, default=0
-        Number of workers for data loading.
     use_n2v2 : bool, default=False
         Whether to use N2V2.
     roi_size : int, default=11
@@ -288,6 +278,8 @@ def create_advanced_n2v_config(
         Axis along which to apply structN2V mask.
     struct_n2v_span : int, default=5
         Span of the structN2V mask.
+    n_workers : int, default=0
+        Number of workers for data loading.
     trainer_params : dict | None, default=None
         Parameters for the trainer, see the relevant documentation.
     model_params : dict | None, default=None

--- a/src/careamics/config/ng_factories/n2v_factory.py
+++ b/src/careamics/config/ng_factories/n2v_factory.py
@@ -19,30 +19,7 @@ from .data_factory import create_ng_data_configuration, list_spatial_augmentatio
 from .training_factory import create_training_configuration, update_trainer_params
 
 
-# TODO back-compatibility, to remove later
-def create_n2v_configuration(*args, **kwargs) -> N2VConfiguration:
-    """
-    Create a configuration for training Noise2Void.
-
-    See `create_advanced_n2v_config` for more details and parameters.
-
-    Parameters
-    ----------
-    *args : positional arguments
-        Positional arguments for `create_advanced_n2v_config`.
-    **kwargs : keyword arguments
-        Keyword arguments for `create_advanced_n2v_config`.
-
-    Returns
-    -------
-    N2VConfiguration
-        Configuration for training N2V.
-    """
-    return create_advanced_n2v_config(*args, **kwargs)
-
-
-# proposal for API, should be renamed to create_n2v_configuration later
-def create_standard_n2v_configuration(
+def create_n2v_config(
     # mandatory parameters
     experiment_name: str,
     data_type: Literal["array", "tiff", "zarr", "czi", "custom"],

--- a/src/careamics/config/ng_factories/n2v_factory.py
+++ b/src/careamics/config/ng_factories/n2v_factory.py
@@ -42,9 +42,6 @@ def create_n2v_config(
     and should be the same throughout all images. The accepted axes are STCZYX. If "C"
     is in `axes`, then you need to set `n_channels` to the number of channels.
 
-    `patch_size` is only along the spatial dimensions and should be of length 3 if "Z"
-    is present in `axes`, otherwise of length 2.
-
     By default, CAREamics will go through the entire training data once per epoch. For
     large datasets, this can lead to very long epochs. To limit the number of batches
     per epoch, set the `num_steps` parameter to the desired number of batches.

--- a/tests/config/ng_factories/test_n2v_factory.py
+++ b/tests/config/ng_factories/test_n2v_factory.py
@@ -152,6 +152,29 @@ class TestN2VConfiguration:
         assert len(config.data_config.patching.patch_size) == 3
         assert config.algorithm_config.model.conv_dims == 3
 
+    def test_epochs_steps(self):
+        """Test step and epoch naming in trainer config."""
+        num_epochs = 10
+        num_steps = 20
+
+        config = create_n2v_config(
+            experiment_name="test",
+            data_type="tiff",
+            axes="YX",
+            patch_size=[64, 64],
+            batch_size=8,
+            num_epochs=num_epochs,
+            num_steps=num_steps,
+        )
+
+        assert (
+            config.training_config.lightning_trainer_config["max_epochs"] == num_epochs
+        )
+        assert (
+            config.training_config.lightning_trainer_config["limit_train_batches"]
+            == num_steps
+        )
+
     @pytest.mark.parametrize(
         "axes, n_channels, channels, error",
         [

--- a/tests/config/ng_factories/test_n2v_factory.py
+++ b/tests/config/ng_factories/test_n2v_factory.py
@@ -1,7 +1,11 @@
 import pytest
 
 from careamics.config.ng_configs import N2VConfiguration
-from careamics.config.ng_factories import create_n2v_configuration
+from careamics.config.ng_factories import (
+    create_advanced_n2v_config,
+    create_n2v_config,
+    create_structn2v_config,
+)
 from careamics.config.support import (
     SupportedPixelManipulation,
     SupportedStructAxis,
@@ -9,21 +13,20 @@ from careamics.config.support import (
 
 
 class TestN2VConfiguration:
-    def test_create_configuration(self):
+    def test_create_standard_config(self):
         """Test that N2V configuration can be created."""
-        config = create_n2v_configuration(
+        config = create_n2v_config(
             experiment_name="test",
             data_type="tiff",
             axes="YX",
             patch_size=[64, 64],
             batch_size=8,
-            train_dataloader_params={"num_workers": 2},
         )
         assert isinstance(config, N2VConfiguration)
 
     def test_no_aug(self):
         """Test the default n2v transforms."""
-        config = create_n2v_configuration(
+        config = create_n2v_config(
             experiment_name="test",
             data_type="tiff",
             axes="YX",
@@ -33,34 +36,23 @@ class TestN2VConfiguration:
         )
         assert config.data_config.transforms == []
 
-    def test_n2v2_structn2v(self):
-        """Test that N2V2 and structn2v params are passed correctly."""
-        use_n2v2 = True
-        roi_size = 15
-        masked_pixel_percentage = 0.5
+    def test_structn2v(self):
+        """Test structn2v params are passed correctly."""
         struct_mask_axis = SupportedStructAxis.HORIZONTAL.value
         struct_n2v_span = 15
 
-        config = create_n2v_configuration(
+        config = create_structn2v_config(
             experiment_name="test",
             data_type="tiff",
             axes="YX",
             patch_size=[64, 64],
             batch_size=8,
-            use_n2v2=use_n2v2,  # median strategy
-            roi_size=roi_size,
-            masked_pixel_percentage=masked_pixel_percentage,
             struct_n2v_axis=struct_mask_axis,
             struct_n2v_span=struct_n2v_span,
         )
         assert (
             config.algorithm_config.n2v_config.strategy
             == SupportedPixelManipulation.MEDIAN.value
-        )
-        assert config.algorithm_config.n2v_config.roi_size == roi_size
-        assert (
-            config.algorithm_config.n2v_config.masked_pixel_percentage
-            == masked_pixel_percentage
         )
         assert config.algorithm_config.n2v_config.struct_mask_axis == struct_mask_axis
         assert config.algorithm_config.n2v_config.struct_mask_span == struct_n2v_span
@@ -69,7 +61,7 @@ class TestN2VConfiguration:
         """Test that num_epochs parameter is correctly passed to trainer config."""
         num_epochs = 50
 
-        config = create_n2v_configuration(
+        config = create_n2v_config(
             experiment_name="test",
             data_type="tiff",
             axes="YX",
@@ -82,7 +74,7 @@ class TestN2VConfiguration:
         )
 
         # Test with num_epochs=None (should not be in config)
-        config = create_n2v_configuration(
+        config = create_n2v_config(
             experiment_name="test",
             data_type="tiff",
             axes="YX",
@@ -96,7 +88,7 @@ class TestN2VConfiguration:
         """Test that num_steps parameter is correctly passed to trainer config."""
         num_steps = 1000
 
-        config = create_n2v_configuration(
+        config = create_n2v_config(
             experiment_name="test",
             data_type="tiff",
             axes="YX",
@@ -110,7 +102,7 @@ class TestN2VConfiguration:
         )
 
         # Test without num_steps (should not be in config)
-        config = create_n2v_configuration(
+        config = create_n2v_config(
             experiment_name="test",
             data_type="tiff",
             axes="YX",
@@ -126,7 +118,7 @@ class TestN2VConfiguration:
         num_epochs = 25
         num_steps = 500
 
-        config = create_n2v_configuration(
+        config = create_n2v_config(
             experiment_name="test",
             data_type="tiff",
             axes="YX",
@@ -142,217 +134,11 @@ class TestN2VConfiguration:
             config.training_config.lightning_trainer_config["limit_train_batches"]
             == num_steps
         )
-
-    def test_trainer_params(self):
-        """Test that various trainer_params are correctly passed to trainer config."""
-        trainer_params = {
-            "accelerator": "gpu",
-            "devices": 2,
-            "precision": 16,
-            "gradient_clip_val": 0.5,
-            "accumulate_grad_batches": 4,
-            "check_val_every_n_epoch": 5,
-            "log_every_n_steps": 10,
-            "enable_checkpointing": True,
-            "enable_progress_bar": False,
-            "enable_model_summary": True,
-        }
-
-        config = create_n2v_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            trainer_params=trainer_params,
-        )
-
-        for key, value in trainer_params.items():
-            assert config.training_config.lightning_trainer_config[key] == value
-
-    def test_trainer_params_with_timing(self):
-        """Test trainer_params with timing-related parameters."""
-        trainer_params = {
-            "min_epochs": 5,
-            "min_steps": 100,
-            "max_time": "00:01:00:00",  # 1 hour
-            "val_check_interval": 0.25,
-        }
-
-        config = create_n2v_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            trainer_params=trainer_params,
-        )
-
-        for key, value in trainer_params.items():
-            assert config.training_config.lightning_trainer_config[key] == value
-
-    def test_trainer_params_override(self):
-        """Test that explicit parameters override trainer_params."""
-        num_epochs = 30
-        num_steps = 800
-
-        # trainer_params has conflicting values
-        trainer_params = {
-            "max_epochs": 100,
-            "limit_train_batches": 0.5,
-            "accelerator": "cpu",
-        }
-
-        config = create_n2v_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=num_epochs,
-            num_steps=num_steps,
-            trainer_params=trainer_params,
-        )
-
-        # Explicit parameters should override trainer_params
-        assert (
-            config.training_config.lightning_trainer_config["max_epochs"] == num_epochs
-        )
-        assert (
-            config.training_config.lightning_trainer_config["limit_train_batches"]
-            == num_steps
-        )
-
-        # Non-conflicting trainer_params should be preserved
-        assert config.training_config.lightning_trainer_config["accelerator"] == "cpu"
-
-    def test_trainer_params_profiler(self):
-        """Test trainer_params with profiler settings."""
-        trainer_params = {
-            "profiler": "simple",
-            "detect_anomaly": True,
-            "benchmark": False,
-            "deterministic": True,
-        }
-
-        config = create_n2v_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            trainer_params=trainer_params,
-        )
-
-        for key, value in trainer_params.items():
-            assert config.training_config.lightning_trainer_config[key] == value
-
-    def test_trainer_params_distributed(self):
-        """Test trainer_params with distributed training settings."""
-        trainer_params = {
-            "strategy": "ddp",
-            "num_nodes": 2,
-            "sync_batchnorm": True,
-            "use_distributed_sampler": True,
-        }
-
-        config = create_n2v_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            trainer_params=trainer_params,
-        )
-
-        for key, value in trainer_params.items():
-            assert config.training_config.lightning_trainer_config[key] == value
-
-    def test_all_trainer_combinations(self):
-        """Test comprehensive combination of all trainer parameters."""
-        num_epochs = 15
-        num_steps = 300
-
-        trainer_params = {
-            "accelerator": "auto",
-            "devices": "auto",
-            "precision": "32-true",
-            "gradient_clip_val": 1.0,
-            "gradient_clip_algorithm": "norm",
-            "accumulate_grad_batches": 2,
-            "check_val_every_n_epoch": 2,
-            "val_check_interval": 1.0,
-            "log_every_n_steps": 50,
-            "enable_checkpointing": True,
-            "enable_progress_bar": True,
-            "enable_model_summary": True,
-            "deterministic": False,
-            "benchmark": True,
-            "inference_mode": True,
-            "use_distributed_sampler": True,
-            "detect_anomaly": False,
-            "barebones": False,
-            "reload_dataloaders_every_n_epochs": 0,
-        }
-
-        config = create_n2v_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=num_epochs,
-            num_steps=num_steps,
-            trainer_params=trainer_params,
-        )
-
-        # Check explicit parameters
-        assert (
-            config.training_config.lightning_trainer_config["max_epochs"] == num_epochs
-        )
-        assert (
-            config.training_config.lightning_trainer_config["limit_train_batches"]
-            == num_steps
-        )
-
-        # Check trainer_params
-        for key, value in trainer_params.items():
-            assert config.training_config.lightning_trainer_config[key] == value
-
-    def test_empty_trainer_params(self):
-        """Test that empty trainer_params dict works correctly."""
-        config = create_n2v_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=None,
-            trainer_params={},
-        )
-
-        # Should have empty dict (no trainer params)
-        assert config.training_config.lightning_trainer_config == {}
-
-    def test_trainer_params_none(self):
-        """Test that trainer_params=None works correctly (default behavior)."""
-        config = create_n2v_configuration(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=None,
-            trainer_params=None,
-        )
-
-        # Should have empty dict when trainer_params is None
-        assert config.training_config.lightning_trainer_config == {}
 
     # TODO arguably this should be tested at the level of the data config only
     def test_czi_with_T_axes(self):
         """Test that SCTYX is accepted by N2V configuration for CZI data."""
-        config = create_n2v_configuration(
+        config = create_n2v_config(
             experiment_name="test",
             data_type="czi",
             axes="SCTYX",
@@ -387,7 +173,7 @@ class TestN2VConfiguration:
         """Test the various settings with channel parameters"""
         if error:
             with pytest.raises(ValueError):
-                _ = create_n2v_configuration(
+                _ = create_advanced_n2v_config(
                     experiment_name="test",
                     data_type="tiff",
                     axes=axes,
@@ -397,7 +183,7 @@ class TestN2VConfiguration:
                     channels=channels,
                 )
         else:
-            config = create_n2v_configuration(
+            config = create_advanced_n2v_config(
                 experiment_name="test",
                 data_type="tiff",
                 axes=axes,

--- a/tests/config/ng_factories/test_n2v_factory.py
+++ b/tests/config/ng_factories/test_n2v_factory.py
@@ -36,8 +36,9 @@ class TestN2VConfiguration:
         )
         assert config.data_config.transforms == []
 
-    def test_structn2v(self):
-        """Test structn2v params are passed correctly."""
+    def test_n2v2_structn2v(self):
+        """Test n2v2 and structn2v params are passed correctly."""
+        n2v2 = True
         struct_mask_axis = SupportedStructAxis.HORIZONTAL.value
         struct_n2v_span = 15
 
@@ -49,6 +50,7 @@ class TestN2VConfiguration:
             batch_size=8,
             struct_n2v_axis=struct_mask_axis,
             struct_n2v_span=struct_n2v_span,
+            use_n2v2=n2v2,
         )
         assert (
             config.algorithm_config.n2v_config.strategy

--- a/uv.lock
+++ b/uv.lock
@@ -361,6 +361,7 @@ source = { editable = "." }
 dependencies = [
     { name = "bioimageio-core" },
     { name = "matplotlib" },
+    { name = "microssim" },
     { name = "numpy" },
     { name = "pillow" },
     { name = "psutil" },
@@ -411,21 +412,22 @@ requires-dist = [
     { name = "careamics-portfolio", marker = "extra == 'examples'" },
     { name = "jupyter", marker = "extra == 'examples'" },
     { name = "matplotlib", specifier = "<=3.10.8" },
+    { name = "microssim" },
     { name = "numpy", specifier = ">=1.21" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
     { name = "pillow", specifier = "<=12.1.0" },
     { name = "protobuf", marker = "extra == 'tensorboard'", specifier = "==5.29.1" },
-    { name = "psutil", specifier = "<=7.2.1" },
+    { name = "psutil", specifier = "<=7.2.2" },
     { name = "pydantic", specifier = ">=2.11,<=2.12.5" },
     { name = "pylibczirw", marker = "extra == 'czi'", specifier = ">=4.1.2,<6.0.0" },
-    { name = "pytorch-lightning", specifier = ">=2.2,<=2.6.0" },
+    { name = "pytorch-lightning", specifier = ">=2.2,<=2.6.1" },
     { name = "pyyaml", specifier = "!=6.0.0,<=6.0.3" },
     { name = "scikit-image", specifier = "<=0.26.0" },
     { name = "tensorboard", marker = "extra == 'tensorboard'" },
-    { name = "tifffile", specifier = "<=2026.1.14" },
-    { name = "torch", specifier = ">=2.0,<=2.9.1" },
+    { name = "tifffile", specifier = "<=2026.1.28" },
+    { name = "torch", specifier = ">=2.0,<=2.10.0" },
     { name = "torchmetrics", specifier = ">=0.11.0,<1.5.0" },
-    { name = "torchvision", specifier = "<=0.24.1" },
+    { name = "torchvision", specifier = "<=0.25.0" },
     { name = "typer", specifier = ">=0.12.3,<=0.21.1" },
     { name = "validators", specifier = "<=0.35.0" },
     { name = "wandb", marker = "extra == 'wandb'" },
@@ -436,7 +438,7 @@ provides-extras = ["czi", "examples", "tensorboard", "wandb"]
 [package.metadata.requires-dev]
 dev = [
     { name = "ml-dtypes", specifier = ">=0.5.0" },
-    { name = "onnxscript", specifier = "<=0.5.7" },
+    { name = "onnxscript", specifier = "<=0.6.0" },
     { name = "pre-commit" },
     { name = "pylibczirw", specifier = ">=4.1.2,<6.0.0" },
     { name = "pytest" },
@@ -2151,6 +2153,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "microssim"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scikit-image" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "torchmetrics" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/7c/0f66f7f41af777d30cbe15951dfcf1a8ea34cdf6a2871679026cd8b62c3d/microssim-0.0.3.tar.gz", hash = "sha256:ad7817d76ca851b7b28d265eb7931756d64e308bcb9040b316006857d2d0b240", size = 5433391, upload-time = "2026-01-19T15:50:23.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/23/5022d1ecd3585088349443a57e260743fb2e6997eaf27bb58ce9ba2f95ce/microssim-0.0.3-py3-none-any.whl", hash = "sha256:753acb31a22db252ab79cbd5816c5dc56a31a3e29628f83cb205e0722446fcbe", size = 20964, upload-time = "2026-01-19T15:50:21.547Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

The changes introduced by this PR are the following:

- Reduce the number of parameters in standard convenience function
- Introduce an advanced convenience function with full parameter range
- Add `n_workers` parameter to advanced convenience function
- Changed `augmentations` to `Literal` to not force users to create Pydantic models

Closes https://github.com/CAREamics/careamics/issues/721