### PR TITLE
Feature(Next-Gen Dataset): Integrate new stratified patching into the dataset

### DIFF
--- a/src/careamics/config/data/ng_data_config.py
+++ b/src/careamics/config/data/ng_data_config.py
@@ -38,7 +38,6 @@ from .patching_strategies import (
     StratifiedPatchingConfig,
     TiledPatchingConfig,
     WholePatchingConfig,
-    _PatchedConfig,
 )
 
 # TODO: Validate the specific sizes of tiles and overlaps given UNet constraints
@@ -886,7 +885,7 @@ class NGDataConfig(BaseModel):
                     patch_size=list(new_patch_size), overlaps=list(overlap_size)
                 )
         else:  # validating
-            assert isinstance(self.patching, _PatchedConfig)  # for mypy
+            assert not isinstance(self.patching, WholePatchingConfig)
 
             patching_strategy = FixedRandomPatchingConfig(
                 patch_size=(

--- a/src/careamics/config/data/ng_data_config.py
+++ b/src/careamics/config/data/ng_data_config.py
@@ -34,9 +34,11 @@ from .patch_filter import (
 )
 from .patching_strategies import (
     FixedRandomPatchingConfig,
+    StratifiedPatchingConfig,
     RandomPatchingConfig,
     TiledPatchingConfig,
     WholePatchingConfig,
+    _PatchedConfig,
 )
 
 # TODO: Validate the specific sizes of tiles and overlaps given UNet constraints
@@ -88,6 +90,7 @@ Float = Annotated[float, PlainSerializer(np_float_to_scientific_str, return_type
 PatchingConfig = Union[
     FixedRandomPatchingConfig,
     RandomPatchingConfig,
+    StratifiedPatchingConfig,
     TiledPatchingConfig,
     WholePatchingConfig,
 ]
@@ -158,6 +161,7 @@ class NGDataConfig(BaseModel):
     axes: str
     """Axes of the data, as defined in SupportedAxes."""
 
+    # TODO: update docs for stratified patching
     patching: PatchingConfig = Field(..., discriminator="name")
     """Patching strategy to use. Note that `random` is the only supported strategy for
     training, while `tiled` and `whole` are only used for prediction."""
@@ -386,7 +390,8 @@ class NGDataConfig(BaseModel):
         """
         mode = info.data["mode"]
         if mode == Mode.TRAINING:
-            if patching.name != "random":
+            if patching.name not in ["random", "stratified"]:
+                # TODO: update error message for stratified patching
                 raise ValueError(
                     f"Patching strategy '{patching.name}' is not compatible with "
                     f"mode '{mode.value}'. Use 'random' for training."
@@ -881,7 +886,7 @@ class NGDataConfig(BaseModel):
                     patch_size=list(new_patch_size), overlaps=list(overlap_size)
                 )
         else:  # validating
-            assert isinstance(self.patching, RandomPatchingConfig)  # for mypy
+            assert isinstance(self.patching, _PatchedConfig)  # for mypy
 
             patching_strategy = FixedRandomPatchingConfig(
                 patch_size=(

--- a/src/careamics/config/data/ng_data_config.py
+++ b/src/careamics/config/data/ng_data_config.py
@@ -34,8 +34,8 @@ from .patch_filter import (
 )
 from .patching_strategies import (
     FixedRandomPatchingConfig,
-    StratifiedPatchingConfig,
     RandomPatchingConfig,
+    StratifiedPatchingConfig,
     TiledPatchingConfig,
     WholePatchingConfig,
     _PatchedConfig,

--- a/src/careamics/config/data/patching_strategies/__init__.py
+++ b/src/careamics/config/data/patching_strategies/__init__.py
@@ -4,12 +4,16 @@ __all__ = [
     "FixedRandomPatchingConfig",
     "RandomPatchingConfig",
     "SequentialPatchingConfig",
+    "StratifiedPatchingConfig",
     "TiledPatchingConfig",
     "WholePatchingConfig",
+    "_PatchedConfig",
 ]
 
 
 from .random_patching_config import FixedRandomPatchingConfig, RandomPatchingConfig
 from .sequential_patching_config import SequentialPatchingConfig
+from .stratified_patching_config import StratifiedPatchingConfig
 from .tiled_patching_config import TiledPatchingConfig
 from .whole_patching_config import WholePatchingConfig
+from ._patched_config import _PatchedConfig

--- a/src/careamics/config/data/patching_strategies/__init__.py
+++ b/src/careamics/config/data/patching_strategies/__init__.py
@@ -7,11 +7,9 @@ __all__ = [
     "StratifiedPatchingConfig",
     "TiledPatchingConfig",
     "WholePatchingConfig",
-    "_PatchedConfig",
 ]
 
 
-from ._patched_config import _PatchedConfig
 from .random_patching_config import FixedRandomPatchingConfig, RandomPatchingConfig
 from .sequential_patching_config import SequentialPatchingConfig
 from .stratified_patching_config import StratifiedPatchingConfig

--- a/src/careamics/config/data/patching_strategies/__init__.py
+++ b/src/careamics/config/data/patching_strategies/__init__.py
@@ -11,9 +11,9 @@ __all__ = [
 ]
 
 
+from ._patched_config import _PatchedConfig
 from .random_patching_config import FixedRandomPatchingConfig, RandomPatchingConfig
 from .sequential_patching_config import SequentialPatchingConfig
 from .stratified_patching_config import StratifiedPatchingConfig
 from .tiled_patching_config import TiledPatchingConfig
 from .whole_patching_config import WholePatchingConfig
-from ._patched_config import _PatchedConfig

--- a/src/careamics/config/data/patching_strategies/stratified_patching_config.py
+++ b/src/careamics/config/data/patching_strategies/stratified_patching_config.py
@@ -1,0 +1,25 @@
+"""Stratified patching Pydantic model."""
+
+from typing import Literal
+
+from pydantic import Field
+
+from ._patched_config import _PatchedConfig
+
+class StratifiedPatchingConfig(_PatchedConfig):
+    """Stratified patching Pydantic model.
+
+    Attributes
+    ----------
+    name : "stratified"
+        The name of the patching strategy.
+    patch_size : sequence of int
+        The size of the patch in each spatial dimension, each patch size must be a power
+        of 2 and larger than 8.
+    """
+
+    name: Literal["stratified"] = "stratified"
+    """The name of the patching strategy."""
+
+    seed: int | None = Field(default=None, gt=0)
+    """Random seed for patch sampling, set to None for random seeding."""

--- a/src/careamics/config/data/patching_strategies/stratified_patching_config.py
+++ b/src/careamics/config/data/patching_strategies/stratified_patching_config.py
@@ -6,6 +6,7 @@ from pydantic import Field
 
 from ._patched_config import _PatchedConfig
 
+
 class StratifiedPatchingConfig(_PatchedConfig):
     """Stratified patching Pydantic model.
 

--- a/src/careamics/config/support/supported_patching_strategies.py
+++ b/src/careamics/config/support/supported_patching_strategies.py
@@ -12,6 +12,8 @@ class SupportedPatchingStrategy(str, BaseEnum):
     RANDOM = "random"
     """Random patching strategy, used during training."""
 
+    STRATIFIED = "stratified"
+
     # SEQUENTIAL = "sequential"
     # """Sequential patching strategy, used during training."""
 

--- a/src/careamics/dataset_ng/patching_strategies/patching_strategy_factory.py
+++ b/src/careamics/dataset_ng/patching_strategies/patching_strategy_factory.py
@@ -9,9 +9,10 @@ from careamics.config.support.supported_patching_strategies import (
 
 from .patching_strategy_protocol import PatchingStrategy
 from .random_patching import FixedRandomPatchingStrategy, RandomPatchingStrategy
+from .stratified_patching import StratifiedPatchingStrategy
 from .tiling_strategy import TilingStrategy
 from .whole_sample import WholeSamplePatchingStrategy
-from .stratified_patching import StratifiedPatchingStrategy
+
 
 def create_patching_strategy(
     data_shapes: list[Sequence[int]], patching_config: PatchingConfig

--- a/src/careamics/dataset_ng/patching_strategies/patching_strategy_factory.py
+++ b/src/careamics/dataset_ng/patching_strategies/patching_strategy_factory.py
@@ -11,7 +11,7 @@ from .patching_strategy_protocol import PatchingStrategy
 from .random_patching import FixedRandomPatchingStrategy, RandomPatchingStrategy
 from .tiling_strategy import TilingStrategy
 from .whole_sample import WholeSamplePatchingStrategy
-
+from .stratified_patching import StratifiedPatchingStrategy
 
 def create_patching_strategy(
     data_shapes: list[Sequence[int]], patching_config: PatchingConfig
@@ -34,6 +34,8 @@ def create_patching_strategy(
     match patching_config.name:
         case SupportedPatchingStrategy.RANDOM:
             patch_class = RandomPatchingStrategy
+        case SupportedPatchingStrategy.STRATIFIED:
+            patch_class = StratifiedPatchingStrategy
         case SupportedPatchingStrategy.FIXED_RANDOM:
             patch_class = FixedRandomPatchingStrategy
         case SupportedPatchingStrategy.TILED:


### PR DESCRIPTION
## Description

> [!NOTE]  
> **tldr**: This PR makes it possible to use the new stratified patching strategy in the next-generation dataset.

### Background - why do we need this PR?

A stratified patching strategy was introduced in #710 with 2 applications in mind: validation data splitting, and more efficient masking. This PR allows it to be used by the `CAREamicsDataset`.

### Overview - what changed?

A new `StratifiedPatchingConfig` pydantic class, and some minor changes to the `NGDataConfig`.

### Implementation - how did you implement the changes?

Simply added a new case to the match-case block in the `create_patching_strategy` factory. And in the `NGDataConfig` validation "stratified" is a valid patching strategy choice for validation


## Changes Made

### New features or files

- `StratifiedPatchingConfig`

### Modified features or files

- `NGDataConfig`
- `create_patching_strategy`

## How has this been tested?

Currently working on notebooks to benchmark. Denoising results so far look good but stratified patching seems to be a little slower. I will include results here shortly.

EDIT: performance benchmarking

Could be a bit more rigorous but the set-up is:
- Machine: M3 Mac with 16GB Memory:
- Data: SEM (long scan time as GT for PSNR)
- Training: 10 epochs (5 repeats)

Full train time:
- Stratified: 40.9 ± 0.9 s
- Random: 40.0 ± 1.4 s

PSNR:
- Stratified: 18.9 ± 0.2
- Random: 18.5 ± 0.4

## Related Issues

- Resolves #715 


## Additional Notes and Examples

I haven't changed any of the convenience functions, so currently the easiest way to test with the new configuration is to do something like:

```python
from careamics.config.ng_factories import create_n2v_configuration
from careamics.config.data.patching_strategies import StratifiedPatchingConfig

config = create_n2v_configuration(
    experiment_name="example",
    data_type="array",
    axes="YX",
    patch_size=(64, 64),
    batch_size=32,
    num_epochs=50,
    use_n2v2=False,
    train_dataloader_params={"num_workers": 0}
)
config.data_config.patching = StratifiedPatchingConfig(patch_size=(64, 64))
```

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)