### PR TITLE
Implement stop_training, get_losses, and export_to_bmz for CAREamistV2

### DIFF
--- a/src/careamics/careamist_v2.py
+++ b/src/careamics/careamist_v2.py
@@ -478,4 +478,4 @@ class CAREamistV2:
     def stop_training(self) -> None:
         """Stop the training loop."""
         self.trainer.should_stop = True
-        self.trainer.limit_val_batches = 0 #skip validation
+        self.trainer.limit_val_batches = 0 # skip validation

--- a/src/careamics/careamist_v2.py
+++ b/src/careamics/careamist_v2.py
@@ -30,6 +30,7 @@ from .lightning.dataset_ng.lightning_modules import (
     get_module_cls,
 )
 from .utils import get_logger
+from .utils.lightning_utils import read_csv_logger
 
 logger = get_logger(__name__)
 
@@ -402,6 +403,14 @@ class CAREamistV2:
         model_version: str = "0.1.0",
     ) -> None: ...
 
-    def get_losses(self) -> dict[str, list]: ...
+    def get_losses(self) -> dict[str, list]:
+        """Return data that can be used to plot train and validation loss curves.
+
+        Returns
+        -------
+        dict of str: list
+            Dictionary containing the losses for each epoch.
+        """
+        return read_csv_logger(self.config.experiment_name, self.work_dir / "csv_logs")
 
     def stop_training(self) -> None: ...

--- a/src/careamics/careamist_v2.py
+++ b/src/careamics/careamist_v2.py
@@ -33,7 +33,6 @@ from .lightning.dataset_ng.lightning_modules import (
     get_module_cls,
 )
 from .utils import get_logger
-from .utils.array
 from .utils.lightning_utils import read_csv_logger
 
 logger = get_logger(__name__)
@@ -445,7 +444,7 @@ class CAREamistV2:
             Version of the model.
         """
         output_patch = self.predict(
-            input_array,
+            pred_data=input_array,
             data_type=SupportedData.ARRAY.value,
         )
         output = np.concatenate(output_patch, axis=0)
@@ -479,4 +478,4 @@ class CAREamistV2:
     def stop_training(self) -> None:
         """Stop the training loop."""
         self.trainer.should_stop = True
-        self.trainer.limit_val_batches = 0
+        self.trainer.limit_val_batches = 0 #skip validation


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

> [!NOTE]  
> **tldr**: <!-- Write a one sentence summary. -->
Added `get_losses`, `export_to_bmz` and `stop_training` feature to CAREamistV2

### Implementation - how did you implement the changes?

<!-- How did you solve the issue technically? Explain why you chose this approach and 
provide code examples if applicable (e.g. change in the API for users). -->
Using same implementation as old CAREamist.


## Related Issues

<!-- Link to any related issues or discussions. Use keywords like "Fixes", "Resolves",
or "Closes" to link to issues automatically. -->

- Resolves #728 , #730 , #731 

## Breaking changes

<!-- Describe any breaking changes introduced by this PR. -->

## Additional Notes and Examples


<!-- Provide any additional information that will help reviewers understand the
changes. This can be links to documentations, forum posts, past discussions etc. -->
- export_to_bmz runtime blocked by predict() stub (returns None) - dependent on another open issue being addressed
- Testing blocked by XOR validation bug (also being addressed separately)
---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)