### PR TITLE
Chore: rename flag in prediction writer

### DIFF
--- a/src/careamics/careamist_v2.py
+++ b/src/careamics/careamist_v2.py
@@ -132,7 +132,6 @@ class CAREamistV2:
 
         # init callbacks
         self.prediction_writer = PredictionWriterCallback(self.work_dir)
-        self.prediction_writer.enable_writing(True)
         self.callbacks = self._define_callbacks(
             user_context["callbacks"], self.config, self.work_dir
         )

--- a/src/careamics/careamist_v2.py
+++ b/src/careamics/careamist_v2.py
@@ -131,7 +131,9 @@ class CAREamistV2:
         )
 
         # init callbacks
-        self.prediction_writer = PredictionWriterCallback(self.work_dir)
+        self.prediction_writer = PredictionWriterCallback(
+            self.work_dir, enable_writing=False
+        )
         self.callbacks = self._define_callbacks(
             user_context["callbacks"], self.config, self.work_dir
         )

--- a/src/careamics/careamist_v2.py
+++ b/src/careamics/careamist_v2.py
@@ -132,7 +132,7 @@ class CAREamistV2:
 
         # init callbacks
         self.prediction_writer = PredictionWriterCallback(self.work_dir)
-        self.prediction_writer.disable_writing(True)
+        self.prediction_writer.enable_writing(True)
         self.callbacks = self._define_callbacks(
             user_context["callbacks"], self.config, self.work_dir
         )

--- a/src/careamics/lightning/dataset_ng/callbacks/prediction_writer/prediction_writer_callback.py
+++ b/src/careamics/lightning/dataset_ng/callbacks/prediction_writer/prediction_writer_callback.py
@@ -70,12 +70,8 @@ class PredictionWriterCallback(BasePredictionWriter):
         """
         super().__init__(write_interval="batch")
 
-        self.writing_predictions = True  # flag to turn off predictions
-
-        # forward declaration
-        self.write_strategy: WriteStrategy
-        if write_strategy is not None:  # avoid `WriteStrategy | None` type
-            self.write_strategy = write_strategy
+        self.is_disabled = True  # flag to turn off predictions
+        self.write_strategy = write_strategy
 
         self.dirpath: Path
 
@@ -92,7 +88,7 @@ class PredictionWriterCallback(BasePredictionWriter):
         disable_writing : bool
             If writing predictions should be disabled.
         """
-        self.writing_predictions = disable_writing
+        self.is_disabled = disable_writing
 
     def _init_dirpath(self, dirpath):
         """
@@ -201,7 +197,7 @@ class PredictionWriterCallback(BasePredictionWriter):
             Dataloader index.
         """
         # if writing prediction is turned off
-        if not self.writing_predictions:
+        if self.is_disabled:
             return
 
         if self.write_strategy is not None:

--- a/src/careamics/lightning/dataset_ng/callbacks/prediction_writer/prediction_writer_callback.py
+++ b/src/careamics/lightning/dataset_ng/callbacks/prediction_writer/prediction_writer_callback.py
@@ -25,7 +25,12 @@ class PredictionWriterCallback(BasePredictionWriter):
     PyTorch Lightning callback to save predictions.
 
     A `WriteStrategy` must be provided at instantiation or later via
-    `set_writing_strategy`.
+    `set_writing_strategy`. This allows passing the callback to the Lightning `Trainer`
+    before knowing what writing strategy (e.g. tiling or file tyope) will be used.
+
+    By default the prediction writer is enabled, but it can be disabled by passing
+    `enable_writing=False` at instantiation or by calling `enable_writing(False)`.
+    Subsequently, writing can be re-enabled by calling `enable_writing(True)`.
 
     Parameters
     ----------
@@ -35,11 +40,13 @@ class PredictionWriterCallback(BasePredictionWriter):
         directory.
     write_strategy : WriteStrategy or None, default=None
         A strategy for writing predictions.
+    enable_writing : bool, default=True
+        If writing predictions should be enabled by default.
 
     Attributes
     ----------
-    writing_predictions : bool
-        If writing predictions is turned on or off.
+    is_enabled : bool
+        Whether writing predictions is enabled.
     dirpath : pathlib.Path, default=""
         The path to the directory where prediction outputs will be saved. If
         `dirpath` is not absolute it is assumed to be relative to current working
@@ -52,6 +59,7 @@ class PredictionWriterCallback(BasePredictionWriter):
         self,
         dirpath: Path | str = "",
         write_strategy: WriteStrategy | None = None,
+        enable_writing: bool = True,
     ):
         """
         Constructor.
@@ -67,10 +75,12 @@ class PredictionWriterCallback(BasePredictionWriter):
             directory.
         write_strategy : WriteStrategy or None, default=None
             A strategy for writing predictions.
+        enable_writing : bool, default=True
+            If writing predictions should be enabled by default.
         """
         super().__init__(write_interval="batch")
 
-        self.is_disabled = True  # flag to turn off predictions
+        self.is_enabled = enable_writing
         self.write_strategy = write_strategy
 
         self.dirpath: Path
@@ -88,7 +98,7 @@ class PredictionWriterCallback(BasePredictionWriter):
         enable_writing : bool
             If writing predictions should be enabled.
         """
-        self.is_disabled = not enable_writing
+        self.is_enabled = enable_writing
 
     def _init_dirpath(self, dirpath):
         """
@@ -197,7 +207,7 @@ class PredictionWriterCallback(BasePredictionWriter):
             Dataloader index.
         """
         # if writing prediction is turned off
-        if self.is_disabled:
+        if not self.is_enabled:
             return
 
         if self.write_strategy is not None:

--- a/src/careamics/lightning/dataset_ng/callbacks/prediction_writer/prediction_writer_callback.py
+++ b/src/careamics/lightning/dataset_ng/callbacks/prediction_writer/prediction_writer_callback.py
@@ -80,15 +80,15 @@ class PredictionWriterCallback(BasePredictionWriter):
         if dirpath != "":
             self._init_dirpath(dirpath)
 
-    def disable_writing(self, disable_writing: bool) -> None:
-        """Disable writing.
+    def enable_writing(self, enable_writing: bool) -> None:
+        """Enable or disable writing.
 
         Parameters
         ----------
-        disable_writing : bool
-            If writing predictions should be disabled.
+        enable_writing : bool
+            If writing predictions should be enabled.
         """
-        self.is_disabled = disable_writing
+        self.is_disabled = not enable_writing
 
     def _init_dirpath(self, dirpath):
         """

--- a/tests/lightning/dataset_ng/callbacks/prediction_writer_callbacks/test_ng_prediction_writer_callback.py
+++ b/tests/lightning/dataset_ng/callbacks/prediction_writer_callbacks/test_ng_prediction_writer_callback.py
@@ -31,7 +31,7 @@ def prediction_writer_callback(write_strategy: WriteStrategy, dirpath: Path | st
 
 def test_initialization(prediction_writer_callback, write_strategy, dirpath):
     """Test `PredictionWriterCallback` initializes as expected."""
-    assert prediction_writer_callback.enable_writing is True
+    assert prediction_writer_callback.is_enabled is True
     assert prediction_writer_callback.write_strategy is write_strategy
     assert prediction_writer_callback.dirpath == Path(dirpath).resolve()
 
@@ -70,12 +70,12 @@ def test_setup_prediction_directory_creation(
 
 def test_write_on_batch_end_writing_predictions_off(mocker, prediction_writer_callback):
     """
-    Test that `write_batch` acts as expected when writing predictions is set to off.
+    Test that `write_batch` acts as expected when writing predictions is off.
 
     Ensure `PredictionWriterCallback.write_strategy.write_batch` is not called when
     `PredictionWriterCallback.writing_predictions=False`.
     """
-    prediction_writer_callback.enable_writing = False
+    prediction_writer_callback.is_enabled = False
     write_strategy = mocker.Mock(spec=WriteStrategy)
     prediction_writer_callback.write_strategy = write_strategy
 

--- a/tests/lightning/dataset_ng/callbacks/prediction_writer_callbacks/test_ng_prediction_writer_callback.py
+++ b/tests/lightning/dataset_ng/callbacks/prediction_writer_callbacks/test_ng_prediction_writer_callback.py
@@ -31,7 +31,7 @@ def prediction_writer_callback(write_strategy: WriteStrategy, dirpath: Path | st
 
 def test_initialization(prediction_writer_callback, write_strategy, dirpath):
     """Test `PredictionWriterCallback` initializes as expected."""
-    assert prediction_writer_callback.writing_predictions is True
+    assert prediction_writer_callback.enable_writing is True
     assert prediction_writer_callback.write_strategy is write_strategy
     assert prediction_writer_callback.dirpath == Path(dirpath).resolve()
 
@@ -75,7 +75,7 @@ def test_write_on_batch_end_writing_predictions_off(mocker, prediction_writer_ca
     Ensure `PredictionWriterCallback.write_strategy.write_batch` is not called when
     `PredictionWriterCallback.writing_predictions=False`.
     """
-    prediction_writer_callback.writing_predictions = False
+    prediction_writer_callback.enable_writing = False
     write_strategy = mocker.Mock(spec=WriteStrategy)
     prediction_writer_callback.write_strategy = write_strategy
 

--- a/uv.lock
+++ b/uv.lock
@@ -361,6 +361,7 @@ source = { editable = "." }
 dependencies = [
     { name = "bioimageio-core" },
     { name = "matplotlib" },
+    { name = "microssim" },
     { name = "numpy" },
     { name = "pillow" },
     { name = "psutil" },
@@ -411,21 +412,22 @@ requires-dist = [
     { name = "careamics-portfolio", marker = "extra == 'examples'" },
     { name = "jupyter", marker = "extra == 'examples'" },
     { name = "matplotlib", specifier = "<=3.10.8" },
+    { name = "microssim" },
     { name = "numpy", specifier = ">=1.21" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
     { name = "pillow", specifier = "<=12.1.0" },
     { name = "protobuf", marker = "extra == 'tensorboard'", specifier = "==5.29.1" },
-    { name = "psutil", specifier = "<=7.2.1" },
+    { name = "psutil", specifier = "<=7.2.2" },
     { name = "pydantic", specifier = ">=2.11,<=2.12.5" },
     { name = "pylibczirw", marker = "extra == 'czi'", specifier = ">=4.1.2,<6.0.0" },
-    { name = "pytorch-lightning", specifier = ">=2.2,<=2.6.0" },
+    { name = "pytorch-lightning", specifier = ">=2.2,<=2.6.1" },
     { name = "pyyaml", specifier = "!=6.0.0,<=6.0.3" },
     { name = "scikit-image", specifier = "<=0.26.0" },
     { name = "tensorboard", marker = "extra == 'tensorboard'" },
-    { name = "tifffile", specifier = "<=2026.1.14" },
-    { name = "torch", specifier = ">=2.0,<=2.9.1" },
+    { name = "tifffile", specifier = "<=2026.1.28" },
+    { name = "torch", specifier = ">=2.0,<=2.10.0" },
     { name = "torchmetrics", specifier = ">=0.11.0,<1.5.0" },
-    { name = "torchvision", specifier = "<=0.24.1" },
+    { name = "torchvision", specifier = "<=0.25.0" },
     { name = "typer", specifier = ">=0.12.3,<=0.21.1" },
     { name = "validators", specifier = "<=0.35.0" },
     { name = "wandb", marker = "extra == 'wandb'" },
@@ -436,7 +438,7 @@ provides-extras = ["czi", "examples", "tensorboard", "wandb"]
 [package.metadata.requires-dev]
 dev = [
     { name = "ml-dtypes", specifier = ">=0.5.0" },
-    { name = "onnxscript", specifier = "<=0.5.7" },
+    { name = "onnxscript", specifier = "<=0.6.0" },
     { name = "pre-commit" },
     { name = "pylibczirw", specifier = ">=4.1.2,<6.0.0" },
     { name = "pytest" },
@@ -2151,6 +2153,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "microssim"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scikit-image" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "torchmetrics" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/7c/0f66f7f41af777d30cbe15951dfcf1a8ea34cdf6a2871679026cd8b62c3d/microssim-0.0.3.tar.gz", hash = "sha256:ad7817d76ca851b7b28d265eb7931756d64e308bcb9040b316006857d2d0b240", size = 5433391, upload-time = "2026-01-19T15:50:23.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/23/5022d1ecd3585088349443a57e260743fb2e6997eaf27bb58ce9ba2f95ce/microssim-0.0.3-py3-none-any.whl", hash = "sha256:753acb31a22db252ab79cbd5816c5dc56a31a3e29628f83cb205e0722446fcbe", size = 20964, upload-time = "2026-01-19T15:50:21.547Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Renamed the prediction writer callback flag to disable/enable writing and added the possibility to choose the starting state at initialization.