### PR TITLE
Chore: rename parameter and prevent override

### DIFF
--- a/src/careamics/config/ng_factories/data_factory.py
+++ b/src/careamics/config/ng_factories/data_factory.py
@@ -79,6 +79,9 @@ def create_ng_data_configuration(
     """
     Create a training NGDatasetConfig.
 
+    Note that `num_workers` is applied to all dataloaders unless explicitly overridden
+    in the respective dataloader parameters.
+
     Parameters
     ----------
     data_type : {"array", "tiff", "zarr", "czi", "custom"}
@@ -147,20 +150,25 @@ def create_ng_data_configuration(
         if "shuffle" not in train_dataloader_params:
             train_dataloader_params["shuffle"] = True
 
-        train_dataloader_params["num_workers"] = num_workers
+        if "num_workers" not in train_dataloader_params:
+            train_dataloader_params["num_workers"] = num_workers
 
         data["train_dataloader_params"] = train_dataloader_params
     else:
         data["train_dataloader_params"] = {"shuffle": True, "num_workers": num_workers}
 
     if val_dataloader_params is not None:
-        val_dataloader_params["num_workers"] = num_workers
+        if "num_workers" not in val_dataloader_params:
+            val_dataloader_params["num_workers"] = num_workers
+
         data["val_dataloader_params"] = val_dataloader_params
     else:
         data["val_dataloader_params"] = {"shuffle": False, "num_workers": num_workers}
 
     if pred_dataloader_params is not None:
-        pred_dataloader_params["num_workers"] = num_workers
+        if "num_workers" not in pred_dataloader_params:
+            pred_dataloader_params["num_workers"] = num_workers
+
         data["pred_dataloader_params"] = pred_dataloader_params
     else:
         data["pred_dataloader_params"] = {"shuffle": False, "num_workers": num_workers}

--- a/src/careamics/config/ng_factories/data_factory.py
+++ b/src/careamics/config/ng_factories/data_factory.py
@@ -70,7 +70,7 @@ def create_ng_data_configuration(
     normalization: dict | None = None,
     channels: Sequence[int] | None = None,
     in_memory: bool | None = None,
-    n_workers: int = 0,
+    num_workers: int = 0,
     train_dataloader_params: dict[str, Any] | None = None,
     val_dataloader_params: dict[str, Any] | None = None,
     pred_dataloader_params: dict[str, Any] | None = None,
@@ -102,7 +102,7 @@ def create_ng_data_configuration(
         'tiff' and 'custom' data types. If `None`, defaults to `True` for 'array',
         'tiff' and `custom`, and `False` for 'zarr' and 'czi' data types. Must be `True`
         for `array`.
-    n_workers : int, default=0
+    num_workers : int, default=0
         Number of workers for data loading.
     augmentations : list of transforms or None, default=None
         List of transforms to apply. If `None`, default augmentations are applied
@@ -147,23 +147,23 @@ def create_ng_data_configuration(
         if "shuffle" not in train_dataloader_params:
             train_dataloader_params["shuffle"] = True
 
-        train_dataloader_params["num_workers"] = n_workers
+        train_dataloader_params["num_workers"] = num_workers
 
         data["train_dataloader_params"] = train_dataloader_params
     else:
-        data["train_dataloader_params"] = {"shuffle": True, "num_workers": n_workers}
+        data["train_dataloader_params"] = {"shuffle": True, "num_workers": num_workers}
 
     if val_dataloader_params is not None:
-        val_dataloader_params["num_workers"] = n_workers
+        val_dataloader_params["num_workers"] = num_workers
         data["val_dataloader_params"] = val_dataloader_params
     else:
-        data["val_dataloader_params"] = {"shuffle": False, "num_workers": n_workers}
+        data["val_dataloader_params"] = {"shuffle": False, "num_workers": num_workers}
 
     if pred_dataloader_params is not None:
-        pred_dataloader_params["num_workers"] = n_workers
+        pred_dataloader_params["num_workers"] = num_workers
         data["pred_dataloader_params"] = pred_dataloader_params
     else:
-        data["pred_dataloader_params"] = {"shuffle": False, "num_workers": n_workers}
+        data["pred_dataloader_params"] = {"shuffle": False, "num_workers": num_workers}
 
     # add training patching
     data["patching"] = {

--- a/src/careamics/config/ng_factories/n2v_factory.py
+++ b/src/careamics/config/ng_factories/n2v_factory.py
@@ -241,25 +241,23 @@ def create_advanced_n2v_config(
     By default, all channels are trained independently. To train all channels together,
     set `independent_channels` to False.
 
-    By default, the transformations applied are a random flip along X or Y, and a random
-    90 degrees rotation in the XY plane. Normalization is always applied, as well as the
-    N2V manipulation.
-
-    By setting `augmentations` to `None`, the default transformations (flip in X and Y,
-    rotations by 90 degrees in the XY plane) are applied. Rather than the default
-    transforms, a list of transforms can be passed to the `augmentations` parameter. To
-    disable the transforms, simply pass an empty list.
+    By default, the augmentations applied are random flips along X or Y, and random
+    90 degrees rotations in the XY plane. To disable the augmentations, simply pass an
+    empty list.
 
     The `roi_size` parameter specifies the size of the area around each pixel that will
     be manipulated by N2V. The `masked_pixel_percentage` parameter specifies how many
     pixels per patch will be manipulated.
 
+    If you pass "horizontal" or "vertical" to `struct_n2v_axis`, then structN2V mask
+    will be applied to each manipulated pixel.
+
     The parameters of the UNet can be specified in the `model_params` (passed as a
     parameter-value dictionary). Note that `use_n2v2` and 'n_channels' override the
     corresponding parameters passed in `model_params`.
 
-    If you pass "horizontal" or "vertical" to `struct_n2v_axis`, then structN2V mask
-    will be applied to each manipulated pixel.
+    Note that `num_workers` is applied to all dataloaders unless explicitly overridden
+    in the respective dataloader parameters.
 
     Parameters
     ----------
@@ -315,7 +313,9 @@ def create_advanced_n2v_config(
     struct_n2v_span : int, default=5
         Span of the structN2V mask.
     num_workers : int, default=0
-        Number of workers for data loading.
+        Number of workers for data loading. Unless explicitly overridden in
+        `train_dataloader_params` and `val_dataloader_params`, this will be applied to
+        all dataloaders.
     trainer_params : dict | None, default=None
         Parameters for the trainer, see the relevant documentation.
     model_params : dict | None, default=None
@@ -331,12 +331,9 @@ def create_advanced_n2v_config(
         details.
     train_dataloader_params : dict[str, Any] | None, default=None
         Parameters for the training dataloader, see the PyTorch docs for `DataLoader`.
-        If left as `None`, the dict `{"shuffle": True}` will be used, this is set in
-        the `GeneralDataConfig`.
+        If left as `None`, `{"shuffle": True}` will be used.
     val_dataloader_params : dict[str, Any] | None, default=None
         Parameters for the validation dataloader, see PyTorch the docs for `DataLoader`.
-        If left as `None`, the empty dict `{}` will be used, this is set in the
-        `GeneralDataConfig`.
     checkpoint_params : dict[str, Any] | None, default=None
         Parameters for the checkpoint callback, see PyTorch Lightning documentation
         (`ModelCheckpoint`) for the list of available parameters.

--- a/src/careamics/config/ng_factories/n2v_factory.py
+++ b/src/careamics/config/ng_factories/n2v_factory.py
@@ -206,7 +206,7 @@ def create_advanced_n2v_config(
     struct_n2v_axis: Literal["horizontal", "vertical", "none"] = "none",
     struct_n2v_span: int = 5,
     # - Lightning parameters
-    n_workers: int = 0,
+    num_workers: int = 0,
     trainer_params: dict | None = None,
     model_params: dict | None = None,
     optimizer: Literal["Adam", "Adamax", "SGD"] = "Adam",
@@ -314,7 +314,7 @@ def create_advanced_n2v_config(
         Axis along which to apply structN2V mask.
     struct_n2v_span : int, default=5
         Span of the structN2V mask.
-    n_workers : int, default=0
+    num_workers : int, default=0
         Number of workers for data loading.
     trainer_params : dict | None, default=None
         Parameters for the trainer, see the relevant documentation.
@@ -409,7 +409,7 @@ def create_advanced_n2v_config(
         normalization=norm_config,
         channels=channels,
         in_memory=in_memory,
-        n_workers=n_workers,
+        num_workers=num_workers,
         train_dataloader_params=train_dataloader_params,
         val_dataloader_params=val_dataloader_params,
         seed=seed,

--- a/tests/config/ng_factories/test_n2v_factory.py
+++ b/tests/config/ng_factories/test_n2v_factory.py
@@ -12,7 +12,13 @@ from careamics.config.support import (
 )
 
 
-class TestN2VConfiguration:
+# TODO standard just calls advanced, where should test reside?
+# - arguably standard should only test the parameters that it enforces, but these are
+# default
+# - advanced should test what it actaully does
+class TestStandardConfig:
+    """Test the standard N2V configuration factory."""
+
     def test_create_standard_config(self):
         """Test that N2V configuration can be created."""
         config = create_n2v_config(
@@ -25,7 +31,7 @@ class TestN2VConfiguration:
         assert isinstance(config, N2VConfiguration)
 
     def test_no_aug(self):
-        """Test the default n2v transforms."""
+        """Test no augmentation."""
         config = create_n2v_config(
             experiment_name="test",
             data_type="tiff",
@@ -35,85 +41,6 @@ class TestN2VConfiguration:
             augmentations=[],
         )
         assert config.data_config.transforms == []
-
-    def test_n2v2_structn2v(self):
-        """Test n2v2 and structn2v params are passed correctly."""
-        n2v2 = True
-        struct_mask_axis = SupportedStructAxis.HORIZONTAL.value
-        struct_n2v_span = 15
-
-        config = create_structn2v_config(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            struct_n2v_axis=struct_mask_axis,
-            struct_n2v_span=struct_n2v_span,
-            use_n2v2=n2v2,
-        )
-        assert (
-            config.algorithm_config.n2v_config.strategy
-            == SupportedPixelManipulation.MEDIAN.value
-        )
-        assert config.algorithm_config.n2v_config.struct_mask_axis == struct_mask_axis
-        assert config.algorithm_config.n2v_config.struct_mask_span == struct_n2v_span
-
-    def test_num_epochs(self):
-        """Test that num_epochs parameter is correctly passed to trainer config."""
-        num_epochs = 50
-
-        config = create_n2v_config(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=num_epochs,
-        )
-        assert (
-            config.training_config.lightning_trainer_config["max_epochs"] == num_epochs
-        )
-
-        # Test with num_epochs=None (should not be in config)
-        config = create_n2v_config(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_epochs=None,
-        )
-        assert "max_epochs" not in config.training_config.lightning_trainer_config
-
-    def test_num_steps(self):
-        """Test that num_steps parameter is correctly passed to trainer config."""
-        num_steps = 1000
-
-        config = create_n2v_config(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-            num_steps=num_steps,
-        )
-        assert (
-            config.training_config.lightning_trainer_config["limit_train_batches"]
-            == num_steps
-        )
-
-        # Test without num_steps (should not be in config)
-        config = create_n2v_config(
-            experiment_name="test",
-            data_type="tiff",
-            axes="YX",
-            patch_size=[64, 64],
-            batch_size=8,
-        )
-        assert (
-            "limit_train_batches" not in config.training_config.lightning_trainer_config
-        )
 
     def test_num_epochs_and_num_steps(self):
         """Test that both num_epochs and num_steps can be set simultaneously."""
@@ -152,28 +79,34 @@ class TestN2VConfiguration:
         assert len(config.data_config.patching.patch_size) == 3
         assert config.algorithm_config.model.conv_dims == 3
 
-    def test_epochs_steps(self):
-        """Test step and epoch naming in trainer config."""
-        num_epochs = 10
-        num_steps = 20
 
-        config = create_n2v_config(
+class TestStructConfig:
+    def test_n2v2_structn2v(self):
+        """Test n2v2 and structn2v params are passed correctly."""
+        n2v2 = True
+        struct_mask_axis = SupportedStructAxis.HORIZONTAL.value
+        struct_n2v_span = 15
+
+        config = create_structn2v_config(
             experiment_name="test",
             data_type="tiff",
             axes="YX",
             patch_size=[64, 64],
             batch_size=8,
-            num_epochs=num_epochs,
-            num_steps=num_steps,
+            struct_n2v_axis=struct_mask_axis,
+            struct_n2v_span=struct_n2v_span,
+            use_n2v2=n2v2,
         )
+        assert (
+            config.algorithm_config.n2v_config.strategy
+            == SupportedPixelManipulation.MEDIAN.value
+        )
+        assert config.algorithm_config.n2v_config.struct_mask_axis == struct_mask_axis
+        assert config.algorithm_config.n2v_config.struct_mask_span == struct_n2v_span
 
-        assert (
-            config.training_config.lightning_trainer_config["max_epochs"] == num_epochs
-        )
-        assert (
-            config.training_config.lightning_trainer_config["limit_train_batches"]
-            == num_steps
-        )
+
+class TestAdvancedConfig:
+    """Test the advanced N2V configuration factory"""
 
     @pytest.mark.parametrize(
         "axes, n_channels, channels, error",
@@ -227,3 +160,36 @@ class TestN2VConfiguration:
             else:
                 assert config.algorithm_config.model.in_channels == len(channels)
                 assert config.algorithm_config.model.num_classes == len(channels)
+
+    def test_num_workers(self):
+        """Test that num_workers can be set and overrriden by train dataloader."""
+        num_workers = 4
+
+        config: N2VConfiguration = create_advanced_n2v_config(
+            experiment_name="test",
+            data_type="tiff",
+            axes="YX",
+            patch_size=[64, 64],
+            batch_size=8,
+            num_workers=num_workers,
+        )
+        assert config.data_config.train_dataloader_params["num_workers"] == num_workers
+        assert config.data_config.val_dataloader_params["num_workers"] == num_workers
+        assert config.data_config.pred_dataloader_params["num_workers"] == num_workers
+
+        # test overrride
+        alt_num_workers = 2
+        config: N2VConfiguration = create_advanced_n2v_config(
+            experiment_name="test",
+            data_type="tiff",
+            axes="YX",
+            patch_size=[64, 64],
+            batch_size=8,
+            num_workers=num_workers,
+            train_dataloader_params={"num_workers": alt_num_workers},
+        )
+        assert (
+            config.data_config.train_dataloader_params["num_workers"] == alt_num_workers
+        )
+        assert config.data_config.val_dataloader_params["num_workers"] == num_workers
+        assert config.data_config.pred_dataloader_params["num_workers"] == num_workers


### PR DESCRIPTION
## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

In the convenience functions, the parameter `n_workers` was passed to `num_workers` in the dataloaders `dict`. This PR rename it for coherence.

The PR also includes a new behaviour related to the workers. Currently, `num_workers` override whatever users set in `train_dataloader_params` and `val_dataloader_params`. This has two consequences:
- no way to set it independently in the dataloaders
- if users have a full `train_dataloader_params` defined, the default value `num_workers=0` might override the value in the dictionary. This for instance will impact the CZI CI.

The new behaviour ignores `num_workers` if it is defined in the `train_dataloader_params` (or `val_dataloader_params`).