### PR TITLE
Fix: EarlyStopping callback initialisation in CAREamist

### DIFF
--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -270,7 +270,9 @@ class CAREamist:
         # early stopping callback
         if self.cfg.training_config.early_stopping_callback is not None:
             self.callbacks.append(
-                EarlyStopping(self.cfg.training_config.early_stopping_callback)
+                EarlyStopping(
+                    **self.cfg.training_config.early_stopping_callback.model_dump()
+                )
             )
 
     def stop_training(self) -> None:

--- a/tests/test_careamist.py
+++ b/tests/test_careamist.py
@@ -5,11 +5,11 @@ import numpy as np
 import pytest
 import tifffile
 from numpy.typing import NDArray
-from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import Callback, EarlyStopping, ModelCheckpoint
 
 from careamics import CAREamist
 from careamics.config import Configuration, save_configuration
+from careamics.config.lightning import CheckpointConfig, EarlyStoppingConfig
 from careamics.config.support import SupportedAlgorithm, SupportedData
 from careamics.dataset.dataset_utils import reshape_array
 from careamics.lightning.callbacks import HyperParametersCallback, ProgressBarCallback
@@ -384,6 +384,36 @@ def test_train_tiff_files(tmp_path: Path, minimum_n2v_configuration: dict):
         data_description="A random array.",
     )
     assert (tmp_path / "model.zip").exists()
+
+
+@pytest.mark.mps_gh_fail
+def test_train_w_callbacks(tmp_path: Path, minimum_n2v_configuration: dict):
+    """
+    Test that basic training with arrays runs without error with supported callbacks.
+    """
+    # training data
+    train_array = random_array((32, 32))
+    val_array = random_array((32, 32))
+
+    # create configuration
+    config = Configuration(**minimum_n2v_configuration)
+    config.data_config.axes = "YX"
+    config.data_config.batch_size = 2
+    config.data_config.data_type = SupportedData.ARRAY.value
+    config.data_config.patch_size = (8, 8)
+
+    # add supported callback configuration
+    config.training_config.checkpoint_callback = CheckpointConfig()
+    config.training_config.early_stopping_callback = EarlyStoppingConfig()
+
+    # set epochs 2 to make sure callbacks are accessed.
+    config.training_config.lightning_trainer_config["max_epochs"] = 2
+
+    # instantiate CAREamist
+    careamist = CAREamist(source=config, work_dir=tmp_path)
+
+    # train CAREamist
+    careamist.train(train_source=train_array, val_source=val_array)
 
 
 @pytest.mark.mps_gh_fail
@@ -1136,12 +1166,7 @@ def test_error_passing_careamics_callback(tmp_path, minimum_n2v_configuration):
     with pytest.raises(ValueError):
         CAREamist(source=config, work_dir=tmp_path, callbacks=[model_ckp])
 
-    early_stp = EarlyStopping(
-        Trainer(
-            max_epochs=1,
-            default_root_dir=tmp_path,
-        )
-    )
+    early_stp = EarlyStopping(monitor="val_loss")
 
     with pytest.raises(ValueError):
         CAREamist(source=config, work_dir=tmp_path, callbacks=[early_stp])


### PR DESCRIPTION
## Description

> [!NOTE]  
> **tldr**: Fixes a bug in CAREamist initialisation of the `EarlyStopping` callback. 

### Background - why do we need this PR?

Instead of dumping the parameters from the `EarlyStoppingConfig` pydantic model, it was passed as the first argument and this was interpreted as the value the callback was meant to monitor, later leading to an error.

### Overview - what changed?

Fixed the callback initialisation and added a test.

## Changes Made

<!-- This section highlights the important features and files that reviewers should
pay attention to when reviewing. Only list important features or files, this is useful for 
reviewers to correctly assess how deeply the modifications impact the code base.

## How has this been tested?

Added a test which runs training with CAREamist and has both the `EarlyStopping` and `Checkpoint` callback configuration.

## Related Issues

<!-- Link to any related issues or discussions. Use keywords like "Fixes", "Resolves",
or "Closes" to link to issues automatically. -->

- Resolves #770 

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Pre-commit passes
- [ ] PR to the documentation exists (for bug fixes / features)