### PR TITLE
Fix: Add backward compatibility alias for create_n2v_configuration

### DIFF
--- a/src/careamics/config/ng_factories/__init__.py
+++ b/src/careamics/config/ng_factories/__init__.py
@@ -3,6 +3,7 @@
 __all__ = [
     "create_advanced_n2v_config",
     "create_n2v_config",
+    "create_n2v_configuration",  # deprecated alias
     "create_ng_data_configuration",
     "create_structn2v_config",
 ]
@@ -11,5 +12,6 @@ from .data_factory import create_ng_data_configuration
 from .n2v_factory import (
     create_advanced_n2v_config,
     create_n2v_config,
+    create_n2v_configuration,  # deprecated alias
     create_structn2v_config,
 )

--- a/src/careamics/config/ng_factories/n2v_factory.py
+++ b/src/careamics/config/ng_factories/n2v_factory.py
@@ -461,3 +461,23 @@ def create_advanced_n2v_config(
         data_config=data_config,
         training_config=training_params,
     )
+
+
+# Backward compatibility alias (deprecated)
+def create_n2v_configuration(*args, **kwargs):
+    """
+    Deprecated: Use `create_advanced_n2v_config` instead.
+
+    This function is provided for backward compatibility and will be removed
+    in a future version.
+    """
+    import warnings
+
+    warnings.warn(
+        "create_n2v_configuration is deprecated, use create_advanced_n2v_config "
+        "instead. Note: the 'augmentations' parameter now accepts a list of strings "
+        "(e.g., ['x_flip', 'y_flip', 'rotate_90']) instead of config objects.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return create_advanced_n2v_config(*args, **kwargs)


### PR DESCRIPTION
## Description

Closes #781

This PR adds a backward compatibility alias `create_n2v_configuration` for users who are still importing the old function name from `careamics.config.ng_factories`.

## What Changed

In commit 4665daee (#743), the function `create_n2v_configuration` was refactored into:
- `create_n2v_config` (simplified interface)
- `create_advanced_n2v_config` (full parameters)

This broke external code that was importing `create_n2v_configuration`.

## Solution

Added `create_n2v_configuration` as a deprecated alias that:
- Points to `create_advanced_n2v_config` (closest to the original signature)
- Emits a `DeprecationWarning` to encourage migration
- Is properly exported from `careamics.config.ng_factories`

## Migration Path

Users will see a deprecation warning and should migrate to either:
- `create_n2v_config` - simplified interface with fewer parameters
- `create_advanced_n2v_config` - full control (most similar to old function)

**Note:** The `augmentations` parameter type changed from config objects to string literals (e.g., `['x_flip', 'y_flip', 'rotate_90']`), which is noted in the warning message.

## Testing

Syntax checked successfully. Full test suite requires dependencies.