### PR TITLE
feat: raise ValidationError for batch_size in dataloader params (closes #793)

### DIFF
--- a/src/careamics/config/data/ng_data_config.py
+++ b/src/careamics/config/data/ng_data_config.py
@@ -577,6 +577,41 @@ class NGDataConfig(BaseModel):
                 self.patching.seed = self.seed
         return self
 
+    @field_validator(
+        "train_dataloader_params",
+        "val_dataloader_params",
+        "pred_dataloader_params",
+        mode="before",
+    )
+    @classmethod
+    def check_batch_size_not_in_dataloader_params(
+        cls, dataloader_params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """
+        Check that 'batch_size' is not passed directly via dataloader_params.
+
+        Parameters
+        ----------
+        dataloader_params : dict of {str: Any}
+            The dataloader parameters.
+
+        Returns
+        -------
+        dict of {str: Any}
+            The dataloader parameters.
+
+        Raises
+        ------
+        ValueError
+            If 'batch_size' is present in dataloader_params.
+        """
+        if "batch_size" in dataloader_params:
+            raise ValueError(
+                "Cannot specify 'batch_size' in dataloader parameters. "
+                "Please use the explicit `batch_size` attribute of the configuration."
+            )
+        return dataloader_params
+
     @field_validator("train_dataloader_params", "val_dataloader_params", mode="before")
     @classmethod
     def set_default_pin_memory(

--- a/tests/config/data/test_ng_data_config.py
+++ b/tests/config/data/test_ng_data_config.py
@@ -641,3 +641,24 @@ class TestConvertMode:
                 "validating",
                 new_axes="YX",
             )
+
+
+@pytest.mark.parametrize(
+    "dataloader_param_key",
+    ["train_dataloader_params", "val_dataloader_params", "pred_dataloader_params"],
+)
+def test_dataloader_params_batch_size_validation(dataloader_param_key):
+    """Test that `batch_size` cannot be passed in dataloader_params."""
+    kwargs = {
+        "mode": "training" if dataloader_param_key == "train_dataloader_params" else "predicting",
+        "data_type": "array",
+        "axes": "YX",
+        "patching": default_patching(
+            "training" if dataloader_param_key == "train_dataloader_params" else "predicting"
+        ),
+        "normalization": DEFAULT_NORM,
+    }
+    kwargs[dataloader_param_key] = {"batch_size": 16}
+
+    with pytest.raises(ValueError, match="Cannot specify 'batch_size' in dataloader parameters"):
+        NGDataConfig(**kwargs)

--- a/tests/config/data/test_ng_data_config.py
+++ b/tests/config/data/test_ng_data_config.py
@@ -650,15 +650,23 @@ class TestConvertMode:
 def test_dataloader_params_batch_size_validation(dataloader_param_key):
     """Test that `batch_size` cannot be passed in dataloader_params."""
     kwargs = {
-        "mode": "training" if dataloader_param_key == "train_dataloader_params" else "predicting",
+        "mode": (
+            "training"
+            if dataloader_param_key == "train_dataloader_params"
+            else "predicting"
+        ),
         "data_type": "array",
         "axes": "YX",
         "patching": default_patching(
-            "training" if dataloader_param_key == "train_dataloader_params" else "predicting"
+            "training"
+            if dataloader_param_key == "train_dataloader_params"
+            else "predicting"
         ),
         "normalization": DEFAULT_NORM,
     }
     kwargs[dataloader_param_key] = {"batch_size": 16}
 
-    with pytest.raises(ValueError, match="Cannot specify 'batch_size' in dataloader parameters"):
+    with pytest.raises(
+        ValueError, match="Cannot specify 'batch_size' in dataloader parameters"
+    ):
         NGDataConfig(**kwargs)


### PR DESCRIPTION
Closes #793

### Description
Added a @field_validator in NGDataConfig across train_dataloader_params, val_dataloader_params, and pred_dataloader_params.
This instantly raises a helpful ValueError if a user attempts to manually configure batch_size via the dataloader_params mapping instead of explicitly setting the batch_size attribute of the configuration class, thus avoiding the obscure SyntaxError: keyword argument repeated error.

### Testing
- Added tests in tests/config/data/test_ng_data_config.py to verify that providing {"batch_size": 16} within any of the three dataloader params properly errors out during Pydantic initialization.