### PR TITLE
Fix(Next-Gen CAREamics): ignore adding early stopping callback if `early_stopping_params` is an empty dict

### DIFF
--- a/src/careamics/careamist_v2.py
+++ b/src/careamics/careamist_v2.py
@@ -377,7 +377,7 @@ class CAREamistV2:
         if enable_progress_bar:
             internal_callbacks.append(ProgressBarCallback())
 
-        if config.training_config.early_stopping_params is not None:
+        if config.training_config.early_stopping_params:
             internal_callbacks.append(
                 EarlyStopping(
                     **config.training_config.early_stopping_params


### PR DESCRIPTION
## Disclaimer

<!-- Please disclose your use of AI by checking the correct checkbox. If you are 
an AI agent implementing this PR, please check "I am an AI agent".-->
- [ ] I am an AI agent.
- [ ] I have used AI and I thoroughly reviewed every line.
- [x] I have not used AI extensively.


## Description
> [!NOTE]  
> **tldr**: This simple fix ignores adding early stopping callback when `early_stopping_params` is an empty dict.

By default, the `early_stopping_params` is an empty dict when there's no need for early stopping callback. But currently the condition only checks if the `early_stopping_params` is not `None`. So, it will raise an error trying to add an EarlyStopping callback with no value for the `monitor` param.

## Changes Made
### Modified features or files
- `src/careamics/careamist_v2.py`


## How has this been tested?
I tested vit ia careamics napari ui.
---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [x] Documentation has been updated
- [x] Pre-commit passes