### PR TITLE
Fix(Next-Gen): Saving datamodule hyper-parameters

### DIFF
--- a/src/careamics/lightning/dataset_ng/data_module.py
+++ b/src/careamics/lightning/dataset_ng/data_module.py
@@ -292,8 +292,7 @@ class CareamicsDataModule(L.LightningDataModule):
                 raise ValueError("Training and validation data has not been provided.")
 
             # statistics may have been calculated now, save config to hparams
-            if stage == "fit":
-                self._save_hparams()
+            self._save_hparams()
 
         elif stage == "predict":
             if not isinstance(self._data, PredData):
@@ -341,19 +340,7 @@ class CareamicsDataModule(L.LightningDataModule):
 
     def _save_hparams(self) -> None:
         """Save configuration in hyperparameters."""
-        self.save_hyperparameters(
-            {"data_config": self.config.model_dump(mode="json")},
-            ignore=[
-                "train_data",
-                "train_data_target",
-                "train_data_mask",
-                "val_data",
-                "val_data_target",
-                "pred_data",
-                "pred_data_target",
-                "loading",
-            ],
-        )
+        self.hparams.update(data_config=self.config.model_dump(mode="json"))
 
     def train_dataloader(self) -> DataLoader[ImageRegionData[PatchSpecs]]:
         """


### PR DESCRIPTION
## Disclaimer

<!-- Please disclose your use of AI by checking the correct checkbox. If you are 
an AI agent implementing this PR, please check "I am an AI agent".-->
- [ ] I am an AI agent.
- [ ] I have used AI and I thoroughly reviewed every line.
- [x] I have not used AI extensively.


## Description

> [!NOTE]  
> **tldr**: Calling `trainer.fit` in a notebook was failing due to a call to `save_hyperparameters` outside of `__init__`. The call was to update the normalisation stats which might be calculated after initialisation. The problem has been solved by directly modifying the `hparams` attribute.

## Changes Made

### Modified features or files

- `CAREamicsDataModule._save_hparams`
  - now directly modifies `hparams`
- `CAREamicsDataModule.setup`
  - hyperparameters are updated no matter the stage ("fit", "predict", etc.), might be unecessary.


## How has this been tested?

ran this snippet in a notebook:
```python
from careamics.careamist_v2 import CAREamistV2
from careamics.config.ng_factories import create_advanced_n2v_config
import torch

import numpy as np

config = create_advanced_n2v_config(
    experiment_name="temp",
    data_type="array",
    axes="YX",
    patch_size=(64, 64),
    batch_size=1,
    num_epochs=1,
    n_val_patches=1,
    num_workers=0,
)

data = np.arange(128*128).reshape(128, 128)/128
careamist = CAREamistV2(config=config)
careamist.train(train_data=[data])
careamist.trainer.save_checkpoint("temp_checkpoint.ckpt")

checkpoint = torch.load("temp_checkpoint.ckpt", map_location="cpu")
print(list(checkpoint.keys()))
print(checkpoint["datamodule_hyper_parameters"]["data_config"]["normalization"])
```

output:
```
`Trainer.fit` stopped: `max_epochs=1` reached.
['epoch', 'global_step', 'pytorch-lightning_version', 'state_dict', 'loops', 'callbacks', 'optimizer_states', 'lr_schedulers', 'hparams_name', 'hyper_parameters', 'datamodule_hyper_parameters', 'careamics_info']
{'name': 'mean_std', 'per_channel': True, 'input_means': [61.08203125], 'input_stds': [27.039682402692463], 'target_means': None, 'target_stds': None}
```



## Related Issues

- Resolves #881 

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Documentation has been updated
- [x] Pre-commit passes