### PR TITLE
Feat(v0.2): use a single `get_device` function

### DIFF
--- a/src/careamics/lvae_training/eval_utils.py
+++ b/src/careamics/lvae_training/eval_utils.py
@@ -20,6 +20,7 @@ from tqdm import tqdm
 from careamics.lightning import VAEModule
 from careamics.lvae_training.dataset import MultiChDloaderRef
 from careamics.metrics.metrics import scale_invariant_psnr
+from careamics.utils import get_device
 
 
 class TilingMode:
@@ -108,15 +109,6 @@ def get_first_index(bin_count, quantile):
         if normalized_cumsum[i] > quantile:
             return i
     return None
-
-
-def get_device():
-    if torch.cuda.is_available():
-        return "cuda"
-    elif torch.backends.mps.is_available():
-        return "mps"
-    else:
-        return "cpu"
 
 
 def show_for_one(

--- a/src/careamics/models/lvae/noise_models.py
+++ b/src/careamics/models/lvae/noise_models.py
@@ -8,6 +8,8 @@ import torch
 import torch.nn as nn
 from numpy.typing import NDArray
 
+from careamics.utils import get_device
+
 if TYPE_CHECKING:
     from careamics.config import GaussianMixtureNMConfig, MultiChannelNMConfig
 
@@ -211,7 +213,7 @@ class MultiChannelNoiseModel(nn.Module):
             List of noise models, one for each output channel.
         """
         super().__init__()
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = get_device()
 
         for i, nmodel in enumerate(nmodels):  # TODO refactor this !!!
             if nmodel is not None:

--- a/src/careamics/utils/__init__.py
+++ b/src/careamics/utils/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
     "autocorrelation",
     "cwd",
     "get_careamics_home",
+    "get_device",
     "get_logger",
     "get_ram_size",
 ]
@@ -11,5 +12,6 @@ __all__ = [
 
 from .autocorrelation import autocorrelation
 from .context import cwd, get_careamics_home
+from .get_device import get_device
 from .logging import get_logger
 from .ram import get_ram_size


### PR DESCRIPTION
## Description

Replaces occurrences of `if torch.device == ...: device = ...` with `careamics.utils.get_device`.

Closes https://github.com/CAREamics/careamics/issues/403.