### PR TITLE
Feat(MicroSplit): towards NG dataset

### DIFF
--- a/src/careamics/config/data/ng_microsplit_config.py
+++ b/src/careamics/config/data/ng_microsplit_config.py
@@ -34,7 +34,7 @@ class MicroSplitDataConfig(NGDataConfig):
     performs internal self-consistency checks.
     """
 
-    # ── LC parameters ─────────────────────────────────────────────────────────
+    #  LC parameters
     lateral_context: bool = Field(default=True)
     """Enable lateral-context multi-scale patch construction."""
 
@@ -44,21 +44,21 @@ class MicroSplitDataConfig(NGDataConfig):
     padding_mode: Literal["reflect", "wrap"] = Field(default="reflect")
     """Boundary padding mode for the LC patch constructor."""
 
-    # ── Alpha / input synthesis ────────────────────────────────────────────────
+    #  Alpha / input synthesis
     input_is_sum: bool = Field(default=False)
     """Multiply the average-combined input by C to get the sum."""
 
     alpha_range: tuple[float, float] | None = Field(default=None)
     """Per-channel alpha sampling range (start, end). None → equal weights."""
 
-    # ── Uncorrelated-channel augmentation ─────────────────────────────────────
+    #  Uncorrelated-channel augmentation
     mix_uncorrelated_channels: bool = Field(default=False)
     """Draw channels 1…C-1 from random locations with given probability."""
 
     uncorrelated_channel_probab: float = Field(default=0.5, ge=0.0, le=1.0)
     """Probability of applying the uncorrelated-channel swap per sample."""
 
-    # ── Empty-patch mixing ────────────────────────────────────────────────────
+    #  Empty-patch mixing
     empty_patch_mixing: bool = Field(default=False)
     """Force channels to contain signal or background (requires filters)."""
 
@@ -71,7 +71,7 @@ class MicroSplitDataConfig(NGDataConfig):
     empty_patch_patience: int = Field(default=200, ge=1)
     """Max candidates per channel when enforcing empty/signal criterion."""
 
-    # ── Validators ────────────────────────────────────────────────────────────
+    #  Validators
 
     @model_validator(mode="after")
     def _validate_alpha_range(self) -> MicroSplitDataConfig:

--- a/src/careamics/config/data/ng_microsplit_config.py
+++ b/src/careamics/config/data/ng_microsplit_config.py
@@ -1,0 +1,180 @@
+"""MicroSplit-specific data configuration extending NGDataConfig."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import Field, model_validator
+
+from .ng_data_config import NGDataConfig
+
+
+class MicroSplitDataConfig(NGDataConfig):
+    """Data configuration for MicroSplit (LVAE) channel-separation models.
+
+    Extends :class:`NGDataConfig` with parameters specific to the MicroSplit
+    algorithm:
+
+    - **Lateral context (LC)**: multi-scale context patches centred on the
+      primary crop, used as input to the hierarchical VAE encoder.
+    - **Channel mixing**: synthetic creation of the input by alpha-weighted
+      superposition of multiple fluorescence channels.
+    - **Uncorrelated-channel augmentation**: with a given probability, channels
+      other than channel 0 are drawn from random spatial locations, making them
+      spatially uncorrelated with channel 0.
+    - **Empty-patch mixing**: optionally force one channel to contain only
+      background while another contains signal, mimicking the partially-labelled
+      regime described in the MicroSplit paper.
+
+    Parameters
+    ----------
+    lateral_context : bool
+        If ``True``, the input extractor is built with
+        ``lateral_context_patch_constr`` so that each extracted patch has the
+        shape ``(C, L, (Z), Y, X)`` where ``L == multiscale_count``.
+    multiscale_count : int
+        Number of LC levels including the full-resolution level (level 0).
+        Only used when ``lateral_context=True``. Must satisfy
+        ``multiscale_count >= 1``.
+    padding_mode : {"reflect", "wrap"}
+        Padding mode passed to ``lateral_context_patch_constr`` for handling
+        patch boundaries. Corresponds to legacy ``padding_kwargs["mode"]``.
+    input_is_sum : bool
+        If ``True`` the alpha-weighted channel average is multiplied by the
+        number of channels to obtain the sum rather than the average.
+        Corresponds to the legacy ``input_is_sum`` flag.
+    alpha_range : tuple of (float, float) or None
+        Per-channel alpha sampling range ``(start, end)``.  At each
+        ``__getitem__`` call each channel's weight is drawn uniformly from this
+        range.  ``None`` means equal weights ``1 / num_channels``.
+    mix_uncorrelated_channels : bool
+        If ``True``, apply uncorrelated-channel augmentation during training.
+        Channels 1…C-1 are drawn from random spatial locations with probability
+        ``uncorrelated_channel_probab``.
+    uncorrelated_channel_probab : float
+        Probability of applying the uncorrelated-channel swap on any given
+        sample.  Only relevant when ``mix_uncorrelated_channels=True``.
+    empty_patch_mixing : bool
+        If ``True``, use ``get_empty_channel_patches`` to enforce that selected
+        channels either contain signal or background (controlled by
+        ``empty_signal_channels`` / ``empty_background_channels``).
+    empty_signal_channels : list of int or None
+        Channel indices that must contain signal patches (not filtered out).
+        Only used when ``empty_patch_mixing=True``.
+    empty_background_channels : list of int or None
+        Channel indices that must be background (empty) patches.
+        Only used when ``empty_patch_mixing=True``.
+    empty_patch_patience : int
+        Number of random patch candidates to try before giving up when looking
+        for a patch satisfying the empty/signal criterion.
+
+    Notes
+    -----
+    Model-side cross-validation (e.g. confirming ``multiscale_count`` matches
+    the number of LVAE encoder levels) is delegated to the configuration
+    factory (``create_ng_microsplit_configuration``); this Pydantic model only
+    performs internal self-consistency checks.
+    """
+
+    # ── LC parameters ─────────────────────────────────────────────────────────
+    lateral_context: bool = Field(default=True)
+    """Enable lateral-context multi-scale patch construction."""
+
+    multiscale_count: int = Field(default=3, ge=1)
+    """Number of LC levels (including full-resolution level 0)."""
+
+    padding_mode: Literal["reflect", "wrap"] = Field(default="reflect")
+    """Boundary padding mode for the LC patch constructor."""
+
+    # ── Alpha / input synthesis ────────────────────────────────────────────────
+    input_is_sum: bool = Field(default=False)
+    """Multiply the average-combined input by C to get the sum."""
+
+    alpha_range: tuple[float, float] | None = Field(default=None)
+    """Per-channel alpha sampling range (start, end). None → equal weights."""
+
+    # ── Uncorrelated-channel augmentation ─────────────────────────────────────
+    mix_uncorrelated_channels: bool = Field(default=False)
+    """Draw channels 1…C-1 from random locations with given probability."""
+
+    uncorrelated_channel_probab: float = Field(default=0.5, ge=0.0, le=1.0)
+    """Probability of applying the uncorrelated-channel swap per sample."""
+
+    # ── Empty-patch mixing ────────────────────────────────────────────────────
+    empty_patch_mixing: bool = Field(default=False)
+    """Force channels to contain signal or background (requires filters)."""
+
+    empty_signal_channels: list[int] | None = Field(default=None)
+    """Channel indices that must contain signal."""
+
+    empty_background_channels: list[int] | None = Field(default=None)
+    """Channel indices that must be background (empty)."""
+
+    empty_patch_patience: int = Field(default=200, ge=1)
+    """Max candidates per channel when enforcing empty/signal criterion."""
+
+    # ── Validators ────────────────────────────────────────────────────────────
+
+    @model_validator(mode="after")
+    def _validate_alpha_range(self) -> MicroSplitDataConfig:
+        """Validate alpha_range is ordered and within [0, 1]."""
+        if self.alpha_range is not None:
+            start, end = self.alpha_range
+            if start < 0.0 or end > 1.0:
+                raise ValueError(
+                    f"alpha_range values must be in [0, 1], got {self.alpha_range}."
+                )
+            if start > end:
+                raise ValueError(f"alpha_range start ({start}) must be <= end ({end}).")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_empty_patch_channels(self) -> MicroSplitDataConfig:
+        """Validate that signal and background channel sets do not overlap."""
+        if not self.empty_patch_mixing:
+            return self
+        signal = set(self.empty_signal_channels or [])
+        background = set(self.empty_background_channels or [])
+        overlap = signal & background
+        if overlap:
+            raise ValueError(
+                f"Channels {overlap} appear in both empty_signal_channels and "
+                f"empty_background_channels. A channel cannot be both."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_lateral_context_needs_multiscale(self) -> MicroSplitDataConfig:
+        """Warn (or fail) if lateral_context is False but multiscale_count > 1."""
+        if not self.lateral_context and self.multiscale_count > 1:
+            raise ValueError(
+                f"lateral_context=False but multiscale_count={self.multiscale_count} "
+                f"> 1. Set multiscale_count=1 when lateral_context is disabled."
+            )
+        return self
+
+    def sample_alphas(self, n_channels: int, rng: Any | None = None) -> list[float]:
+        """Sample per-channel alpha weights.
+
+        Parameters
+        ----------
+        n_channels : int
+            Number of channels.
+        rng : numpy.random.Generator or None
+            Optional RNG for reproducibility. Uses ``numpy.random`` module-level
+            functions when ``None``.
+
+        Returns
+        -------
+        list of float
+            Alpha weight for each channel.
+        """
+        import numpy as np
+
+        if self.alpha_range is None:
+            return [1.0 / n_channels] * n_channels
+
+        start, end = self.alpha_range
+        if rng is not None:
+            return [float(rng.uniform(start, end)) for _ in range(n_channels)]
+        return [float(np.random.uniform(start, end)) for _ in range(n_channels)]

--- a/src/careamics/config/data/ng_microsplit_config.py
+++ b/src/careamics/config/data/ng_microsplit_config.py
@@ -26,48 +26,6 @@ class MicroSplitDataConfig(NGDataConfig):
       background while another contains signal, mimicking the partially-labelled
       regime described in the MicroSplit paper.
 
-    Parameters
-    ----------
-    lateral_context : bool
-        If ``True``, the input extractor is built with
-        ``lateral_context_patch_constr`` so that each extracted patch has the
-        shape ``(C, L, (Z), Y, X)`` where ``L == multiscale_count``.
-    multiscale_count : int
-        Number of LC levels including the full-resolution level (level 0).
-        Only used when ``lateral_context=True``. Must satisfy
-        ``multiscale_count >= 1``.
-    padding_mode : {"reflect", "wrap"}
-        Padding mode passed to ``lateral_context_patch_constr`` for handling
-        patch boundaries. Corresponds to legacy ``padding_kwargs["mode"]``.
-    input_is_sum : bool
-        If ``True`` the alpha-weighted channel average is multiplied by the
-        number of channels to obtain the sum rather than the average.
-        Corresponds to the legacy ``input_is_sum`` flag.
-    alpha_range : tuple of (float, float) or None
-        Per-channel alpha sampling range ``(start, end)``.  At each
-        ``__getitem__`` call each channel's weight is drawn uniformly from this
-        range.  ``None`` means equal weights ``1 / num_channels``.
-    mix_uncorrelated_channels : bool
-        If ``True``, apply uncorrelated-channel augmentation during training.
-        Channels 1…C-1 are drawn from random spatial locations with probability
-        ``uncorrelated_channel_probab``.
-    uncorrelated_channel_probab : float
-        Probability of applying the uncorrelated-channel swap on any given
-        sample.  Only relevant when ``mix_uncorrelated_channels=True``.
-    empty_patch_mixing : bool
-        If ``True``, use ``get_empty_channel_patches`` to enforce that selected
-        channels either contain signal or background (controlled by
-        ``empty_signal_channels`` / ``empty_background_channels``).
-    empty_signal_channels : list of int or None
-        Channel indices that must contain signal patches (not filtered out).
-        Only used when ``empty_patch_mixing=True``.
-    empty_background_channels : list of int or None
-        Channel indices that must be background (empty) patches.
-        Only used when ``empty_patch_mixing=True``.
-    empty_patch_patience : int
-        Number of random patch candidates to try before giving up when looking
-        for a patch satisfying the empty/signal criterion.
-
     Notes
     -----
     Model-side cross-validation (e.g. confirming ``multiscale_count`` matches
@@ -117,7 +75,13 @@ class MicroSplitDataConfig(NGDataConfig):
 
     @model_validator(mode="after")
     def _validate_alpha_range(self) -> MicroSplitDataConfig:
-        """Validate alpha_range is ordered and within [0, 1]."""
+        """Validate alpha_range is ordered and within [0, 1].
+
+        Returns
+        -------
+        MicroSplitDataConfig
+            The validated configuration instance.
+        """
         if self.alpha_range is not None:
             start, end = self.alpha_range
             if start < 0.0 or end > 1.0:
@@ -130,7 +94,13 @@ class MicroSplitDataConfig(NGDataConfig):
 
     @model_validator(mode="after")
     def _validate_empty_patch_channels(self) -> MicroSplitDataConfig:
-        """Validate that signal and background channel sets do not overlap."""
+        """Validate that signal and background channel sets do not overlap.
+
+        Returns
+        -------
+        MicroSplitDataConfig
+            The validated configuration instance.
+        """
         if not self.empty_patch_mixing:
             return self
         signal = set(self.empty_signal_channels or [])
@@ -145,7 +115,13 @@ class MicroSplitDataConfig(NGDataConfig):
 
     @model_validator(mode="after")
     def _validate_lateral_context_needs_multiscale(self) -> MicroSplitDataConfig:
-        """Warn (or fail) if lateral_context is False but multiscale_count > 1."""
+        """Validate lateral-context consistency with multiscale_count.
+
+        Returns
+        -------
+        MicroSplitDataConfig
+            The validated configuration instance.
+        """
         if not self.lateral_context and self.multiscale_count > 1:
             raise ValueError(
                 f"lateral_context=False but multiscale_count={self.multiscale_count} "

--- a/src/careamics/config/data/ng_microsplit_config.py
+++ b/src/careamics/config/data/ng_microsplit_config.py
@@ -35,9 +35,6 @@ class MicroSplitDataConfig(NGDataConfig):
     """
 
     #  LC parameters
-    lateral_context: bool = Field(default=True)
-    """Enable lateral-context multi-scale patch construction."""
-
     multiscale_count: int = Field(default=3, ge=1)
     """Number of LC levels (including full-resolution level 0)."""
 
@@ -110,22 +107,6 @@ class MicroSplitDataConfig(NGDataConfig):
             raise ValueError(
                 f"Channels {overlap} appear in both empty_signal_channels and "
                 f"empty_background_channels. A channel cannot be both."
-            )
-        return self
-
-    @model_validator(mode="after")
-    def _validate_lateral_context_needs_multiscale(self) -> MicroSplitDataConfig:
-        """Validate lateral-context consistency with multiscale_count.
-
-        Returns
-        -------
-        MicroSplitDataConfig
-            The validated configuration instance.
-        """
-        if not self.lateral_context and self.multiscale_count > 1:
-            raise ValueError(
-                f"lateral_context=False but multiscale_count={self.multiscale_count} "
-                f"> 1. Set multiscale_count=1 when lateral_context is disabled."
             )
         return self
 

--- a/src/careamics/dataset_ng/demos/microsplit_comparison.ipynb
+++ b/src/careamics/dataset_ng/demos/microsplit_comparison.ipynb
@@ -1,0 +1,211 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "import matplotlib.pyplot as plt\n",
+        "import numpy as np\n",
+        "import tifffile\n",
+        "import pooch\n",
+        "\n",
+        "from careamics.config.data.ng_data_config import NGDataConfig\n",
+        "from careamics.config.data.normalization_config import MeanStdConfig\n",
+        "from careamics.config.data.patching_strategies import RandomPatchingConfig\n",
+        "from careamics.dataset_ng.microsplit_dataset import MicroSplitDataset\n",
+        "from careamics.dataset_ng.patching_strategies import FixedPatchingStrategy\n",
+        "from careamics.lvae_training.dataset import LCMultiChDloader, MicroSplitDataConfig\n",
+        "from careamics.lvae_training.dataset.types import DataSplitType, DataType, TilingMode"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "DATA = pooch.create(\n",
+        "    path=\"./data/\",\n",
+        "    base_url=\"https://download.fht.org/jug/msplit/ht_lif24/data_tiff/\",\n",
+        "    registry={\"ht_lif24_5ms_reduced.zip\": None},\n",
+        ")\n",
+        "for fname in DATA.registry:\n",
+        "    DATA.fetch(fname, processor=pooch.Unzip(), progressbar=True)\n",
+        "\n",
+        "DATA_PATH = DATA.abspath / (DATA.registry_files[0] + \".unzip/5ms/data/\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "ch0_files = sorted((DATA_PATH / \"microtubules\").glob(\"*.tiff\"))\n",
+        "ch1_files = sorted((DATA_PATH / \"nucleus\").glob(\"*.tiff\"))\n",
+        "rng = np.random.default_rng(42)\n",
+        "ch0_path = ch0_files[int(rng.integers(len(ch0_files)))]\n",
+        "ch1_path = ch1_files[int(rng.integers(len(ch1_files)))]\n",
+        "stack_ch0 = tifffile.imread(ch0_path).astype(np.float32)\n",
+        "stack_ch1 = tifffile.imread(ch1_path).astype(np.float32)\n",
+        "slice_idx = int(rng.integers(stack_ch0.shape[0]))\n",
+        "img_ch0 = stack_ch0[slice_idx]\n",
+        "img_ch1 = stack_ch1[slice_idx]\n",
+        "print(f\"ch0={ch0_path.name} ch1={ch1_path.name} slice={slice_idx} shape={img_ch0.shape}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "img_ch0 = img_ch0[np.newaxis]\n",
+        "img_ch1 = img_ch1[np.newaxis]\n",
+        "\n",
+        "nhwc = np.stack([img_ch0, img_ch1], axis=-1)\n",
+        "scyx = nhwc.transpose(0, 3, 1, 2).copy()\n",
+        "\n",
+        "PATCH = 64\n",
+        "MULTISCALE = 3"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def load_data_fn(data_config, datapath, datasplit_type, **kwargs):\n",
+        "    return nhwc\n",
+        "\n",
+        "old_config = MicroSplitDataConfig(\n",
+        "    data_type=DataType.HTLIF24Data,\n",
+        "    axes=\"SYX\",\n",
+        "    image_size=(PATCH, PATCH),\n",
+        "    grid_size=PATCH,\n",
+        "    num_channels=2,\n",
+        "    batch_size=1,\n",
+        "    datasplit_type=DataSplitType.Train,\n",
+        "    multiscale_lowres_count=MULTISCALE,\n",
+        "    tiling_mode=TilingMode.ShiftBoundary,\n",
+        "    enable_random_cropping=False,\n",
+        "    target_separate_normalization=True,\n",
+        "    train_dataloader_params={\"num_workers\": 0, \"shuffle\": True},\n",
+        "    val_dataloader_params={\"num_workers\": 0},\n",
+        ")\n",
+        "\n",
+        "old_dset = LCMultiChDloader(\n",
+        "    data_config=old_config,\n",
+        "    datapath=Path(\"/synthetic\"),\n",
+        "    load_data_fn=load_data_fn,\n",
+        ")\n",
+        "mean_d, std_d = old_dset.compute_mean_std()\n",
+        "old_dset.set_mean_std(mean_d, std_d)\n",
+        "old_inp, old_tgt = old_dset[0]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fixed_spec = {\n",
+        "    \"data_idx\": 0,\n",
+        "    \"sample_idx\": 0,\n",
+        "    \"coords\": [0, 0],\n",
+        "    \"patch_size\": [PATCH, PATCH],\n",
+        "}\n",
+        "\n",
+        "new_config = NGDataConfig(\n",
+        "    mode=\"training\",\n",
+        "    data_type=\"array\",\n",
+        "    axes=\"SCYX\",\n",
+        "    patching=RandomPatchingConfig(patch_size=[PATCH, PATCH], seed=1),\n",
+        "    normalization=MeanStdConfig(per_channel=True),\n",
+        "    batch_size=1,\n",
+        "    augmentations=[],\n",
+        "    train_dataloader_params={\"shuffle\": True, \"num_workers\": 0},\n",
+        ")\n",
+        "\n",
+        "new_dset = MicroSplitDataset(\n",
+        "    data_config=new_config,\n",
+        "    train_data=scyx,\n",
+        "    multiscale_count=MULTISCALE,\n",
+        "    padding_mode=\"reflect\",\n",
+        "    input_is_sum=False,\n",
+        "    mix_uncorrelated_channels=False,\n",
+        "    patching_strategy=FixedPatchingStrategy([fixed_spec]),\n",
+        "    seed=1,\n",
+        ")\n",
+        "\n",
+        "new_inp_region, new_tgt_region = new_dset[0]\n",
+        "new_inp = new_inp_region.data\n",
+        "new_tgt = new_tgt_region.data"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig, axes = plt.subplots(2, MULTISCALE + 2, figsize=(4 * (MULTISCALE + 2), 8))\n",
+        "\n",
+        "for scale in range(MULTISCALE):\n",
+        "    axes[0, scale].imshow(old_inp[scale], cmap=\"gray\")\n",
+        "    axes[0, scale].set_title(f\"Old  inp  scale {scale}\")\n",
+        "    axes[0, scale].axis(\"off\")\n",
+        "\n",
+        "    axes[1, scale].imshow(new_inp[scale], cmap=\"gray\")\n",
+        "    axes[1, scale].set_title(f\"New  inp  scale {scale}\")\n",
+        "    axes[1, scale].axis(\"off\")\n",
+        "\n",
+        "for ch in range(2):\n",
+        "    axes[0, MULTISCALE + ch].imshow(old_tgt[ch], cmap=\"gray\")\n",
+        "    axes[0, MULTISCALE + ch].set_title(f\"Old  tgt  ch{ch}\")\n",
+        "    axes[0, MULTISCALE + ch].axis(\"off\")\n",
+        "\n",
+        "    axes[1, MULTISCALE + ch].imshow(new_tgt[ch], cmap=\"gray\")\n",
+        "    axes[1, MULTISCALE + ch].set_title(f\"New  tgt  ch{ch}\")\n",
+        "    axes[1, MULTISCALE + ch].axis(\"off\")\n",
+        "\n",
+        "plt.tight_layout()\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}

--- a/src/careamics/dataset_ng/demos/microsplit_comparison.ipynb
+++ b/src/careamics/dataset_ng/demos/microsplit_comparison.ipynb
@@ -83,6 +83,10 @@
         "def load_data_fn(data_config, datapath, datasplit_type, **kwargs):\n",
         "    return nhwc\n",
         "\n",
+        "patch_seed = 17\n",
+        "np.random.seed(patch_seed)\n",
+        "coords = [int(np.random.choice(img_ch0.shape[-2] - PATCH)), int(np.random.choice(img_ch0.shape[-1] - PATCH))]\n",
+        "\n",
         "old_config = MicroSplitDataConfig(\n",
         "    data_type=DataType.HTLIF24Data,\n",
         "    axes=\"SYX\",\n",
@@ -93,7 +97,7 @@
         "    datasplit_type=DataSplitType.Train,\n",
         "    multiscale_lowres_count=MULTISCALE,\n",
         "    tiling_mode=TilingMode.ShiftBoundary,\n",
-        "    enable_random_cropping=False,\n",
+        "    enable_random_cropping=True,\n",
         "    target_separate_normalization=True,\n",
         "    train_dataloader_params={\"num_workers\": 0, \"shuffle\": True},\n",
         "    val_dataloader_params={\"num_workers\": 0},\n",
@@ -106,7 +110,9 @@
         ")\n",
         "mean_d, std_d = old_dset.compute_mean_std()\n",
         "old_dset.set_mean_std(mean_d, std_d)\n",
-        "old_inp, old_tgt = old_dset[0]"
+        "np.random.seed(patch_seed)\n",
+        "old_inp, old_tgt = old_dset[0]\n",
+        "coords"
       ]
     },
     {
@@ -118,7 +124,7 @@
         "fixed_spec = {\n",
         "    \"data_idx\": 0,\n",
         "    \"sample_idx\": 0,\n",
-        "    \"coords\": [0, 0],\n",
+        "    \"coords\": coords,\n",
         "    \"patch_size\": [PATCH, PATCH],\n",
         "}\n",
         "\n",
@@ -155,6 +161,31 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "old_input_mean = float(mean_d[\"input\"].mean())\n",
+        "old_input_std = float(std_d[\"input\"].mean())\n",
+        "old_target_mean = mean_d[\"target\"].squeeze().astype(float)\n",
+        "old_target_std = std_d[\"target\"].squeeze().astype(float)\n",
+        "new_input_mean = np.array(new_dset._norm_input.input_means, dtype=float)\n",
+        "new_input_std = np.array(new_dset._norm_input.input_stds, dtype=float)\n",
+        "new_target_mean = np.array(new_dset._norm_target.input_means, dtype=float)\n",
+        "new_target_std = np.array(new_dset._norm_target.input_stds, dtype=float)\n",
+        "\n",
+        "print(\"coords\", coords)\n",
+        "print(\"input mean\", old_input_mean, new_input_mean)\n",
+        "print(\"input std\", old_input_std, new_input_std)\n",
+        "print(\"target mean\", old_target_mean, new_target_mean)\n",
+        "print(\"target std\", old_target_std, new_target_std)\n",
+        "print(\"stats close\", np.allclose(old_input_mean, new_input_mean), np.allclose(old_input_std, new_input_std), np.allclose(old_target_mean, new_target_mean), np.allclose(old_target_std, new_target_std))\n",
+        "print(\"max abs input diff\", [float(np.max(np.abs(old_inp[s] - new_inp[s]))) for s in range(MULTISCALE)])\n",
+        "print(\"max abs target diff\", [float(np.max(np.abs(old_tgt[c] - new_tgt[c]))) for c in range(2)])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
         "fig, axes = plt.subplots(2, MULTISCALE + 2, figsize=(4 * (MULTISCALE + 2), 8))\n",
         "\n",
         "for scale in range(MULTISCALE):\n",
@@ -177,6 +208,18 @@
         "\n",
         "plt.tight_layout()\n",
         "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "_, ax = plt.subplots(1, 3)\n",
+        "\n",
+        "for scale in range(MULTISCALE):\n",
+        "    ax[scale].imshow(old_inp[scale] - new_inp[scale])"
       ]
     },
     {

--- a/src/careamics/dataset_ng/microsplit_dataset.py
+++ b/src/careamics/dataset_ng/microsplit_dataset.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any, Literal
+from typing import Literal
 
 import numpy as np
 from numpy.typing import NDArray
@@ -12,15 +11,16 @@ from torch.utils.data import Dataset
 from careamics.config.data.ng_data_config import NGDataConfig
 from careamics.dataset_ng.dataset import ImageRegionData, _adjust_shape_for_channels
 from careamics.dataset_ng.image_stack import InMemoryImageStack
-from careamics.dataset_ng.normalization.mean_std_normalization import MeanStdNormalization
+from careamics.dataset_ng.normalization.mean_std_normalization import (
+    MeanStdNormalization,
+)
 from careamics.dataset_ng.patch_extractor import PatchExtractor
 from careamics.dataset_ng.patch_extractor.patch_construction import (
     lateral_context_patch_constr,
 )
 from careamics.dataset_ng.patching_strategies import (
-    FixedPatchingStrategy,
-    PatchSpecs,
     PatchingStrategy,
+    PatchSpecs,
     RandomPatchingStrategy,
 )
 from careamics.transforms import Compose
@@ -88,7 +88,32 @@ class MicroSplitDataset(Dataset):
         patching_strategy: PatchingStrategy | None = None,
         seed: int | None = None,
     ) -> None:
-        """Constructor — see class docstring for parameter descriptions."""
+        """Initialize the MicroSplit dataset.
+
+        Parameters
+        ----------
+        data_config : NGDataConfig
+            Base dataset configuration (mode, axes, patching, augmentations).
+        train_data : NDArray
+            Array of shape ``(S, C, Y, X)`` in SC(Z)YX order.
+        multiscale_count : int, default=1
+            Number of lateral-context scales, including the full-resolution level.
+        padding_mode : {"reflect", "wrap"}, default="reflect"
+            Boundary padding mode used by ``lateral_context_patch_constr``.
+        input_is_sum : bool, default=False
+            If ``True``, multiply alpha-averaged input by ``C``.
+        mix_uncorrelated_channels : bool, default=False
+            Whether to sample channels 1...C-1 from independent patch locations.
+        uncorrelated_channel_probab : float, default=0.5
+            Probability of applying uncorrelated channel sampling.
+        alpha_range : tuple[float, float] | None, default=None
+            Uniform sampling range for per-channel alphas. ``None`` gives equal
+            weights.
+        patching_strategy : PatchingStrategy | None, default=None
+            Optional strategy override. If ``None``, one is built from config.
+        seed : int | None, default=None
+            RNG seed used for patching (when built here) and runtime sampling.
+        """
         super().__init__()
 
         self.config = data_config
@@ -113,9 +138,14 @@ class MicroSplitDataset(Dataset):
         if patching_strategy is not None:
             self.patching_strategy: PatchingStrategy = patching_strategy
         else:
+            patch_size = getattr(data_config.patching, "patch_size", None)
+            if patch_size is None:
+                raise ValueError(
+                    "MicroSplitDataset requires a patching config with patch_size."
+                )
             self.patching_strategy = RandomPatchingStrategy(
                 data_shapes=[image_stack.data_shape],
-                patch_size=list(data_config.patching.patch_size),
+                patch_size=list(patch_size),
                 seed=seed if seed is not None else getattr(data_config, "seed", None),
             )
 
@@ -164,9 +194,7 @@ class MicroSplitDataset(Dataset):
         from careamics.config.data.ng_data_config import Mode
 
         if data_config.mode == Mode.TRAINING:
-            self.transforms: Compose | None = Compose(
-                list(data_config.augmentations)
-            )
+            self.transforms: Compose | None = Compose(list(data_config.augmentations))
         else:
             self.transforms = Compose([])
 
@@ -182,9 +210,7 @@ class MicroSplitDataset(Dataset):
         """
         return self.patching_strategy.n_patches
 
-    def __getitem__(
-        self, index: int
-    ) -> tuple[ImageRegionData, ImageRegionData]:
+    def __getitem__(self, index: int) -> tuple[ImageRegionData, ImageRegionData]:
         """Return a ``(input_region, target_region)`` pair.
 
         Parameters
@@ -215,9 +241,7 @@ class MicroSplitDataset(Dataset):
         # Alpha superposition along C → input (L, (Z), Y, X)
         alphas = self._sample_alphas()
         n_extra_dims = len(patches.shape) - 1  # all dims except C
-        alpha_bc = np.array(alphas)[
-            :, *(np.newaxis for _ in range(n_extra_dims))
-        ]
+        alpha_bc = np.array(alphas)[:, *(np.newaxis for _ in range(n_extra_dims))]
         input_patch = (alpha_bc * patches).sum(axis=0).astype(np.float32)
 
         if self.input_is_sum:
@@ -230,8 +254,8 @@ class MicroSplitDataset(Dataset):
         input_patch, _ = self._norm_input(input_patch)
         target_patch, _ = self._norm_target(target_patch)
 
-        # Augmentation (operates on C(Z)YX arrays; skip for input since it's L(Z)YX).
-        # TODO: apply augmentation to input/target jointly when transforms expect C(Z)YX.
+        # Augmentation operates on C(Z)YX arrays. Input is L(Z)YX.
+        # TODO: apply augmentation jointly when transforms expect C(Z)YX.
 
         # Wrap into ImageRegionData.
         input_region = self._make_image_region(input_patch, primary_spec)
@@ -289,7 +313,7 @@ class MicroSplitDataset(Dataset):
         for rand_idx in random_indices:
             specs.append(self.patching_strategy.get_patch_spec(int(rand_idx)))
 
-        channel_patches = []
+        channel_patches: list[NDArray] = []
         for spec in specs:
             ch_patch = self.input_extractor.extract_patch(
                 data_idx=spec["data_idx"],
@@ -298,7 +322,9 @@ class MicroSplitDataset(Dataset):
                 patch_size=spec["patch_size"],
             )
             # ch_patch: (C, L, (Z), Y, X) — take one channel
-            channel_patches.append(ch_patch[len(channel_patches) : len(channel_patches) + 1])
+            channel_patches.append(
+                ch_patch[len(channel_patches) : len(channel_patches) + 1]
+            )
 
         return np.concatenate(channel_patches, axis=0), specs
 

--- a/src/careamics/dataset_ng/microsplit_dataset.py
+++ b/src/careamics/dataset_ng/microsplit_dataset.py
@@ -1,0 +1,349 @@
+"""MicroSplit dataset: CareamicsDataset subclass for LVAE channel-separation models."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Literal
+
+import numpy as np
+from numpy.typing import NDArray
+from torch.utils.data import Dataset
+
+from careamics.config.data.ng_data_config import NGDataConfig
+from careamics.dataset_ng.dataset import ImageRegionData, _adjust_shape_for_channels
+from careamics.dataset_ng.image_stack import InMemoryImageStack
+from careamics.dataset_ng.normalization.mean_std_normalization import MeanStdNormalization
+from careamics.dataset_ng.patch_extractor import PatchExtractor
+from careamics.dataset_ng.patch_extractor.patch_construction import (
+    lateral_context_patch_constr,
+)
+from careamics.dataset_ng.patching_strategies import (
+    FixedPatchingStrategy,
+    PatchSpecs,
+    PatchingStrategy,
+    RandomPatchingStrategy,
+)
+from careamics.transforms import Compose
+
+
+class MicroSplitDataset(Dataset):
+    """Dataset for MicroSplit (LVAE) channel-separation training.
+
+    This dataset implements the MicroSplit input synthesis pipeline:
+
+    1. Multi-channel fluorescence images are loaded into a single image stack.
+    2. A multi-scale lateral-context (LC) patch is extracted for each channel.
+    3. Channels are combined via alpha-weighted superposition to create the
+       synthetic input (mimicking a multi-channel microscope observation).
+    4. Target is the full-resolution patch per channel.
+    5. Input and target are normalized separately (one-mu-std for input,
+       per-channel for target), matching the legacy ``LCMultiChDloader``.
+
+    This class intentionally does **not** call ``CareamicsDataset.__init__``:
+    the normalization and patch-extraction pipelines differ fundamentally from
+    the standard single-channel workflow, so a composition approach is used
+    while still inheriting the ``ImageRegionData`` type contract.
+
+    Parameters
+    ----------
+    data_config : NGDataConfig
+        Base dataset configuration (mode, axes, augmentations, etc.).
+    train_data : numpy.ndarray
+        Array of shape ``(S, C, Y, X)`` in SC(Z)YX order, where S is the
+        number of samples and C is the number of channels.
+    multiscale_count : int
+        Number of LC scales to produce, including the full-resolution level.
+    padding_mode : {"reflect", "wrap"}
+        Boundary padding mode for the LC patch constructor.
+    input_is_sum : bool
+        If ``True``, multiply the alpha-averaged input by ``C`` to get the sum.
+    mix_uncorrelated_channels : bool
+        If ``True``, channels 1…C-1 are independently sampled from random
+        locations on each ``__getitem__`` call with probability
+        ``uncorrelated_channel_probab``.
+    uncorrelated_channel_probab : float
+        Probability of applying the uncorrelated-channel swap. Only relevant
+        when ``mix_uncorrelated_channels=True``.
+    alpha_range : tuple of (float, float) or None
+        Uniform sampling range ``(start, end)`` for per-channel alpha weights.
+        ``None`` → equal weights ``1 / C``.
+    patching_strategy : PatchingStrategy or None, optional
+        If provided, overrides the patching strategy derived from the config.
+        Useful for testing with a ``FixedPatchingStrategy``.
+    seed : int or None, optional
+        Random seed for the internal RNG (uncorrelated sampling, alpha). When
+        ``None`` the config seed is used if available.
+    """
+
+    def __init__(
+        self,
+        data_config: NGDataConfig,
+        train_data: NDArray,
+        multiscale_count: int = 1,
+        padding_mode: Literal["reflect", "wrap"] = "reflect",
+        input_is_sum: bool = False,
+        mix_uncorrelated_channels: bool = False,
+        uncorrelated_channel_probab: float = 0.5,
+        alpha_range: tuple[float, float] | None = None,
+        patching_strategy: PatchingStrategy | None = None,
+        seed: int | None = None,
+    ) -> None:
+        """Constructor — see class docstring for parameter descriptions."""
+        super().__init__()
+
+        self.config = data_config
+
+        # ── Image stack ───────────────────────────────────────────────────────
+        # train_data is expected in SC(Z)YX order (e.g. SCYX for 2-D).
+        image_stack = InMemoryImageStack(
+            source="array",
+            data=train_data,
+            original_axes=data_config.axes,
+            original_data_shape=train_data.shape,
+        )
+        self._image_stack = image_stack
+
+        # ── Patch extractor with lateral-context constructor ──────────────────
+        lc_constructor = lateral_context_patch_constr(multiscale_count, padding_mode)
+        self.input_extractor: PatchExtractor[InMemoryImageStack] = PatchExtractor(
+            [image_stack], patch_constructor=lc_constructor
+        )
+
+        # ── Patching strategy ─────────────────────────────────────────────────
+        if patching_strategy is not None:
+            self.patching_strategy: PatchingStrategy = patching_strategy
+        else:
+            self.patching_strategy = RandomPatchingStrategy(
+                data_shapes=[image_stack.data_shape],
+                patch_size=list(data_config.patching.patch_size),
+                seed=seed if seed is not None else getattr(data_config, "seed", None),
+            )
+
+        # ── Normalization statistics ──────────────────────────────────────────
+        # Compute directly from the raw array (mirrors compute_mean_std in
+        # the legacy MultiChDloader with target_separate_normalization=True,
+        # use_one_mu_std=True, input_is_sum=False).
+        raw = train_data.astype(np.float64)  # use float64 for stat precision
+        n_channels = train_data.shape[1]
+
+        # Input: global mean/std across all samples, all channels, all pixels.
+        global_mean = float(raw.mean())
+        global_std = float(raw.std())
+
+        # Target: per-channel mean/std (channel is axis 1 in SCYX).
+        per_ch_means = [float(raw[:, c, ...].mean()) for c in range(n_channels)]
+        per_ch_stds = [float(raw[:, c, ...].std()) for c in range(n_channels)]
+
+        # For the input (L, H, W) array, `n_channels = L` in MeanStdNormalization.
+        # Using a length-1 list means the single stat is broadcast across all L.
+        self._norm_input = MeanStdNormalization(
+            input_means=[global_mean],
+            input_stds=[global_std],
+        )
+        # Target normalization is per-channel (length == C, one stat per channel).
+        self._norm_target = MeanStdNormalization(
+            input_means=per_ch_means,
+            input_stds=per_ch_stds,
+        )
+
+        # ── LC / mixing parameters ────────────────────────────────────────────
+        self.multiscale_count = multiscale_count
+        self.padding_mode = padding_mode
+        self.input_is_sum = input_is_sum
+        self.mix_uncorrelated_channels = mix_uncorrelated_channels
+        self.uncorrelated_channel_probab = uncorrelated_channel_probab
+        self.alpha_range = alpha_range
+        self._n_channels = n_channels
+
+        # Internal RNG (used for uncorrelated sampling and alpha draws).
+        _seed = seed if seed is not None else getattr(data_config, "seed", None)
+        self._rng = np.random.default_rng(seed=_seed)
+
+        # ── Augmentations ─────────────────────────────────────────────────────
+        # Reuse the Compose pipeline from the config (training mode only).
+        from careamics.config.data.ng_data_config import Mode
+
+        if data_config.mode == Mode.TRAINING:
+            self.transforms: Compose | None = Compose(
+                list(data_config.augmentations)
+            )
+        else:
+            self.transforms = Compose([])
+
+    # ── Protocol ──────────────────────────────────────────────────────────────
+
+    def __len__(self) -> int:
+        """Number of patches in the dataset.
+
+        Returns
+        -------
+        int
+            Equal to ``patching_strategy.n_patches``.
+        """
+        return self.patching_strategy.n_patches
+
+    def __getitem__(
+        self, index: int
+    ) -> tuple[ImageRegionData, ImageRegionData]:
+        """Return a ``(input_region, target_region)`` pair.
+
+        Parameters
+        ----------
+        index : int
+            Dataset index; routed through the patching strategy.
+
+        Returns
+        -------
+        tuple of ImageRegionData
+            ``(input_region, target_region)`` where:
+            - ``input_region.data`` has shape ``(L, (Z), Y, X)``
+            - ``target_region.data`` has shape ``(C, (Z), Y, X)``
+        """
+        patch_spec = self.patching_strategy.get_patch_spec(index)
+
+        if (
+            self.mix_uncorrelated_channels
+            and self._rng.random() < self.uncorrelated_channel_probab
+        ):
+            patches, patch_specs = self._get_uncorrelated_patches(index, patch_spec)
+            primary_spec = patch_specs[0]
+        else:
+            patches = self._extract_lc_patch(patch_spec)
+            primary_spec = patch_spec
+
+        # patches shape: (C, L, (Z), Y, X)
+        # Alpha superposition along C → input (L, (Z), Y, X)
+        alphas = self._sample_alphas()
+        n_extra_dims = len(patches.shape) - 1  # all dims except C
+        alpha_bc = np.array(alphas)[
+            :, *(np.newaxis for _ in range(n_extra_dims))
+        ]
+        input_patch = (alpha_bc * patches).sum(axis=0).astype(np.float32)
+
+        if self.input_is_sum:
+            input_patch = input_patch * self._n_channels
+
+        # Target: first LC level (full-res) for each channel → (C, (Z), Y, X)
+        target_patch = patches[:, 0, ...].astype(np.float32)
+
+        # Normalization (applies in-place style via callable).
+        input_patch, _ = self._norm_input(input_patch)
+        target_patch, _ = self._norm_target(target_patch)
+
+        # Augmentation (operates on C(Z)YX arrays; skip for input since it's L(Z)YX).
+        # TODO: apply augmentation to input/target jointly when transforms expect C(Z)YX.
+
+        # Wrap into ImageRegionData.
+        input_region = self._make_image_region(input_patch, primary_spec)
+        target_region = self._make_image_region(target_patch, primary_spec)
+
+        return input_region, target_region
+
+    # ── Internal helpers ───────────────────────────────────────────────────────
+
+    def _extract_lc_patch(self, patch_spec: PatchSpecs) -> NDArray:
+        """Extract an ``(C, L, (Z), Y, X)`` LC patch for all channels.
+
+        Parameters
+        ----------
+        patch_spec : PatchSpecs
+            Patch specification returned by the patching strategy.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of shape ``(C, L, (Z), Y, X)``.
+        """
+        return self.input_extractor.extract_patch(
+            data_idx=patch_spec["data_idx"],
+            sample_idx=patch_spec["sample_idx"],
+            coords=patch_spec["coords"],
+            patch_size=patch_spec["patch_size"],
+        )
+
+    def _get_uncorrelated_patches(
+        self, idx: int, primary_spec: PatchSpecs
+    ) -> tuple[NDArray, list[PatchSpecs]]:
+        """Sample patches where each channel uses an independent spatial location.
+
+        Channel 0 always uses ``idx``; channels 1…C-1 use random indices.
+
+        Parameters
+        ----------
+        idx : int
+            Dataset index for channel 0.
+        primary_spec : PatchSpecs
+            Pre-computed patch spec for channel 0.
+
+        Returns
+        -------
+        patches : numpy.ndarray
+            Shape ``(C, L, (Z), Y, X)``.
+        patch_specs : list of PatchSpecs
+            One spec per channel.
+        """
+        n_patches = self.patching_strategy.n_patches
+        random_indices = self._rng.integers(n_patches, size=(self._n_channels - 1,))
+
+        specs: list[PatchSpecs] = [primary_spec]
+        for rand_idx in random_indices:
+            specs.append(self.patching_strategy.get_patch_spec(int(rand_idx)))
+
+        channel_patches = []
+        for spec in specs:
+            ch_patch = self.input_extractor.extract_patch(
+                data_idx=spec["data_idx"],
+                sample_idx=spec["sample_idx"],
+                coords=spec["coords"],
+                patch_size=spec["patch_size"],
+            )
+            # ch_patch: (C, L, (Z), Y, X) — take one channel
+            channel_patches.append(ch_patch[len(channel_patches) : len(channel_patches) + 1])
+
+        return np.concatenate(channel_patches, axis=0), specs
+
+    def _sample_alphas(self) -> list[float]:
+        """Sample per-channel alpha weights.
+
+        Returns
+        -------
+        list of float
+            Length ``n_channels``.
+        """
+        if self.alpha_range is None:
+            return [1.0 / self._n_channels] * self._n_channels
+        start, end = self.alpha_range
+        return [float(self._rng.uniform(start, end)) for _ in range(self._n_channels)]
+
+    def _make_image_region(
+        self, data: NDArray, patch_spec: PatchSpecs
+    ) -> ImageRegionData:
+        """Wrap a patch array and its spec into an ``ImageRegionData``.
+
+        Parameters
+        ----------
+        data : numpy.ndarray
+            Patch data in ``(L, (Z), Y, X)`` or ``(C, (Z), Y, X)`` format.
+        patch_spec : PatchSpecs
+            Patch specification (used for metadata).
+
+        Returns
+        -------
+        ImageRegionData
+            Named tuple with all metadata fields populated.
+        """
+        image_stack = self._image_stack
+        data_shape = _adjust_shape_for_channels(
+            shape=image_stack.data_shape,
+            channels=self.config.channels,
+        )
+        return ImageRegionData(
+            data=data,
+            source=str(image_stack.source),
+            data_shape=data_shape,
+            dtype=str(image_stack.data_dtype),
+            axes=self.config.axes,
+            original_data_shape=image_stack.original_data_shape,
+            region_spec=patch_spec,
+            additional_metadata={},
+        )

--- a/src/careamics/dataset_ng/microsplit_dataset.py
+++ b/src/careamics/dataset_ng/microsplit_dataset.py
@@ -27,22 +27,23 @@ from careamics.transforms import Compose
 
 
 class MicroSplitDataset(Dataset):
-    """Dataset for MicroSplit (LVAE) channel-separation training.
+    """Dataset for MicroSplit channel-separation training.
 
-    This dataset implements the MicroSplit input synthesis pipeline:
-
-    1. Multi-channel fluorescence images are loaded into a single image stack.
+    1. Multi-channel images are loaded into a single image stack.
     2. A multi-scale lateral-context (LC) patch is extracted for each channel.
     3. Channels are combined via alpha-weighted superposition to create the
-       synthetic input (mimicking a multi-channel microscope observation).
+       synthetic input.
     4. Target is the full-resolution patch per channel.
     5. Input and target are normalized separately (one-mu-std for input,
        per-channel for target), matching the legacy ``LCMultiChDloader``.
 
-    This class intentionally does **not** call ``CareamicsDataset.__init__``:
+    This class intentionally does not call ``CareamicsDataset.__init__``:
     the normalization and patch-extraction pipelines differ fundamentally from
     the standard single-channel workflow, so a composition approach is used
     while still inheriting the ``ImageRegionData`` type contract.
+
+    Some parameters are left as is from the legacy ``LCMultiChDloader``, subject to
+    review and potential removal.
 
     Parameters
     ----------
@@ -118,7 +119,7 @@ class MicroSplitDataset(Dataset):
 
         self.config = data_config
 
-        # ── Image stack ───────────────────────────────────────────────────────
+        #  Image stack
         # train_data is expected in SC(Z)YX order (e.g. SCYX for 2-D).
         image_stack = InMemoryImageStack(
             source="array",
@@ -128,13 +129,13 @@ class MicroSplitDataset(Dataset):
         )
         self._image_stack = image_stack
 
-        # ── Patch extractor with lateral-context constructor ──────────────────
+        #  Patch extractor with lateral-context constructor
         lc_constructor = lateral_context_patch_constr(multiscale_count, padding_mode)
         self.input_extractor: PatchExtractor[InMemoryImageStack] = PatchExtractor(
             [image_stack], patch_constructor=lc_constructor
         )
 
-        # ── Patching strategy ─────────────────────────────────────────────────
+        #  Patching strategy
         if patching_strategy is not None:
             self.patching_strategy: PatchingStrategy = patching_strategy
         else:
@@ -149,7 +150,7 @@ class MicroSplitDataset(Dataset):
                 seed=seed if seed is not None else getattr(data_config, "seed", None),
             )
 
-        # ── Normalization statistics ──────────────────────────────────────────
+        #  Normalization statistics
         # Compute directly from the raw array (mirrors compute_mean_std in
         # the legacy MultiChDloader with target_separate_normalization=True,
         # use_one_mu_std=True, input_is_sum=False).
@@ -176,7 +177,7 @@ class MicroSplitDataset(Dataset):
             input_stds=per_ch_stds,
         )
 
-        # ── LC / mixing parameters ────────────────────────────────────────────
+        #  LC / mixing parameters
         self.multiscale_count = multiscale_count
         self.padding_mode = padding_mode
         self.input_is_sum = input_is_sum
@@ -189,7 +190,7 @@ class MicroSplitDataset(Dataset):
         _seed = seed if seed is not None else getattr(data_config, "seed", None)
         self._rng = np.random.default_rng(seed=_seed)
 
-        # ── Augmentations ─────────────────────────────────────────────────────
+        #  Augmentations
         # Reuse the Compose pipeline from the config (training mode only).
         from careamics.config.data.ng_data_config import Mode
 
@@ -198,7 +199,7 @@ class MicroSplitDataset(Dataset):
         else:
             self.transforms = Compose([])
 
-    # ── Protocol ──────────────────────────────────────────────────────────────
+    #  Protocol
 
     def __len__(self) -> int:
         """Number of patches in the dataset.
@@ -263,7 +264,7 @@ class MicroSplitDataset(Dataset):
 
         return input_region, target_region
 
-    # ── Internal helpers ───────────────────────────────────────────────────────
+    #  Internal helpers
 
     def _extract_lc_patch(self, patch_spec: PatchSpecs) -> NDArray:
         """Extract an ``(C, L, (Z), Y, X)`` LC patch for all channels.

--- a/src/careamics/lightning/dataset_ng/microsplit_data_module.py
+++ b/src/careamics/lightning/dataset_ng/microsplit_data_module.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pytorch_lightning as L
@@ -10,6 +10,7 @@ from numpy.typing import NDArray
 from torch.utils.data import DataLoader
 from torch.utils.data._utils.collate import default_collate
 
+from careamics.config.data.ng_data_config import NGDataConfig
 from careamics.config.data.ng_microsplit_config import MicroSplitDataConfig
 from careamics.dataset_ng.microsplit_dataset import MicroSplitDataset
 from careamics.lightning.dataset_ng.data_module import CareamicsDataModule
@@ -34,6 +35,9 @@ class MicroSplitDataModule(CareamicsDataModule):
         Validation array in ``(S, C, Y, X)`` order.  If ``None``, a random
         split of ``n_val_patches`` patches from the training data is used
         (requires stratified patching in config).
+    **kwargs : Any
+        Additional keyword arguments accepted for compatibility with the
+        ``CareamicsDataModule`` constructor.
     """
 
     def __init__(
@@ -107,11 +111,25 @@ class MicroSplitDataModule(CareamicsDataModule):
 
     def _setup_train_val(self) -> None:
         """Build train and validation ``MicroSplitDataset`` instances."""
-        cfg = self.config
+        cfg = cast(MicroSplitDataConfig, self.config)
 
         def _build_dataset(data: NDArray, mode_str: str) -> MicroSplitDataset:
-            """Build a MicroSplitDataset from an array with the given mode."""
+            """Build a dataset for a specific mode.
+
+            Parameters
+            ----------
+            data : NDArray
+                Array in ``(S, C, Y, X)`` order used to build the dataset.
+            mode_str : str
+                Either ``"training"`` or ``"validating"``.
+
+            Returns
+            -------
+            MicroSplitDataset
+                Configured dataset instance for the requested mode.
+            """
             # Create a mode-specific version of the config.
+            dataset_config: NGDataConfig
             if mode_str == "training":
                 dataset_config = cfg
             else:

--- a/src/careamics/lightning/dataset_ng/microsplit_data_module.py
+++ b/src/careamics/lightning/dataset_ng/microsplit_data_module.py
@@ -1,0 +1,170 @@
+"""MicroSplit Lightning DataModule for the NG dataset pipeline."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytorch_lightning as L
+from numpy.typing import NDArray
+from torch.utils.data import DataLoader
+from torch.utils.data._utils.collate import default_collate
+
+from careamics.config.data.ng_microsplit_config import MicroSplitDataConfig
+from careamics.dataset_ng.microsplit_dataset import MicroSplitDataset
+from careamics.lightning.dataset_ng.data_module import CareamicsDataModule
+
+
+class MicroSplitDataModule(CareamicsDataModule):
+    """Lightning DataModule for MicroSplit (LVAE) training.
+
+    Extends :class:`CareamicsDataModule` to create :class:`MicroSplitDataset`
+    instances instead of :class:`CareamicsDataset` when the configuration is a
+    :class:`MicroSplitDataConfig`.
+
+    All sampler / collate behaviour is inherited unchanged from the parent.
+
+    Parameters
+    ----------
+    data_config : MicroSplitDataConfig
+        MicroSplit-specific dataset configuration.
+    train_data : numpy.ndarray
+        Training array in ``(S, C, Y, X)`` order.
+    val_data : numpy.ndarray or None, optional
+        Validation array in ``(S, C, Y, X)`` order.  If ``None``, a random
+        split of ``n_val_patches`` patches from the training data is used
+        (requires stratified patching in config).
+    """
+
+    def __init__(
+        self,
+        data_config: MicroSplitDataConfig,
+        train_data: NDArray,
+        val_data: NDArray | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Constructor.
+
+        Parameters
+        ----------
+        data_config : MicroSplitDataConfig
+            Data configuration for MicroSplit training.
+        train_data : numpy.ndarray
+            Training array in ``(S, C, Y, X)`` order.
+        val_data : numpy.ndarray or None, optional
+            Validation array. If ``None``, validation patches are split from
+            training data using ``n_val_patches`` (default = 8).
+        **kwargs : Any
+            Additional keyword arguments forwarded to
+            :class:`CareamicsDataModule` (e.g. ``loading``).
+        """
+        if not isinstance(data_config, MicroSplitDataConfig):
+            raise TypeError(
+                f"MicroSplitDataModule requires a MicroSplitDataConfig, "
+                f"got {type(data_config).__name__}."
+            )
+
+        # Store raw arrays; don't call super().__init__() here because the
+        # parent class validates data against NGDataConfig field expectations
+        # and would wire up CareamicsDataset rather than MicroSplitDataset.
+        # We initialise only what we need from L.LightningDataModule.
+        L.LightningDataModule.__init__(self)
+
+        self.config = data_config
+        self.batch_size: int = data_config.batch_size
+
+        self._train_data = train_data
+        self._val_data = val_data
+
+        self.train_dataset: MicroSplitDataset | None = None
+        self.val_dataset: MicroSplitDataset | None = None
+        self.predict_dataset = None
+
+        self.rng = np.random.default_rng(seed=data_config.seed)
+
+    def setup(self, stage: str) -> None:
+        """Create datasets for training/validation.
+
+        Parameters
+        ----------
+        stage : str
+            One of ``"fit"``, ``"validate"``, ``"predict"``.
+
+        Raises
+        ------
+        NotImplementedError
+            If stage is not ``"fit"`` or ``"validate"``.
+        """
+        if stage in ("fit", "validate"):
+            if self.train_dataset is not None and self.val_dataset is not None:
+                return
+            self._setup_train_val()
+        else:
+            raise NotImplementedError(
+                f"Stage '{stage}' is not implemented in MicroSplitDataModule. "
+                f"Use stage='fit' or 'validate'."
+            )
+
+    def _setup_train_val(self) -> None:
+        """Build train and validation ``MicroSplitDataset`` instances."""
+        cfg = self.config
+
+        def _build_dataset(data: NDArray, mode_str: str) -> MicroSplitDataset:
+            """Build a MicroSplitDataset from an array with the given mode."""
+            # Create a mode-specific version of the config.
+            if mode_str == "training":
+                dataset_config = cfg
+            else:
+                # Convert to validating mode (uses FixedRandomPatchingConfig).
+                dataset_config = cfg.convert_mode("validating")
+
+            return MicroSplitDataset(
+                data_config=dataset_config,
+                train_data=data,
+                multiscale_count=cfg.multiscale_count,
+                padding_mode=cfg.padding_mode,
+                input_is_sum=cfg.input_is_sum,
+                mix_uncorrelated_channels=(
+                    cfg.mix_uncorrelated_channels if mode_str == "training" else False
+                ),
+                uncorrelated_channel_probab=cfg.uncorrelated_channel_probab,
+                alpha_range=cfg.alpha_range,
+                seed=int(self.rng.integers(1, 2**31)),
+            )
+
+        self.train_dataset = _build_dataset(self._train_data, "training")
+
+        val_data = self._val_data if self._val_data is not None else self._train_data
+        self.val_dataset = _build_dataset(val_data, "validating")
+
+    def train_dataloader(self) -> DataLoader:
+        """Create the training DataLoader.
+
+        Returns
+        -------
+        DataLoader
+            Training dataloader with ``default_collate``.
+        """
+        assert self.train_dataset is not None
+        return DataLoader(
+            self.train_dataset,
+            batch_size=self.batch_size,
+            collate_fn=default_collate,
+            **self.config.train_dataloader_params,
+        )
+
+    def val_dataloader(self) -> DataLoader:
+        """Create the validation DataLoader.
+
+        Returns
+        -------
+        DataLoader
+            Validation dataloader with ``default_collate``.
+        """
+        assert self.val_dataset is not None
+        return DataLoader(
+            self.val_dataset,
+            batch_size=self.batch_size,
+            collate_fn=default_collate,
+            **self.config.val_dataloader_params,
+        )

--- a/src/careamics/lvae_training/dataset/config.py
+++ b/src/careamics/lvae_training/dataset/config.py
@@ -37,8 +37,8 @@ class MicroSplitDataConfig(BaseModel):
     """Indices of the channels where the targets are stored in the data"""
 
     # TODO: where are there used?
-    start_alpha: Any | None = None
-    end_alpha: Any | None = None
+    start_alpha: Any | None = None  # remove
+    end_alpha: Any | None = None  # remove
 
     image_size: tuple  # TODO: revisit, new model_config uses tuple
     """Size of one patch of data"""
@@ -60,16 +60,16 @@ class MicroSplitDataConfig(BaseModel):
     channel content 'uncorrelated'"""
     uncorrelated_channel_probab: float | None = 0.5
 
-    poisson_noise_factor: float | None = -1
+    poisson_noise_factor: float | None = -1  # remove
     """The added poisson noise factor"""
 
-    synthetic_gaussian_scale: float | None = 0.1
+    synthetic_gaussian_scale: float | None = 0.1  # remove
 
     # TODO: set to True in training code, recheck
-    input_has_dependant_noise: bool | None = False
+    input_has_dependant_noise: bool | None = False  # remove
 
     # TODO: sometimes max_val differs between runs with fixed seeds with noise enabled
-    enable_gaussian_noise: bool | None = False
+    enable_gaussian_noise: bool | None = False  # remove
     """Whether to enable gaussian noise"""
 
     # TODO: is this parameter used?
@@ -86,17 +86,17 @@ class MicroSplitDataConfig(BaseModel):
     """Maximum data in the dataset. Is calculated for train split, and should be
     externally set for val and test splits."""
 
-    overlapping_padding_kwargs: Any = None
+    overlapping_padding_kwargs: Any = None  # remove
     """Parameters for np.pad method"""
 
     # TODO: remove this parameter, controls debug print
-    print_vars: bool | None = False
+    print_vars: bool | None = False  # remove
 
     # Hard-coded parameters (used to be in the config file)
-    normalized_input: bool = True
+    normalized_input: bool = True  # remove
     """If this is set to true, then one mean and stdev is used
                 for both channels. Otherwise, two different mean and stdev are used."""
-    use_one_mu_std: bool | None = True
+    use_one_mu_std: bool | None = True  # remove
 
     # TODO: is this parameter used?
     train_aug_rotate: bool | None = False
@@ -112,15 +112,15 @@ class MicroSplitDataConfig(BaseModel):
     mode_3D: bool | None = False
     """If training in 3D mode or not"""
 
-    trainig_datausage_fraction: float | None = 1.0
+    trainig_datausage_fraction: float | None = 1.0  # remove
 
-    validtarget_random_fraction: float | None = None
+    validtarget_random_fraction: float | None = None  # remove
 
-    validation_datausage_fraction: float | None = 1.0
+    validation_datausage_fraction: float | None = 1.0  # remove
 
     random_flip_z_3D: bool | None = False
 
-    padding_kwargs: dict = {"mode": "reflect"}  # TODO remove !!
+    padding_kwargs: dict = {"mode": "reflect"}  # remove !!
 
     def __init__(self, **data):
         # Convert string data_type to enum if needed

--- a/tests/dataset_ng/dataset/fixtures_microsplit.py
+++ b/tests/dataset_ng/dataset/fixtures_microsplit.py
@@ -1,11 +1,4 @@
-"""Shared fixtures for MicroSplit old-vs-new equivalence tests.
-
-This module provides:
-- Deterministic synthetic 2-channel image data (N, H, W, C=2) for the old dataset
-  and the same data reshaped to (S, C, Y, X) for the new pipeline.
-- A factory function to create a configured `LCMultiChDloader` from synthetic data.
-- Per-channel and one-mu-std statistics helpers that match the legacy computation.
-"""
+"""Shared fixtures for MicroSplit old-vs-new equivalence tests."""
 
 from __future__ import annotations
 
@@ -14,7 +7,7 @@ from typing import NamedTuple
 
 import numpy as np
 
-# ── Constants ─────────────────────────────────────────────────────────────────
+# Constants
 
 SEED = 42
 N_FRAMES = 4
@@ -27,7 +20,7 @@ MULTISCALE_COUNT = 3  # multiscale_lowres_count
 AXES = "SYX"  # new pipeline axes string
 
 
-# ── Synthetic data helpers ─────────────────────────────────────────────────────
+# Synthetic data helpers
 
 
 def make_synthetic_nhwc() -> np.ndarray:
@@ -62,7 +55,7 @@ def make_synthetic_scyx() -> np.ndarray:
     return nhwc.transpose(0, 3, 1, 2).copy()
 
 
-# ── Legacy dataset factory ─────────────────────────────────────────────────────
+# Legacy dataset factory
 
 
 class LegacyDatasetBundle(NamedTuple):
@@ -163,7 +156,7 @@ def make_legacy_dataset(
     return LegacyDatasetBundle(dataset=dataset, mean_dict=mean_dict, std_dict=std_dict)
 
 
-# ── Statistics extraction helpers ─────────────────────────────────────────────
+# Statistics extraction helpers
 
 
 def compute_legacy_stats(

--- a/tests/dataset_ng/dataset/fixtures_microsplit.py
+++ b/tests/dataset_ng/dataset/fixtures_microsplit.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import NamedTuple
 
 import numpy as np
-import numpy.testing as npt
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -32,7 +31,13 @@ AXES = "SYX"  # new pipeline axes string
 
 
 def make_synthetic_nhwc() -> np.ndarray:
-    """Return deterministic float32 array shaped (N, H, W, C) for old dataset."""
+    """Return deterministic float32 array shaped (N, H, W, C) for old dataset.
+
+    Returns
+    -------
+    np.ndarray
+        Synthetic data in NHWC layout.
+    """
     rng = np.random.default_rng(SEED)
     # Use values well above 0 so the downsampled-ratio sanity check passes
     data = rng.uniform(10.0, 200.0, (N_FRAMES, HEIGHT, WIDTH, N_CHANNELS)).astype(
@@ -46,6 +51,11 @@ def make_synthetic_scyx() -> np.ndarray:
 
     This is the same data as make_synthetic_nhwc() but transposed to the
     SC(Z)YX axis order expected by InMemoryImageStack.
+
+    Returns
+    -------
+    np.ndarray
+        Synthetic data in SCYX layout.
     """
     nhwc = make_synthetic_nhwc()
     # (N, H, W, C) → (S, C, Y, X)
@@ -100,6 +110,24 @@ def make_legacy_dataset(
     synthetic_data = make_synthetic_nhwc()
 
     def _load_data_fn(data_config, datapath, datasplit_type, **kwargs):
+        """Return the in-memory synthetic array for legacy loader tests.
+
+        Parameters
+        ----------
+        data_config : object
+            Legacy data configuration (unused by this test loader).
+        datapath : pathlib.Path
+            Input path from the legacy loader API (unused).
+        datasplit_type : object
+            Requested data split value from the legacy loader API (unused).
+        **kwargs : object
+            Additional keyword arguments accepted for API compatibility.
+
+        Returns
+        -------
+        np.ndarray
+            Synthetic NHWC array used to build the legacy dataset.
+        """
         return synthetic_data
 
     config = MicroSplitDataConfig(
@@ -154,8 +182,9 @@ def compute_legacy_stats(
 
     Returns
     -------
-    mean_dict, std_dict : dict[str, np.ndarray]
-        Same structure as produced by ``compute_mean_std``.
+    tuple[dict[str, np.ndarray], dict[str, np.ndarray]]
+        ``(mean_dict, std_dict)`` in the same structure as
+        ``compute_mean_std``.
     """
     # One-mu-std input stats: single mean/std across the entire array, repeated C times
     input_mean = np.mean(data).reshape(1, 1, 1, 1)

--- a/tests/dataset_ng/dataset/fixtures_microsplit.py
+++ b/tests/dataset_ng/dataset/fixtures_microsplit.py
@@ -1,0 +1,178 @@
+"""Shared fixtures for MicroSplit old-vs-new equivalence tests.
+
+This module provides:
+- Deterministic synthetic 2-channel image data (N, H, W, C=2) for the old dataset
+  and the same data reshaped to (S, C, Y, X) for the new pipeline.
+- A factory function to create a configured `LCMultiChDloader` from synthetic data.
+- Per-channel and one-mu-std statistics helpers that match the legacy computation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
+
+import numpy as np
+import numpy.testing as npt
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+SEED = 42
+N_FRAMES = 4
+HEIGHT = 128
+WIDTH = 128
+N_CHANNELS = 2
+PATCH_SIZE = 64
+GRID_SIZE = 64  # grid == patch → no overlap (simplest tiling)
+MULTISCALE_COUNT = 3  # multiscale_lowres_count
+AXES = "SYX"  # new pipeline axes string
+
+
+# ── Synthetic data helpers ─────────────────────────────────────────────────────
+
+
+def make_synthetic_nhwc() -> np.ndarray:
+    """Return deterministic float32 array shaped (N, H, W, C) for old dataset."""
+    rng = np.random.default_rng(SEED)
+    # Use values well above 0 so the downsampled-ratio sanity check passes
+    data = rng.uniform(10.0, 200.0, (N_FRAMES, HEIGHT, WIDTH, N_CHANNELS)).astype(
+        np.float32
+    )
+    return data
+
+
+def make_synthetic_scyx() -> np.ndarray:
+    """Return deterministic float32 array shaped (S, C, Y, X) for new dataset.
+
+    This is the same data as make_synthetic_nhwc() but transposed to the
+    SC(Z)YX axis order expected by InMemoryImageStack.
+    """
+    nhwc = make_synthetic_nhwc()
+    # (N, H, W, C) → (S, C, Y, X)
+    return nhwc.transpose(0, 3, 1, 2).copy()
+
+
+# ── Legacy dataset factory ─────────────────────────────────────────────────────
+
+
+class LegacyDatasetBundle(NamedTuple):
+    """Holds the legacy dataset and its pre-computed statistics."""
+
+    dataset: object  # LCMultiChDloader
+    mean_dict: dict
+    std_dict: dict
+
+
+def make_legacy_dataset(
+    multiscale_count: int = MULTISCALE_COUNT,
+    enable_random_cropping: bool = True,
+    uncorrelated_channels: bool = False,
+    input_is_sum: bool = False,
+) -> LegacyDatasetBundle:
+    """Create and configure an ``LCMultiChDloader`` from synthetic data.
+
+    Parameters
+    ----------
+    multiscale_count : int
+        Number of LC scales (passed as ``multiscale_lowres_count``).
+    enable_random_cropping : bool
+        ``True`` for training-like random patches; ``False`` for deterministic.
+    uncorrelated_channels : bool
+        Enable uncorrelated channel mixing.
+    input_is_sum : bool
+        If ``True``, input is the sum of channels rather than the average.
+
+    Returns
+    -------
+    LegacyDatasetBundle
+        Dataset and its mean/std statistics.
+    """
+    from careamics.lvae_training.dataset import (
+        LCMultiChDloader,
+        MicroSplitDataConfig,
+    )
+    from careamics.lvae_training.dataset.types import (
+        DataSplitType,
+        DataType,
+        TilingMode,
+    )
+
+    synthetic_data = make_synthetic_nhwc()
+
+    def _load_data_fn(data_config, datapath, datasplit_type, **kwargs):
+        return synthetic_data
+
+    config = MicroSplitDataConfig(
+        data_type=DataType.HTLIF24Data,
+        axes=AXES,
+        image_size=(PATCH_SIZE, PATCH_SIZE),
+        grid_size=GRID_SIZE,
+        num_channels=N_CHANNELS,
+        batch_size=64,
+        datasplit_type=DataSplitType.Train,
+        multiscale_lowres_count=multiscale_count,
+        tiling_mode=TilingMode.ShiftBoundary,
+        enable_random_cropping=enable_random_cropping,
+        uncorrelated_channels=uncorrelated_channels,
+        uncorrelated_channel_probab=0.5,
+        input_is_sum=input_is_sum,
+        target_separate_normalization=True,
+        use_one_mu_std=True,
+        normalized_input=True,
+        train_dataloader_params={"num_workers": 0, "shuffle": True},
+        val_dataloader_params={"num_workers": 0},
+    )
+
+    dataset = LCMultiChDloader(
+        data_config=config,
+        datapath=Path("/synthetic"),
+        load_data_fn=_load_data_fn,
+    )
+
+    mean_dict, std_dict = dataset.compute_mean_std()
+    dataset.set_mean_std(mean_dict, std_dict)
+
+    return LegacyDatasetBundle(dataset=dataset, mean_dict=mean_dict, std_dict=std_dict)
+
+
+# ── Statistics extraction helpers ─────────────────────────────────────────────
+
+
+def compute_legacy_stats(
+    data: np.ndarray,
+) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
+    """Compute legacy-style mean/std dictionaries from (N,H,W,C) data.
+
+    Replicates the ``MultiChDloader.compute_mean_std`` logic with
+    ``target_separate_normalization=True``, ``use_one_mu_std=True``,
+    ``input_is_sum=False`` (canonical path).
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Array of shape (N, H, W, C) as used by the legacy dataset.
+
+    Returns
+    -------
+    mean_dict, std_dict : dict[str, np.ndarray]
+        Same structure as produced by ``compute_mean_std``.
+    """
+    # One-mu-std input stats: single mean/std across the entire array, repeated C times
+    input_mean = np.mean(data).reshape(1, 1, 1, 1)
+    input_std = np.std(data).reshape(1, 1, 1, 1)
+    input_mean = np.repeat(input_mean, N_CHANNELS, axis=1)
+    input_std = np.repeat(input_std, N_CHANNELS, axis=1)
+
+    # Per-channel target stats
+    target_means = []
+    target_stds = []
+    for ch in range(data.shape[-1]):
+        target_means.append(data[..., ch].mean())
+        target_stds.append(data[..., ch].std())
+    target_mean = np.array(target_means)[None, :, None, None]  # (1, C, 1, 1)
+    target_std = np.array(target_stds)[None, :, None, None]
+
+    return (
+        {"input": input_mean, "target": target_mean},
+        {"input": input_std, "target": target_std},
+    )

--- a/tests/dataset_ng/dataset/test_lc_dataset_characterization.py
+++ b/tests/dataset_ng/dataset/test_lc_dataset_characterization.py
@@ -1,0 +1,188 @@
+"""Tests for the legacy LCMultiChDloader.
+
+These tests pin the observable behavior of the old pipeline. Subject to removal.
+
+Pins verified:
+- Output tuple length and element types.
+- Output tensor shapes.
+- Output dtype (float32).
+- Normalization: mean of normalized input is ≈ 0; std is ≈ 1 (approximately).
+- Deterministic output when random cropping is disabled (index → same patch).
+- LC structure: each channel carries `multiscale_count` scales stacked on axis 0.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from tests.dataset_ng.dataset.fixtures_microsplit import (
+    MULTISCALE_COUNT,
+    N_CHANNELS,
+    PATCH_SIZE,
+    make_legacy_dataset,
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def legacy_bundle():
+    """LCMultiChDloader + stats; deterministic (random cropping disabled)."""
+    return make_legacy_dataset(enable_random_cropping=False)
+
+
+@pytest.fixture(scope="module")
+def legacy_bundle_random():
+    """LCMultiChDloader + stats; random cropping enabled."""
+    return make_legacy_dataset(enable_random_cropping=True)
+
+
+# ── Output contract ────────────────────────────────────────────────────────────
+
+
+class TestOutputContract:
+    """Pin the __getitem__ return type and shape contract."""
+
+    def test_returns_tuple(self, legacy_bundle):
+        sample = legacy_bundle.dataset[0]
+        assert isinstance(sample, tuple)
+
+    def test_tuple_length_two_by_default(self, legacy_bundle):
+        """Default output: (inp, norm_target) — alpha and grid_size not returned."""
+        sample = legacy_bundle.dataset[0]
+        assert len(sample) == 2
+
+    def test_input_is_ndarray(self, legacy_bundle):
+        inp, _ = legacy_bundle.dataset[0]
+        assert isinstance(inp, np.ndarray)
+
+    def test_target_is_ndarray(self, legacy_bundle):
+        _, tgt = legacy_bundle.dataset[0]
+        assert isinstance(tgt, np.ndarray)
+
+    def test_input_dtype_float32(self, legacy_bundle):
+        inp, _ = legacy_bundle.dataset[0]
+        assert inp.dtype == np.float32
+
+    def test_target_dtype_float32(self, legacy_bundle):
+        _, tgt = legacy_bundle.dataset[0]
+        assert tgt.dtype == np.float32
+
+
+# ── Shape contract ─────────────────────────────────────────────────────────────
+
+
+class TestShapes:
+    """Pin the expected tensor shapes given the reference parameter set."""
+
+    def test_input_shape_is_L_H_W(self, legacy_bundle):
+        """Input: (L, H, W) where L = multiscale_lowres_count."""
+        inp, _ = legacy_bundle.dataset[0]
+        assert inp.shape == (MULTISCALE_COUNT, PATCH_SIZE, PATCH_SIZE)
+
+    def test_target_shape_is_C_H_W(self, legacy_bundle):
+        """Target: (C, H, W) where C = num_channels."""
+        _, tgt = legacy_bundle.dataset[0]
+        assert tgt.shape == (N_CHANNELS, PATCH_SIZE, PATCH_SIZE)
+
+    def test_input_shape_multiscale_count_1(self):
+        """Input L=1 when multiscale_lowres_count=1."""
+        bundle = make_legacy_dataset(multiscale_count=1, enable_random_cropping=False)
+        inp, _ = bundle.dataset[0]
+        assert inp.shape[0] == 1
+
+    def test_input_shape_multiscale_count_2(self):
+        """Input L=2 when multiscale_lowres_count=2."""
+        bundle = make_legacy_dataset(multiscale_count=2, enable_random_cropping=False)
+        inp, _ = bundle.dataset[0]
+        assert inp.shape[0] == 2
+
+
+# ── Determinism when random_cropping=False ────────────────────────────────────
+
+
+class TestDeterminism:
+    """Same index must always return the same patch when random_cropping is off."""
+
+    def test_same_index_returns_same_input(self, legacy_bundle):
+        inp0a, _ = legacy_bundle.dataset[0]
+        inp0b, _ = legacy_bundle.dataset[0]
+        npt.assert_array_equal(inp0a, inp0b)
+
+    def test_same_index_returns_same_target(self, legacy_bundle):
+        _, tgt0a = legacy_bundle.dataset[0]
+        _, tgt0b = legacy_bundle.dataset[0]
+        npt.assert_array_equal(tgt0a, tgt0b)
+
+    def test_different_indices_can_differ(self, legacy_bundle):
+        """Not a strict requirement, but usually true for a non-trivial dataset."""
+        if len(legacy_bundle.dataset) < 2:
+            pytest.skip("Dataset too small to compare two indices")
+        inp0, _ = legacy_bundle.dataset[0]
+        inp1, _ = legacy_bundle.dataset[1]
+        # Content will differ for non-uniform data
+        assert not np.array_equal(inp0, inp1)
+
+
+# ── Normalization properties ───────────────────────────────────────────────────
+
+
+class TestNormalization:
+    """Verify that the normalized output is in a reasonable range."""
+
+    def test_input_mean_near_zero(self, legacy_bundle):
+        """Mean of the normalized input (across all patches) is approximately 0."""
+        inputs = [
+            legacy_bundle.dataset[i][0] for i in range(len(legacy_bundle.dataset))
+        ]
+        all_inp = np.stack(inputs)
+        assert abs(all_inp.mean()) < 1.0  # one-mu-std → global centering
+
+    def test_target_shape_matches_channels(self, legacy_bundle):
+        for i in range(min(4, len(legacy_bundle.dataset))):
+            _, tgt = legacy_bundle.dataset[i]
+            assert tgt.shape[0] == N_CHANNELS
+
+
+# ── LC structure ───────────────────────────────────────────────────────────────
+
+
+class TestLCStructure:
+    """Verify lateral context scale properties."""
+
+    def test_input_first_scale_is_finest(self, legacy_bundle):
+        """Scale 0 should have the finest resolution (highest variance)."""
+        inp, _ = legacy_bundle.dataset[0]
+        var_scale0 = np.var(inp[0])
+        for k in range(1, MULTISCALE_COUNT):
+            # Coarser scales have context from larger areas; no strict ordering but
+            # check they are not trivially zero.
+            assert inp[k].max() > 0, f"Scale {k} should have non-zero values"
+        _ = var_scale0  # used above
+
+    def test_all_scales_have_same_spatial_size(self, legacy_bundle):
+        """All LC levels are cropped back to (PATCH_SIZE, PATCH_SIZE)."""
+        inp, _ = legacy_bundle.dataset[0]
+        for k in range(MULTISCALE_COUNT):
+            assert inp[k].shape == (
+                PATCH_SIZE,
+                PATCH_SIZE,
+            ), f"Scale {k} has wrong shape: {inp[k].shape}"
+
+
+# ── Dataset length ─────────────────────────────────────────────────────────────
+
+
+class TestDatasetLength:
+    """Basic sanity on __len__."""
+
+    def test_positive_length(self, legacy_bundle):
+        assert len(legacy_bundle.dataset) > 0
+
+    def test_all_indices_accessible(self, legacy_bundle):
+        """Every index in [0, len) should return a valid tuple."""
+        n = min(len(legacy_bundle.dataset), 8)
+        for i in range(n):
+            sample = legacy_bundle.dataset[i]
+            assert len(sample) == 2

--- a/tests/dataset_ng/dataset/test_lc_dataset_characterization.py
+++ b/tests/dataset_ng/dataset/test_lc_dataset_characterization.py
@@ -11,7 +11,7 @@ Pins verified:
 - LC structure: each channel carries `multiscale_count` scales stacked on axis 0.
 """
 
-# TODO to be removed after refactoring is complete
+# TODO this module to be removed after refactoring is complete
 
 from __future__ import annotations
 

--- a/tests/dataset_ng/dataset/test_lc_dataset_characterization.py
+++ b/tests/dataset_ng/dataset/test_lc_dataset_characterization.py
@@ -11,6 +11,8 @@ Pins verified:
 - LC structure: each channel carries `multiscale_count` scales stacked on axis 0.
 """
 
+# TODO to be removed after refactoring is complete
+
 from __future__ import annotations
 
 import numpy as np
@@ -23,7 +25,7 @@ from tests.dataset_ng.dataset.fixtures_microsplit import (
     make_legacy_dataset,
 )
 
-# ── Helpers ────────────────────────────────────────────────────────────────────
+# Helpers
 
 
 @pytest.fixture(scope="module")
@@ -38,11 +40,11 @@ def legacy_bundle_random():
     return make_legacy_dataset(enable_random_cropping=True)
 
 
-# ── Output contract ────────────────────────────────────────────────────────────
+# Output
 
 
-class TestOutputContract:
-    """Pin the __getitem__ return type and shape contract."""
+class TestOutput:
+    """Pin the __getitem__ return type and shape."""
 
     def test_returns_tuple(self, legacy_bundle):
         sample = legacy_bundle.dataset[0]
@@ -70,7 +72,7 @@ class TestOutputContract:
         assert tgt.dtype == np.float32
 
 
-# ── Shape contract ─────────────────────────────────────────────────────────────
+# Shape
 
 
 class TestShapes:
@@ -99,7 +101,7 @@ class TestShapes:
         assert inp.shape[0] == 2
 
 
-# ── Determinism when random_cropping=False ────────────────────────────────────
+# Determinism when random_cropping=False
 
 
 class TestDeterminism:
@@ -125,7 +127,7 @@ class TestDeterminism:
         assert not np.array_equal(inp0, inp1)
 
 
-# ── Normalization properties ───────────────────────────────────────────────────
+# Normalization properties
 
 
 class TestNormalization:
@@ -145,7 +147,7 @@ class TestNormalization:
             assert tgt.shape[0] == N_CHANNELS
 
 
-# ── LC structure ───────────────────────────────────────────────────────────────
+# LC structure
 
 
 class TestLCStructure:
@@ -171,7 +173,7 @@ class TestLCStructure:
             ), f"Scale {k} has wrong shape: {inp[k].shape}"
 
 
-# ── Dataset length ─────────────────────────────────────────────────────────────
+# Dataset length
 
 
 class TestDatasetLength:

--- a/tests/dataset_ng/dataset/test_old_vs_new_equivalence.py
+++ b/tests/dataset_ng/dataset/test_old_vs_new_equivalence.py
@@ -34,35 +34,34 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-# ── Stage-gate import: will raise ImportError until Stage 4 is complete ───────
-from careamics.dataset_ng.microsplit_dataset import MicroSplitDataset  # noqa: E402
-
 # ── Legacy and fixture imports ────────────────────────────────────────────────
 from tests.dataset_ng.dataset.fixtures_microsplit import (
-    AXES,
     MULTISCALE_COUNT,
-    N_CHANNELS,
     PATCH_SIZE,
     SEED,
     make_legacy_dataset,
     make_synthetic_scyx,
 )
 
+from careamics.config.data.ng_data_config import NGDataConfig
+
 # ── Config imports (new pipeline) ─────────────────────────────────────────────
 from careamics.config.data.normalization_config import MeanStdConfig
-from careamics.config.data.ng_data_config import NGDataConfig
 from careamics.config.data.patching_strategies import RandomPatchingConfig
+
+# ── Stage-gate import: will raise ImportError until Stage 4 is complete ───────
+from careamics.dataset_ng.microsplit_dataset import MicroSplitDataset
 from careamics.dataset_ng.patching_strategies import FixedPatchingStrategy
 
-
 # ── Fixtures ──────────────────────────────────────────────────────────────────
+
 
 @pytest.fixture(scope="module")
 def legacy_bundle_det():
     """Legacy dataset with deterministic patch locations (no random crop).
 
     Index 0 with ShiftBoundary tiling and grid_size == patch_size == 64
-    on a 128×128 frame produces a patch at coords (h=0, w=0) of frame 0.
+    on a 128x128 frame produces a patch at coords (h=0, w=0) of frame 0.
     """
     return make_legacy_dataset(enable_random_cropping=False)
 
@@ -75,18 +74,18 @@ def new_dataset_det():
     deterministic location as the legacy dataset at index 0:
     sample_idx=0, coords=[0, 0], patch_size=[PATCH_SIZE, PATCH_SIZE].
     """
-    scyx = make_synthetic_scyx()   # shape (S, C, Y, X) — SCYX axis order
+    scyx = make_synthetic_scyx()  # shape (S, C, Y, X) — SCYX axis order
 
     # The array is already in SCYX order; pass axes="SCYX" so that
     # InMemoryImageStack stores it correctly without reshaping.
     data_config = NGDataConfig(
         mode="training",
         data_type="array",
-        axes="SCYX",   # explicit channel axis matches scyx array order
+        axes="SCYX",  # explicit channel axis matches scyx array order
         patching=RandomPatchingConfig(patch_size=[PATCH_SIZE, PATCH_SIZE], seed=SEED),
         normalization=MeanStdConfig(per_channel=True),
         batch_size=1,
-        augmentations=[],               # no augmentation for equivalence
+        augmentations=[],  # no augmentation for equivalence
         train_dataloader_params={"shuffle": False, "num_workers": 0},
     )
 
@@ -113,6 +112,7 @@ def new_dataset_det():
 
 # ── Equivalence assertions ────────────────────────────────────────────────────
 
+
 class TestSingleSampleEquivalence:
     """Compare a single sample from old and new dataset implementations."""
 
@@ -120,17 +120,17 @@ class TestSingleSampleEquivalence:
         """New input_region.data has the same shape as the legacy inp tensor."""
         inp_old, _ = legacy_bundle_det.dataset[0]
         input_region, _ = new_dataset_det[0]
-        assert input_region.data.shape == inp_old.shape, (
-            f"Shape mismatch: new={input_region.data.shape}, old={inp_old.shape}"
-        )
+        assert (
+            input_region.data.shape == inp_old.shape
+        ), f"Shape mismatch: new={input_region.data.shape}, old={inp_old.shape}"
 
     def test_target_data_shape_matches(self, legacy_bundle_det, new_dataset_det):
         """New target_region.data has the same shape as the legacy norm_target."""
         _, tgt_old = legacy_bundle_det.dataset[0]
         _, target_region = new_dataset_det[0]
-        assert target_region.data.shape == tgt_old.shape, (
-            f"Shape mismatch: new={target_region.data.shape}, old={tgt_old.shape}"
-        )
+        assert (
+            target_region.data.shape == tgt_old.shape
+        ), f"Shape mismatch: new={target_region.data.shape}, old={tgt_old.shape}"
 
     def test_input_scale0_values_close(self, legacy_bundle_det, new_dataset_det):
         """Scale-0 (full-resolution) input values agree within numerical tolerance.
@@ -153,7 +153,9 @@ class TestSingleSampleEquivalence:
             ),
         )
 
-    def test_input_lc_scales_exist_and_are_finite(self, legacy_bundle_det, new_dataset_det):
+    def test_input_lc_scales_exist_and_are_finite(
+        self, legacy_bundle_det, new_dataset_det
+    ):
         """LC scales 1+ exist, are non-zero, and are finite.
 
         The values differ from the legacy implementation by design (see module
@@ -163,7 +165,9 @@ class TestSingleSampleEquivalence:
         input_region, _ = new_dataset_det[0]
         assert input_region.data.shape[0] == inp_old.shape[0], "LC depth mismatch"
         for k in range(1, MULTISCALE_COUNT):
-            assert np.isfinite(input_region.data[k]).all(), f"Scale {k} contains non-finite values"
+            assert np.isfinite(
+                input_region.data[k]
+            ).all(), f"Scale {k} contains non-finite values"
             assert input_region.data[k].max() != 0.0, f"Scale {k} is all zeros"
 
     def test_target_data_values_close(self, legacy_bundle_det, new_dataset_det):
@@ -179,7 +183,9 @@ class TestSingleSampleEquivalence:
             tgt_old,
             rtol=1e-4,
             atol=1e-5,
-            err_msg="Normalized target tensors do not agree between old and new dataset",
+            err_msg=(
+                "Normalized target tensors do not agree between old and new dataset"
+            ),
         )
 
     def test_input_dtype_is_float32(self, new_dataset_det):
@@ -194,6 +200,7 @@ class TestSingleSampleEquivalence:
 
 
 # ── Metadata contract ─────────────────────────────────────────────────────────
+
 
 class TestMetadataContract:
     """Verify ImageRegionData metadata fields are correctly populated."""
@@ -249,6 +256,7 @@ class TestMetadataContract:
 
 # ── Return-type contract ──────────────────────────────────────────────────────
 
+
 class TestReturnTypeContract:
     """Verify that __getitem__ returns a 2-tuple of ImageRegionData."""
 
@@ -259,10 +267,12 @@ class TestReturnTypeContract:
 
     def test_first_element_is_image_region_data(self, new_dataset_det):
         from careamics.dataset_ng.dataset import ImageRegionData
+
         input_region, _ = new_dataset_det[0]
         assert isinstance(input_region, ImageRegionData)
 
     def test_second_element_is_image_region_data(self, new_dataset_det):
         from careamics.dataset_ng.dataset import ImageRegionData
+
         _, target_region = new_dataset_det[0]
         assert isinstance(target_region, ImageRegionData)

--- a/tests/dataset_ng/dataset/test_old_vs_new_equivalence.py
+++ b/tests/dataset_ng/dataset/test_old_vs_new_equivalence.py
@@ -1,0 +1,268 @@
+"""Old-vs-new equivalence tests for the MicroSplit dataset migration.
+
+Gate: these tests REQUIRE the new `MicroSplitDataset` implementation from Stage 4.
+Until Stage 4 is complete, this file will fail at import with an ImportError and
+that is the EXPECTED behavior during Stage 3.
+
+Do NOT weaken or skip these tests to make them pass prematurely.
+
+Equivalence criteria (single sample, deterministic patch location):
+
+Scale-0 (full-resolution level):
+- ``input_region.data[0]`` ≈ ``legacy_inp[0]``  (allclose, rtol=1e-4)
+- ``target_region.data``   ≈ ``legacy_norm_target`` (allclose, rtol=1e-4)
+
+Scales 1+ (lateral-context levels):
+- The new and legacy implementations use DIFFERENT algorithms:
+    * Legacy: pre-downsamples the full image, then crops.
+    * New (lateral_context_patch_constr): crops a larger region from the
+      original, then resizes.
+  The two approaches produce numerically different values for the same
+  center location, so only structural equivalence is required for scales 1+.
+  This is NOT a test weakening — it documents a deliberate design choice.
+
+Metadata:
+- ``input_region.axes`` == NGDataConfig.axes
+- ``input_region.data_shape`` is a non-empty sequence
+- ``input_region.dtype`` is a non-empty string
+- ``input_region.region_spec`` contains the required PatchSpecs keys
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+# ── Stage-gate import: will raise ImportError until Stage 4 is complete ───────
+from careamics.dataset_ng.microsplit_dataset import MicroSplitDataset  # noqa: E402
+
+# ── Legacy and fixture imports ────────────────────────────────────────────────
+from tests.dataset_ng.dataset.fixtures_microsplit import (
+    AXES,
+    MULTISCALE_COUNT,
+    N_CHANNELS,
+    PATCH_SIZE,
+    SEED,
+    make_legacy_dataset,
+    make_synthetic_scyx,
+)
+
+# ── Config imports (new pipeline) ─────────────────────────────────────────────
+from careamics.config.data.normalization_config import MeanStdConfig
+from careamics.config.data.ng_data_config import NGDataConfig
+from careamics.config.data.patching_strategies import RandomPatchingConfig
+from careamics.dataset_ng.patching_strategies import FixedPatchingStrategy
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def legacy_bundle_det():
+    """Legacy dataset with deterministic patch locations (no random crop).
+
+    Index 0 with ShiftBoundary tiling and grid_size == patch_size == 64
+    on a 128×128 frame produces a patch at coords (h=0, w=0) of frame 0.
+    """
+    return make_legacy_dataset(enable_random_cropping=False)
+
+
+@pytest.fixture(scope="module")
+def new_dataset_det():
+    """New MicroSplitDataset built from the same synthetic data.
+
+    Uses a ``FixedPatchingStrategy`` that places index 0 at the same
+    deterministic location as the legacy dataset at index 0:
+    sample_idx=0, coords=[0, 0], patch_size=[PATCH_SIZE, PATCH_SIZE].
+    """
+    scyx = make_synthetic_scyx()   # shape (S, C, Y, X) — SCYX axis order
+
+    # The array is already in SCYX order; pass axes="SCYX" so that
+    # InMemoryImageStack stores it correctly without reshaping.
+    data_config = NGDataConfig(
+        mode="training",
+        data_type="array",
+        axes="SCYX",   # explicit channel axis matches scyx array order
+        patching=RandomPatchingConfig(patch_size=[PATCH_SIZE, PATCH_SIZE], seed=SEED),
+        normalization=MeanStdConfig(per_channel=True),
+        batch_size=1,
+        augmentations=[],               # no augmentation for equivalence
+        train_dataloader_params={"shuffle": False, "num_workers": 0},
+    )
+
+    # A single fixed spec at the same location as the legacy dataset at index 0.
+    fixed_spec = {
+        "data_idx": 0,
+        "sample_idx": 0,
+        "coords": [0, 0],
+        "patch_size": [PATCH_SIZE, PATCH_SIZE],
+    }
+    patching_strategy = FixedPatchingStrategy([fixed_spec])
+
+    return MicroSplitDataset(
+        data_config=data_config,
+        train_data=scyx,
+        multiscale_count=MULTISCALE_COUNT,
+        padding_mode="reflect",
+        input_is_sum=False,
+        mix_uncorrelated_channels=False,
+        patching_strategy=patching_strategy,
+        seed=SEED,
+    )
+
+
+# ── Equivalence assertions ────────────────────────────────────────────────────
+
+class TestSingleSampleEquivalence:
+    """Compare a single sample from old and new dataset implementations."""
+
+    def test_input_data_shape_matches(self, legacy_bundle_det, new_dataset_det):
+        """New input_region.data has the same shape as the legacy inp tensor."""
+        inp_old, _ = legacy_bundle_det.dataset[0]
+        input_region, _ = new_dataset_det[0]
+        assert input_region.data.shape == inp_old.shape, (
+            f"Shape mismatch: new={input_region.data.shape}, old={inp_old.shape}"
+        )
+
+    def test_target_data_shape_matches(self, legacy_bundle_det, new_dataset_det):
+        """New target_region.data has the same shape as the legacy norm_target."""
+        _, tgt_old = legacy_bundle_det.dataset[0]
+        _, target_region = new_dataset_det[0]
+        assert target_region.data.shape == tgt_old.shape, (
+            f"Shape mismatch: new={target_region.data.shape}, old={tgt_old.shape}"
+        )
+
+    def test_input_scale0_values_close(self, legacy_bundle_det, new_dataset_det):
+        """Scale-0 (full-resolution) input values agree within numerical tolerance.
+
+        Both implementations extract the same raw pixels and apply the same
+        alpha weighting and normalization at scale 0.  Higher LC scales use
+        different resampling algorithms (legacy: pre-downsample then crop;
+        new: crop then resize), so only scale 0 is compared numerically.
+        """
+        inp_old, _ = legacy_bundle_det.dataset[0]
+        input_region, _ = new_dataset_det[0]
+        npt.assert_allclose(
+            input_region.data[0],
+            inp_old[0],
+            rtol=1e-4,
+            atol=1e-5,
+            err_msg=(
+                "Normalized full-resolution (scale 0) input values do not agree "
+                "between old and new dataset"
+            ),
+        )
+
+    def test_input_lc_scales_exist_and_are_finite(self, legacy_bundle_det, new_dataset_det):
+        """LC scales 1+ exist, are non-zero, and are finite.
+
+        The values differ from the legacy implementation by design (see module
+        docstring), but must be structurally valid.
+        """
+        inp_old, _ = legacy_bundle_det.dataset[0]
+        input_region, _ = new_dataset_det[0]
+        assert input_region.data.shape[0] == inp_old.shape[0], "LC depth mismatch"
+        for k in range(1, MULTISCALE_COUNT):
+            assert np.isfinite(input_region.data[k]).all(), f"Scale {k} contains non-finite values"
+            assert input_region.data[k].max() != 0.0, f"Scale {k} is all zeros"
+
+    def test_target_data_values_close(self, legacy_bundle_det, new_dataset_det):
+        """Normalized target values agree within numerical tolerance.
+
+        The target is always the full-resolution patch, so both implementations
+        should produce identical values.
+        """
+        _, tgt_old = legacy_bundle_det.dataset[0]
+        _, target_region = new_dataset_det[0]
+        npt.assert_allclose(
+            target_region.data,
+            tgt_old,
+            rtol=1e-4,
+            atol=1e-5,
+            err_msg="Normalized target tensors do not agree between old and new dataset",
+        )
+
+    def test_input_dtype_is_float32(self, new_dataset_det):
+        """New input region data is float32."""
+        input_region, _ = new_dataset_det[0]
+        assert input_region.data.dtype == np.float32
+
+    def test_target_dtype_is_float32(self, new_dataset_det):
+        """New target region data is float32."""
+        _, target_region = new_dataset_det[0]
+        assert target_region.data.dtype == np.float32
+
+
+# ── Metadata contract ─────────────────────────────────────────────────────────
+
+class TestMetadataContract:
+    """Verify ImageRegionData metadata fields are correctly populated."""
+
+    def test_input_axes_matches_config(self, new_dataset_det):
+        # New dataset uses axes="SCYX" (explicit channel dim); see fixture.
+        input_region, _ = new_dataset_det[0]
+        assert input_region.axes == "SCYX"
+
+    def test_target_axes_matches_config(self, new_dataset_det):
+        _, target_region = new_dataset_det[0]
+        assert target_region.axes == "SCYX"
+
+    def test_input_data_shape_is_sequence(self, new_dataset_det):
+        input_region, _ = new_dataset_det[0]
+        assert len(input_region.data_shape) > 0
+
+    def test_target_data_shape_is_sequence(self, new_dataset_det):
+        _, target_region = new_dataset_det[0]
+        assert len(target_region.data_shape) > 0
+
+    def test_input_dtype_str_is_nonempty(self, new_dataset_det):
+        input_region, _ = new_dataset_det[0]
+        assert isinstance(input_region.dtype, str)
+        assert len(input_region.dtype) > 0
+
+    def test_target_dtype_str_is_nonempty(self, new_dataset_det):
+        _, target_region = new_dataset_det[0]
+        assert isinstance(target_region.dtype, str)
+        assert len(target_region.dtype) > 0
+
+    def test_input_region_spec_has_required_keys(self, new_dataset_det):
+        """PatchSpecs must contain data_idx, sample_idx, coords, patch_size."""
+        input_region, _ = new_dataset_det[0]
+        spec = input_region.region_spec
+        for key in ("data_idx", "sample_idx", "coords", "patch_size"):
+            assert key in spec, f"region_spec missing key: {key}"
+
+    def test_target_region_spec_has_required_keys(self, new_dataset_det):
+        _, target_region = new_dataset_det[0]
+        spec = target_region.region_spec
+        for key in ("data_idx", "sample_idx", "coords", "patch_size"):
+            assert key in spec, f"region_spec missing key: {key}"
+
+    def test_input_source_is_str(self, new_dataset_det):
+        input_region, _ = new_dataset_det[0]
+        assert isinstance(input_region.source, str)
+
+    def test_target_source_is_str(self, new_dataset_det):
+        _, target_region = new_dataset_det[0]
+        assert isinstance(target_region.source, str)
+
+
+# ── Return-type contract ──────────────────────────────────────────────────────
+
+class TestReturnTypeContract:
+    """Verify that __getitem__ returns a 2-tuple of ImageRegionData."""
+
+    def test_returns_tuple_of_two(self, new_dataset_det):
+        sample = new_dataset_det[0]
+        assert isinstance(sample, tuple)
+        assert len(sample) == 2
+
+    def test_first_element_is_image_region_data(self, new_dataset_det):
+        from careamics.dataset_ng.dataset import ImageRegionData
+        input_region, _ = new_dataset_det[0]
+        assert isinstance(input_region, ImageRegionData)
+
+    def test_second_element_is_image_region_data(self, new_dataset_det):
+        from careamics.dataset_ng.dataset import ImageRegionData
+        _, target_region = new_dataset_det[0]
+        assert isinstance(target_region, ImageRegionData)

--- a/tests/dataset_ng/dataset/test_old_vs_new_equivalence.py
+++ b/tests/dataset_ng/dataset/test_old_vs_new_equivalence.py
@@ -1,32 +1,6 @@
-"""Old-vs-new equivalence tests for the MicroSplit dataset migration.
+"""Old-vs-new equivalence tests for the MicroSplit dataset migration."""
 
-Gate: these tests REQUIRE the new `MicroSplitDataset` implementation from Stage 4.
-Until Stage 4 is complete, this file will fail at import with an ImportError and
-that is the EXPECTED behavior during Stage 3.
-
-Do NOT weaken or skip these tests to make them pass prematurely.
-
-Equivalence criteria (single sample, deterministic patch location):
-
-Scale-0 (full-resolution level):
-- ``input_region.data[0]`` ≈ ``legacy_inp[0]``  (allclose, rtol=1e-4)
-- ``target_region.data``   ≈ ``legacy_norm_target`` (allclose, rtol=1e-4)
-
-Scales 1+ (lateral-context levels):
-- The new and legacy implementations use DIFFERENT algorithms:
-    * Legacy: pre-downsamples the full image, then crops.
-    * New (lateral_context_patch_constr): crops a larger region from the
-      original, then resizes.
-  The two approaches produce numerically different values for the same
-  center location, so only structural equivalence is required for scales 1+.
-  This is NOT a test weakening — it documents a deliberate design choice.
-
-Metadata:
-- ``input_region.axes`` == NGDataConfig.axes
-- ``input_region.data_shape`` is a non-empty sequence
-- ``input_region.dtype`` is a non-empty string
-- ``input_region.region_spec`` contains the required PatchSpecs keys
-"""
+# TODO this module to be removed after refactoring is complete
 
 from __future__ import annotations
 
@@ -34,7 +8,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-# ── Legacy and fixture imports ────────────────────────────────────────────────
+# Legacy and fixture imports
 from tests.dataset_ng.dataset.fixtures_microsplit import (
     MULTISCALE_COUNT,
     PATCH_SIZE,
@@ -45,15 +19,15 @@ from tests.dataset_ng.dataset.fixtures_microsplit import (
 
 from careamics.config.data.ng_data_config import NGDataConfig
 
-# ── Config imports (new pipeline) ─────────────────────────────────────────────
+# Config imports (new pipeline)
 from careamics.config.data.normalization_config import MeanStdConfig
 from careamics.config.data.patching_strategies import RandomPatchingConfig
 
-# ── Stage-gate import: will raise ImportError until Stage 4 is complete ───────
+# Stage-gate import: will raise ImportError until Stage 4 is complete
 from careamics.dataset_ng.microsplit_dataset import MicroSplitDataset
 from careamics.dataset_ng.patching_strategies import FixedPatchingStrategy
 
-# ── Fixtures ──────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture(scope="module")
@@ -110,7 +84,7 @@ def new_dataset_det():
     )
 
 
-# ── Equivalence assertions ────────────────────────────────────────────────────
+# Equivalence assertions
 
 
 class TestSingleSampleEquivalence:
@@ -199,10 +173,10 @@ class TestSingleSampleEquivalence:
         assert target_region.data.dtype == np.float32
 
 
-# ── Metadata contract ─────────────────────────────────────────────────────────
+# Metadata
 
 
-class TestMetadataContract:
+class TestMetadata:
     """Verify ImageRegionData metadata fields are correctly populated."""
 
     def test_input_axes_matches_config(self, new_dataset_det):
@@ -254,10 +228,10 @@ class TestMetadataContract:
         assert isinstance(target_region.source, str)
 
 
-# ── Return-type contract ──────────────────────────────────────────────────────
+# Return-type
 
 
-class TestReturnTypeContract:
+class TestReturnType:
     """Verify that __getitem__ returns a 2-tuple of ImageRegionData."""
 
     def test_returns_tuple_of_two(self, new_dataset_det):


### PR DESCRIPTION
## Disclaimer

- [ ] I am an AI agent.
- [x] I have used AI and I thoroughly reviewed every line.
- [ ] I have not used AI extensively.


## Description

> [!NOTE]  
> **tldr**: Starts a migration from legacy `LCMultiChDloader` to `MicroSplitDataset` NG pipeline

### Background - why do we need this PR?

The legacy MicroSplit data path `LCMultiChDloader` is hard to maintain, and not aligned with the NG dataset architecture used elsewhere in CAREamics.  

### Overview - what changed?

The PR introduces and validates a new NG-based MicroSplit pipeline:
- `MicroSplitDataConfig(NGDataConfig)` for cleaned data configuration.
- `MicroSplitDataset` as a new reference dataset implementation.
- `MicroSplitDataModule` wiring under `lightning/dataset_ng`.
- Tests for legacy behavior and old-vs-new equivalence tests.

### Implementation - how did you implement the changes?

The implementation follows a behavior-preserving migration strategy:
1. Captured legacy behavior with dedicated characterization tests.
2. Implemented the NG MicroSplit pipeline (`config` + `dataset` + `datamodule`) using NG patterns.
3. Added equivalence tests comparing legacy and new pipelines.

### Potential difference
For LC, scale 0 is numerically identical, while scales 1+ are validated structurally (shape/finite/non-zero) but numerically they might not be identical (see notebook) due to an intentional algorithmic difference between legacy downsample-then-crop and new crop-then-resize semantics. This is to remove legacy precomputed multiscale memory overhead.

### New features or files

- `src/careamics/config/data/ng_microsplit_config.py`  
  Added `MicroSplitDataConfig(NGDataConfig)`
- `src/careamics/dataset_ng/microsplit_dataset.py`  
  Added `MicroSplitDataset` reference implementation.
- `src/careamics/lightning/dataset_ng/microsplit_data_module.py`  
  Added NG Lightning DataModule integration for MicroSplit.
- `tests/dataset_ng/dataset/fixtures_microsplit.py`  
  Added shared test fixtures for MicroSplit scenarios.
- `tests/dataset_ng/dataset/test_lc_dataset_characterization.py`  
  Added legacy behavior characterization coverage.
- `tests/dataset_ng/dataset/test_old_vs_new_equivalence.py`  
  Added old-vs-new equivalence coverage.

### Modified features or files

- Legacy and NG paths are now validated side-by-side through targeted tests.
- Migration documentation artifacts were added/updated (`old_pipeline_report.md`, `new_pipeline_contract.md`, `progress.md`, `state.json`, `final_report.md`) to make behavior, scope, and next-phase cleanup explicit.

### Removed features or files

- None (intentional additive migration; cleanup/deletions deferred to follow-up phase).

## How has this been tested?

new tests + example notebook

### Related Issues
(Partially) Resolves #407
Following issues should be created or 407 updated

### Breaking changes

Souldn't be any. This PR does not remove legacy code paths.

### Additional Notes and Examples
- This PR intentionally does not include cleanup work. This we should do after we're finish with the refac.
- Current`MicroSplitDataset` uses `get_random_channel_patches`-style light-weight
   uncorrelated sampling (same strategy, independent indices per channel). The
   full strategy design (one independent `PatchingStrategy` per channel)
   enables per-channel patch filtering, which is needed for the empty-patch
   mixing path. This is the next implementation step.
- Empty-patch mixing from `microsplit_input_synth.py` is not implemented
- This implementation bases on one dataset class from original setup(ht_lif24). Some other datasets used different setups, e.g. working with multifile(files have different shapes) input instead of stacking all input into an array.
- Current implementation handles 2D data only. The 3D case should work in theory but haven't been tested.
- Augmentation are not implemented fully.
- Config validation needs updating probable between new dataset and configuration

Please ensure your PR meets the following requirements:
[x] Code builds and passes tests locally, including doctests
[x] New tests have been added (for bug fixes/features)
[x] Pre-commit passes
[ ] PR to the documentation exists (for bug fixes / features)
