### PR TITLE
Fix: fix CI test call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,9 @@ jobs:
 
       # Check that basic features work and we didn't miss to include crucial files
       - name: Smoke test (wheel)
-        run: uv run --isolated --no-project --with dist/*.whl tests/smoke_test.py
-
+        run: uv run --isolated --no-project --with dist/*.whl tests/test_smoke_after_packaging.py
       - name: Smoke test (source distribution)
-        run: uv run --isolated --no-project --with dist/*.tar.gz tests/smoke_test.py
+        run: uv run --isolated --no-project --with dist/*.tar.gz tests/test_smoke_after_packaging.py
         
       - name: Publish
         run: uv publish


### PR DESCRIPTION
Renaming of the smoke test used in the CI to check packaging has not been updated in the CI itself. This fixes it!