### PR TITLE
Feat(BMZ): BMZ export for NG CAREamics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-tags: true
+          fetch-depth: 0 
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     # included in the sdist (unless explicitly excluded)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: pipx run check-manifest
 
   test:
@@ -37,7 +37,9 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/ci_compat.yml
+++ b/.github/workflows/ci_compat.yml
@@ -27,7 +27,9 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
             
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/ci_compat.yml
+++ b/.github/workflows/ci_compat.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-tags: true
+          fetch-depth: 0
             
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/ci_lvae.yml
+++ b/.github/workflows/ci_lvae.yml
@@ -27,7 +27,9 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
             
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/ci_lvae.yml
+++ b/.github/workflows/ci_lvae.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-tags: true
+          fetch-depth: 0
             
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -1239,7 +1239,6 @@ class CAREamist:
             output_array=output_array,
             covers=covers,
             channel_names=channel_names,
-            model_version=model_version,
         )
 
     def get_losses(self) -> dict[str, list]:

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -32,8 +32,10 @@ from .lightning.utils import (
     load_module_from_checkpoint,
     read_csv_logger,
 )
+from .model_io.bmz_io import load_from_bmz
 from .models import get_model_constraints
 from .utils import get_logger, get_run_version
+from .utils.reshape_array import reshape_array
 
 logger = get_logger(__name__)
 
@@ -291,13 +293,8 @@ class CAREamist:
             The loaded configuration.
         CAREamicsModule
             The loaded model.
-
-        Raises
-        ------
-        NotImplementedError
-            Loading from BMZ is not implemented yet.
         """
-        raise NotImplementedError("Loading from BMZ is not implemented yet.")
+        return load_from_bmz(bmz_path)
 
     @staticmethod
     def _resolve_work_dir(work_dir: str | Path | None) -> Path:
@@ -1217,30 +1214,33 @@ class CAREamist:
         model_version : str, default="0.1.0"
             Version of the model.
         """
-        # from .model_io import export_to_bmz
+        import numpy as np
 
-        # output_patch = self.predict(
-        #     pred_data=input_array,
-        #     data_type=SupportedData.ARRAY.value,
-        # )
-        # output = np.concatenate(output_patch, axis=0)
-        # input_array = reshape_array(input_array, self.config.data_config.axes)
+        from .model_io import export_to_bmz
 
-        # export_to_bmz(
-        #     model=self.model,
-        #     config=self.config,
-        #     path_to_archive=path_to_archive,
-        #     model_name=friendly_model_name,
-        #     general_description=general_description,
-        #     data_description=data_description,
-        #     authors=authors,
-        #     input_array=input_array,
-        #     output_array=output,
-        #     covers=covers,
-        #     channel_names=channel_names,
-        #     model_version=model_version,
-        # )
-        raise NotImplementedError("Exporting to BMZ is not implemented yet.")
+        output_patch, _ = self.predict(
+            pred_data=input_array,
+            data_type="array",
+        )
+        output_array = reshape_array(
+            np.concatenate(output_patch, axis=0), self.config.data_config.axes
+        )
+        input_array = reshape_array(input_array, self.config.data_config.axes)
+
+        export_to_bmz(
+            model=self.model,
+            config=self.config,
+            path_to_archive=path_to_archive,
+            model_name=friendly_model_name,
+            general_description=general_description,
+            data_description=data_description,
+            authors=authors,
+            input_array=input_array,
+            output_array=output_array,
+            covers=covers,
+            channel_names=channel_names,
+            model_version=model_version,
+        )
 
     def get_losses(self) -> dict[str, list]:
         """Return data that can be used to plot train and validation loss curves.

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -1174,7 +1174,6 @@ class CAREamist:
         data_description: str,
         covers: list[Path | str] | None = None,
         channel_names: list[str] | None = None,
-        model_version: str = "0.2.0",
     ) -> None:
         """Export the model to the BioImage Model Zoo format.
 
@@ -1211,8 +1210,6 @@ class CAREamist:
             Paths to the cover images.
         channel_names : list of str, default=None
             Channel names.
-        model_version : str, default="0.1.0"
-            Version of the model.
         """
         import numpy as np
 

--- a/src/careamics/config/algorithms/care_algorithm_config.py
+++ b/src/careamics/config/algorithms/care_algorithm_config.py
@@ -11,25 +11,13 @@ from careamics.config.validators import (
     model_without_final_activation,
     model_without_n2v2,
 )
+from careamics.references.care import (
+    CARE,
+    CARE_DESCRIPTION,
+    CARE_REF,
+)
 
 from .unet_algorithm_config import UNetBasedAlgorithm
-
-CARE = "CARE"
-
-CARE_DESCRIPTION = (
-    "Content-aware image restoration (CARE) is a deep-learning-based "
-    "algorithm that uses a U-Net architecture to restore images. CARE "
-    "is a supervised algorithm that requires pairs of noisy and "
-    "clean images to train the network. The algorithm learns to "
-    "predict the clean image from the noisy image. CARE is "
-    "particularly useful for denoising images acquired in low-light "
-    "conditions, such as fluorescence microscopy images."
-)
-CARE_REF = CiteEntry(
-    text='Weigert, Martin, et al. "Content-aware image restoration: pushing the '
-    'limits of fluorescence microscopy." Nature methods 15.12 (2018): 1090-1097.',
-    doi="10.1038/s41592-018-0216-7",
-)
 
 
 class CAREAlgorithm(UNetBasedAlgorithm):
@@ -98,7 +86,7 @@ class CAREAlgorithm(UNetBasedAlgorithm):
         str
             Algorithm references.
         """
-        return CARE_REF.text + " doi: " + CARE_REF.doi
+        return CARE_REF.text + " doi: " + str(CARE_REF.doi)
 
     def get_algorithm_citations(self) -> list[CiteEntry]:
         """

--- a/src/careamics/config/algorithms/n2n_algorithm_config.py
+++ b/src/careamics/config/algorithms/n2n_algorithm_config.py
@@ -11,26 +11,13 @@ from careamics.config.validators import (
     model_without_final_activation,
     model_without_n2v2,
 )
+from careamics.references.n2n import (
+    N2N,
+    N2N_DESCRIPTION,
+    N2N_REF,
+)
 
 from .unet_algorithm_config import UNetBasedAlgorithm
-
-N2N = "Noise2Noise"
-
-N2N_DESCRIPTION = (
-    "Noise2Noise is a deep-learning-based algorithm that uses a U-Net "
-    "architecture to restore images. Noise2Noise is a self-supervised "
-    "algorithm that requires only noisy images to train the network. "
-    "The algorithm learns to predict the clean image from the noisy "
-    "image. Noise2Noise is particularly useful when clean images are "
-    "not available for training."
-)
-
-N2N_REF = CiteEntry(
-    text="Lehtinen, J., Munkberg, J., Hasselgren, J., Laine, S., Karras, T., "
-    'Aittala, M. and Aila, T., 2018. "Noise2Noise: Learning image restoration '
-    'without clean data". arXiv preprint arXiv:1803.04189.',
-    doi="10.48550/arXiv.1803.04189",
-)
 
 
 class N2NAlgorithm(UNetBasedAlgorithm):
@@ -91,7 +78,7 @@ class N2NAlgorithm(UNetBasedAlgorithm):
         str
             Algorithm references.
         """
-        return N2N_REF.text + " doi: " + N2N_REF.doi
+        return N2N_REF.text + " doi: " + str(N2N_REF.doi)
 
     def get_algorithm_citations(self) -> list[CiteEntry]:
         """

--- a/src/careamics/config/algorithms/n2v_algorithm_config.py
+++ b/src/careamics/config/algorithms/n2v_algorithm_config.py
@@ -11,79 +11,22 @@ from careamics.config.validators import (
     model_matching_in_out_channels,
     model_without_final_activation,
 )
+from careamics.references.n2v import (
+    N2V,
+    N2V2,
+    N2V2_DESCRIPTION,
+    N2V2_REF,
+    N2V_DESCRIPTION,
+    N2V_REF,
+    STR_N2V2_DESCRIPTION,
+    STR_N2V_DESCRIPTION,
+    STRUCT_N2V,
+    STRUCT_N2V2,
+    STRUCTN2V_REF,
+)
 
 from .n2v_manipulation import N2VManipulateConfig
 from .unet_algorithm_config import UNetBasedAlgorithm
-
-N2V = "Noise2Void"
-N2V2 = "N2V2"
-STRUCT_N2V = "StructN2V"
-STRUCT_N2V2 = "StructN2V2"
-
-N2V_REF = CiteEntry(
-    text='Krull, A., Buchholz, T.O. and Jug, F., 2019. "Noise2Void - Learning '
-    'denoising from single noisy images". In Proceedings of the IEEE/CVF '
-    "conference on computer vision and pattern recognition (pp. 2129-2137).",
-    doi="10.1109/cvpr.2019.00223",
-)
-
-N2V2_REF = CiteEntry(
-    text="Höck, E., Buchholz, T.O., Brachmann, A., Jug, F. and Freytag, A., "
-    '2022. "N2V2 - Fixing Noise2Void checkerboard artifacts with modified '
-    'sampling strategies and a tweaked network architecture". In European '
-    "Conference on Computer Vision (pp. 503-518).",
-    doi="10.1007/978-3-031-25069-9_33",
-)
-
-STRUCTN2V_REF = CiteEntry(
-    text="Broaddus, C., Krull, A., Weigert, M., Schmidt, U. and Myers, G., 2020."
-    '"Removing structured noise with self-supervised blind-spot '
-    'networks". In 2020 IEEE 17th International Symposium on Biomedical '
-    "Imaging (ISBI) (pp. 159-163).",
-    doi="10.1109/isbi45749.2020.9098336",
-)
-
-N2V_DESCRIPTION = (
-    "Noise2Void is a UNet-based self-supervised algorithm that "
-    "uses blind-spot training to denoise images. In short, in every "
-    "patches during training, random pixels are selected and their "
-    "value replaced by a neighboring pixel value. The network is then "
-    "trained to predict the original pixel value. The algorithm "
-    "relies on the continuity of the signal (neighboring pixels have "
-    "similar values) and the pixel-wise independence of the noise "
-    "(the noise in a pixel is not correlated with the noise in "
-    "neighboring pixels)."
-)
-
-N2V2_DESCRIPTION = (
-    "N2V2 is a variant of Noise2Void. "
-    + N2V_DESCRIPTION
-    + "\nN2V2 introduces blur-pool layers and removed skip "
-    "connections in the UNet architecture to remove checkboard "
-    "artefacts, a common artefacts ocurring in Noise2Void."
-)
-
-STR_N2V_DESCRIPTION = (
-    "StructN2V is a variant of Noise2Void. "
-    + N2V_DESCRIPTION
-    + "\nStructN2V uses a linear mask (horizontal or vertical) to replace "
-    "the pixel values of neighbors of the masked pixels by a random "
-    "value. Such masking allows removing 1D structured noise from the "
-    "the images, the main failure case of the original N2V."
-)
-
-STR_N2V2_DESCRIPTION = (
-    "StructN2V2 is a a variant of Noise2Void that uses both "
-    "structN2V and N2V2. "
-    + N2V_DESCRIPTION
-    + "\nStructN2V2 uses a linear mask (horizontal or vertical) to replace "
-    "the pixel values of neighbors of the masked pixels by a random "
-    "value. Such masking allows removing 1D structured noise from the "
-    "the images, the main failure case of the original N2V."
-    "\nN2V2 introduces blur-pool layers and removed skip connections in "
-    "the UNet architecture to remove checkboard artefacts, a common "
-    "artefacts ocurring in Noise2Void."
-)
 
 
 class N2VAlgorithm(UNetBasedAlgorithm):
@@ -239,9 +182,9 @@ class N2VAlgorithm(UNetBasedAlgorithm):
         use_structN2V = self.is_struct_n2v()
 
         references = [
-            N2V_REF.text + " doi: " + N2V_REF.doi,
-            N2V2_REF.text + " doi: " + N2V2_REF.doi,
-            STRUCTN2V_REF.text + " doi: " + STRUCTN2V_REF.doi,
+            N2V_REF.text + " doi: " + str(N2V_REF.doi),
+            N2V2_REF.text + " doi: " + str(N2V2_REF.doi),
+            STRUCTN2V_REF.text + " doi: " + str(STRUCTN2V_REF.doi),
         ]
 
         # return the (struct)N2V(2) references

--- a/src/careamics/config/algorithms/pn2v_algorithm_config.py
+++ b/src/careamics/config/algorithms/pn2v_algorithm_config.py
@@ -12,77 +12,21 @@ from careamics.config.support import SupportedPixelManipulation, SupportedStruct
 from careamics.config.validators import (
     model_without_final_activation,
 )
+from careamics.references.pn2v import (
+    N2V2_REF,
+    PN2V,
+    PN2V2,
+    PN2V2_DESCRIPTION,
+    PN2V_DESCRIPTION,
+    PN2V_REF,
+    STRUCT_PN2V,
+    STRUCT_PN2V2,
+    STRUCT_PN2V2_DESCRIPTION,
+    STRUCT_PN2V_DESCRIPTION,
+    STRUCTN2V_REF,
+)
 
 from .unet_algorithm_config import UNetBasedAlgorithm
-
-PN2V = "Probabilistic Noise2Void"
-PN2V2 = "PN2V2"
-STRUCT_PN2V = "StructPN2V"
-STRUCT_PN2V2 = "StructPN2V2"
-
-PN2V_REF = CiteEntry(
-    text="Krull, A., Vicar, T., Prakash, M., Lalit, M. and Jug, F., 2020. "
-    '"Probabilistic noise2void: Unsupervised content-aware denoising". '
-    "Frontiers in Computer Science, 2, p.5.",
-    doi="10.3389/fcomp.2020.00005",
-)
-
-N2V2_REF = CiteEntry(
-    text="Höck, E., Buchholz, T.O., Brachmann, A., Jug, F. and Freytag, A., "
-    '2022. "N2V2 - Fixing Noise2Void checkerboard artifacts with modified '
-    'sampling strategies and a tweaked network architecture". In European '
-    "Conference on Computer Vision (pp. 503-518).",
-    doi="10.1007/978-3-031-25069-9_33",
-)
-
-STRUCTN2V_REF = CiteEntry(
-    text="Broaddus, C., Krull, A., Weigert, M., Schmidt, U. and Myers, G., 2020."
-    '"Removing structured noise with self-supervised blind-spot '
-    'networks". In 2020 IEEE 17th International Symposium on Biomedical '
-    "Imaging (ISBI) (pp. 159-163).",
-    doi="10.1109/isbi45749.2020.9098336",
-)
-
-PN2V_DESCRIPTION = (
-    "Probabilistic Noise2Void (PN2V) is a UNet-based self-supervised algorithm that "
-    "extends Noise2Void by incorporating a probabilistic noise model to estimate the "
-    "posterior distribution of each pixel more precisely. Like N2V, it uses blind-spot "
-    "training where random pixels are selected in patches during training and their "
-    "value replaced by a neighboring pixel value. The model is then trained to predict "
-    "the original pixel value. PN2V additionally uses a noise model to better capture "
-    "the noise characteristics and provide more accurate denoising by modeling the "
-    "likelihood of pixel intensities."
-)
-
-PN2V2_DESCRIPTION = (
-    "PN2V2 is a variant of Probabilistic Noise2Void. "
-    + PN2V_DESCRIPTION
-    + "\nPN2V2 introduces blur-pool layers and removed skip "
-    "connections in the UNet architecture to remove checkboard "
-    "artefacts, a common artefacts occurring in Noise2Void variants."
-)
-
-STRUCT_PN2V_DESCRIPTION = (
-    "StructPN2V is a variant of Probabilistic Noise2Void. "
-    + PN2V_DESCRIPTION
-    + "\nStructPN2V uses a linear mask (horizontal or vertical) to replace "
-    "the pixel values of neighbors of the masked pixels by a random "
-    "value. Such masking allows removing 1D structured noise from the "
-    "the images, the main failure case of the original N2V variants."
-)
-
-STRUCT_PN2V2_DESCRIPTION = (
-    "StructPN2V2 is a variant of Probabilistic Noise2Void that uses both "
-    "structN2V and N2V2. "
-    + PN2V_DESCRIPTION
-    + "\nStructPN2V2 uses a linear mask (horizontal or vertical) to replace "
-    "the pixel values of neighbors of the masked pixels by a random "
-    "value. Such masking allows removing 1D structured noise from the "
-    "the images, the main failure case of the original N2V variants."
-    "\nPN2V2 introduces blur-pool layers and removed skip connections in "
-    "the UNet architecture to remove checkboard artefacts, a common "
-    "artefacts occurring in Noise2Void variants."
-)
 
 
 class PN2VAlgorithm(UNetBasedAlgorithm):
@@ -236,9 +180,9 @@ class PN2VAlgorithm(UNetBasedAlgorithm):
         use_structN2V = self.is_struct_n2v()
 
         references = [
-            PN2V_REF.text + " doi: " + PN2V_REF.doi,
-            N2V2_REF.text + " doi: " + N2V2_REF.doi,
-            STRUCTN2V_REF.text + " doi: " + STRUCTN2V_REF.doi,
+            PN2V_REF.text + " doi: " + str(PN2V_REF.doi),
+            N2V2_REF.text + " doi: " + str(N2V2_REF.doi),
+            STRUCTN2V_REF.text + " doi: " + str(STRUCTN2V_REF.doi),
         ]
 
         # return the (struct)PN2V(2) references

--- a/src/careamics/config/configuration.py
+++ b/src/careamics/config/configuration.py
@@ -368,7 +368,4 @@ class Configuration(BaseModel, Generic[AlgorithmConfig]):
         dict
             Dictionary containing the model parameters.
         """
-        if "exclude_none" not in kwargs:
-            kwargs["exclude_none"] = True
-
         return super().model_dump(**kwargs)

--- a/src/careamics/model_io/__init__.py
+++ b/src/careamics/model_io/__init__.py
@@ -1,0 +1,9 @@
+"""Model I/O utilities."""
+
+from .bmz_io import export_to_bmz
+from .model_io_utils import load_pretrained
+
+__all__ = [
+    "export_to_bmz",
+    "load_pretrained",
+]

--- a/src/careamics/model_io/bioimage/__init__.py
+++ b/src/careamics/model_io/bioimage/__init__.py
@@ -1,0 +1,11 @@
+"""Bioimage Model Zoo format functions."""
+
+from .bioimage_utils import get_env_file, get_unzip_path
+from .model_description import create_model_description, extract_model_path
+
+__all__ = [
+    "create_model_description",
+    "extract_model_path",
+    "get_env_file",
+    "get_unzip_path",
+]

--- a/src/careamics/model_io/bioimage/_readme_factory.py
+++ b/src/careamics/model_io/bioimage/_readme_factory.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import yaml
 
 from careamics.config.configuration import Configuration
-from careamics.utils import cwd, get_careamics_home
 
 
 def _yaml_block(yaml_str: str) -> str:
@@ -25,6 +24,7 @@ def _yaml_block(yaml_str: str) -> str:
 
 
 def readme_factory(
+    model_dir: Path,
     config: Configuration,
     careamics_version: str,
     data_description: str,
@@ -36,6 +36,8 @@ def readme_factory(
 
     Parameters
     ----------
+    model_dir : Path
+        Model directory.
     config : Configuration
         CAREamics configuration.
     careamics_version : str
@@ -49,65 +51,72 @@ def readme_factory(
         Path to the README file.
     """
     # create file
-    # TODO use tempfile as in the bmz_io module
-    with cwd(get_careamics_home()):
-        readme = Path("README.md")
-        readme.touch()
+    readme = model_dir / "README.md"
+    readme.touch()
 
-        # algorithm pretty name
-        algorithm_flavour = config.get_algorithm_friendly_name()
-        algorithm_pretty_name = algorithm_flavour + " - CAREamics"
+    # algorithm pretty name
+    algorithm_flavour = config.get_algorithm_friendly_name()
+    algorithm_pretty_name = algorithm_flavour + " - CAREamics"
 
-        description = [f"# {algorithm_pretty_name}\n\n"]
+    description = [f"# {algorithm_pretty_name}\n\n"]
 
-        # data description
-        description.append("## Data description\n\n")
-        description.append(data_description)
+    # data description
+    description.append("## Data description\n\n")
+    description.append(data_description)
+    description.append("\n\n")
+
+    # algorithm description
+    description.append("## Algorithm description:\n\n")
+    description.append(config.get_algorithm_description())
+    description.append("\n\n")
+
+    # configuration description
+    description.append("## Configuration\n\n")
+
+    description.append(
+        f"{algorithm_flavour} was trained using CAREamics (version "
+        f"{careamics_version}) using the following configuration:\n\n"
+    )
+
+    description.append(_yaml_block(yaml.dump(config.model_dump(exclude_none=True))))
+    description.append("\n\n")
+
+    # validation
+    description.append("# Validation\n\n")
+
+    description.append(
+        "In order to validate the model, we encourage users to acquire a "
+        "test dataset with ground-truth data. Comparing the ground-truth data "
+        "with the prediction allows unbiased evaluation of the model performances. "
+        "This can be done for instance by using metrics such as PSNR, SSIM, or"
+        "MicroSSIM. In the absence of ground-truth, inspecting the residual image "
+        "(difference between input and predicted image) can be helpful to identify "
+        "whether real signal is removed from the input image.\n\n"
+    )
+
+    # careamics uv installation
+    description.append(
+        "## CAREamics installation\n\n"
+        "CAREamics can be installed using `uv` with the following command:\n\n"
+        "```bash\n"
+        'uv pip install "careamics[examples]"\n'
+        "```\n\n"
+    )
+
+    # references
+    reference = config.get_algorithm_references()
+    if reference != "":
+        description.append("## References\n\n")
+        description.append(reference)
         description.append("\n\n")
 
-        # algorithm description
-        description.append("## Algorithm description:\n\n")
-        description.append(config.get_algorithm_description())
-        description.append("\n\n")
+    # links
+    description.append(
+        "# Links\n\n"
+        "- [CAREamics repository](https://github.com/CAREamics/careamics)\n"
+        "- [CAREamics documentation](https://careamics.github.io/)\n"
+    )
 
-        # configuration description
-        description.append("## Configuration\n\n")
+    readme.write_text("".join(description))
 
-        description.append(
-            f"{algorithm_flavour} was trained using CAREamics (version "
-            f"{careamics_version}) using the following configuration:\n\n"
-        )
-
-        description.append(_yaml_block(yaml.dump(config.model_dump(exclude_none=True))))
-        description.append("\n\n")
-
-        # validation
-        description.append("# Validation\n\n")
-
-        description.append(
-            "In order to validate the model, we encourage users to acquire a "
-            "test dataset with ground-truth data. Comparing the ground-truth data "
-            "with the prediction allows unbiased evaluation of the model performances. "
-            "This can be done for instance by using metrics such as PSNR, SSIM, or"
-            "MicroSSIM. In the absence of ground-truth, inspecting the residual image "
-            "(difference between input and predicted image) can be helpful to identify "
-            "whether real signal is removed from the input image.\n\n"
-        )
-
-        # references
-        reference = config.get_algorithm_references()
-        if reference != "":
-            description.append("## References\n\n")
-            description.append(reference)
-            description.append("\n\n")
-
-        # links
-        description.append(
-            "# Links\n\n"
-            "- [CAREamics repository](https://github.com/CAREamics/careamics)\n"
-            "- [CAREamics documentation](https://careamics.github.io/)\n"
-        )
-
-        readme.write_text("".join(description))
-
-        return readme.absolute()
+    return readme.absolute()

--- a/src/careamics/model_io/bioimage/_readme_factory.py
+++ b/src/careamics/model_io/bioimage/_readme_factory.py
@@ -1,0 +1,113 @@
+"""Functions used to create a README.md file for BMZ export."""
+
+from pathlib import Path
+
+import yaml
+
+from careamics.config.configuration import Configuration
+from careamics.utils import cwd, get_careamics_home
+
+
+def _yaml_block(yaml_str: str) -> str:
+    """Return a markdown code block with a yaml string.
+
+    Parameters
+    ----------
+    yaml_str : str
+        YAML string.
+
+    Returns
+    -------
+    str
+        Markdown code block with the YAML string.
+    """
+    return f"```yaml\n{yaml_str}\n```"
+
+
+def readme_factory(
+    config: Configuration,
+    careamics_version: str,
+    data_description: str,
+) -> Path:
+    """Create a README file for the model.
+
+    `data_description` can be used to add more information about the content of the
+    data the model was trained on.
+
+    Parameters
+    ----------
+    config : Configuration
+        CAREamics configuration.
+    careamics_version : str
+        CAREamics version.
+    data_description : str
+        Description of the data.
+
+    Returns
+    -------
+    Path
+        Path to the README file.
+    """
+    # create file
+    # TODO use tempfile as in the bmz_io module
+    with cwd(get_careamics_home()):
+        readme = Path("README.md")
+        readme.touch()
+
+        # algorithm pretty name
+        algorithm_flavour = config.get_algorithm_friendly_name()
+        algorithm_pretty_name = algorithm_flavour + " - CAREamics"
+
+        description = [f"# {algorithm_pretty_name}\n\n"]
+
+        # data description
+        description.append("## Data description\n\n")
+        description.append(data_description)
+        description.append("\n\n")
+
+        # algorithm description
+        description.append("## Algorithm description:\n\n")
+        description.append(config.get_algorithm_description())
+        description.append("\n\n")
+
+        # configuration description
+        description.append("## Configuration\n\n")
+
+        description.append(
+            f"{algorithm_flavour} was trained using CAREamics (version "
+            f"{careamics_version}) using the following configuration:\n\n"
+        )
+
+        description.append(_yaml_block(yaml.dump(config.model_dump(exclude_none=True))))
+        description.append("\n\n")
+
+        # validation
+        description.append("# Validation\n\n")
+
+        description.append(
+            "In order to validate the model, we encourage users to acquire a "
+            "test dataset with ground-truth data. Comparing the ground-truth data "
+            "with the prediction allows unbiased evaluation of the model performances. "
+            "This can be done for instance by using metrics such as PSNR, SSIM, or"
+            "MicroSSIM. In the absence of ground-truth, inspecting the residual image "
+            "(difference between input and predicted image) can be helpful to identify "
+            "whether real signal is removed from the input image.\n\n"
+        )
+
+        # references
+        reference = config.get_algorithm_references()
+        if reference != "":
+            description.append("## References\n\n")
+            description.append(reference)
+            description.append("\n\n")
+
+        # links
+        description.append(
+            "# Links\n\n"
+            "- [CAREamics repository](https://github.com/CAREamics/careamics)\n"
+            "- [CAREamics documentation](https://careamics.github.io/)\n"
+        )
+
+        readme.write_text("".join(description))
+
+        return readme.absolute()

--- a/src/careamics/model_io/bioimage/bioimage_utils.py
+++ b/src/careamics/model_io/bioimage/bioimage_utils.py
@@ -1,0 +1,79 @@
+"""Bioimage.io utils."""
+
+from pathlib import Path
+from typing import Union
+
+from torch import __version__ as PYTORCH_VERSION
+from torchvision import __version__ as TORCHVISION_VERSION
+
+from careamics.utils.version import get_careamics_version
+
+
+def get_unzip_path(zip_path: Union[Path, str]) -> Path:
+    """Generate unzipped folder path from the bioimage.io model path.
+
+    Parameters
+    ----------
+    zip_path : Path
+        Path to the bioimage.io model.
+
+    Returns
+    -------
+    Path
+        Path to the unzipped folder.
+    """
+    zip_path = Path(zip_path)
+
+    return zip_path.parent / (str(zip_path.name) + ".unzip")
+
+
+def get_env_file(model_dir: Path | str) -> Path:
+    """Create environment yaml file for the bioimage model.
+
+    Parameters
+    ----------
+    model_dir : Path
+        Path to the bioimage.io model directory.
+
+    Returns
+    -------
+    Path
+        Path to the environment yaml file.
+    """
+    model_dir = Path(model_dir)
+    env_path = model_dir / "environment.yml"
+    env_path.write_text(create_env_text(PYTORCH_VERSION, TORCHVISION_VERSION))
+
+    return env_path
+
+
+def create_env_text(pytorch_version: str, torchvision_version: str) -> str:
+    """Create environment yaml content for the bioimage model.
+
+    This installs an environment with the specified pytorch version and the latest
+    changes to careamics.
+
+    Parameters
+    ----------
+    pytorch_version : str
+        Pytorch version.
+    torchvision_version : str
+        Torchvision version.
+
+    Returns
+    -------
+    str
+        Environment text.
+    """
+    env = (
+        f"name: careamics\n"
+        f"dependencies:\n"
+        f"  - python=3.12\n"
+        f"  - pip\n"
+        f"  - pip:\n"
+        f"    - torch=={pytorch_version}\n"
+        f"    - torchvision=={torchvision_version}\n"
+        f"    - careamics=={get_careamics_version()}"
+    )
+
+    return env

--- a/src/careamics/model_io/bioimage/cover_factory.py
+++ b/src/careamics/model_io/bioimage/cover_factory.py
@@ -1,0 +1,171 @@
+"""Convenience function to create covers for the BMZ."""
+
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+from PIL import Image
+
+color_palette = np.array(
+    [
+        np.array([255, 195, 0]),  # grey
+        np.array([189, 226, 240]),
+        np.array([96, 60, 76]),
+        np.array([193, 225, 193]),
+    ]
+)
+
+
+def _get_norm_slice(array: NDArray) -> NDArray:
+    """Get the normalized middle slice of a 4D or 5D array (SC(Z)YX).
+
+    Parameters
+    ----------
+    array : NDArray
+        Array from which to get the middle slice.
+
+    Returns
+    -------
+    NDArray
+        Normalized middle slice of the input array.
+    """
+    if array.ndim not in (4, 5):
+        raise ValueError("Array must be 4D or 5D.")
+
+    channels = array.shape[1] > 1
+    z_stack = array.ndim == 5
+
+    # get slice
+    if z_stack:
+        array_slice = array[0, :, array.shape[2] // 2, ...]
+    else:
+        array_slice = array[0, ...]
+
+    # channels
+    if channels:
+        array_slice = np.moveaxis(array_slice, 0, -1)
+    else:
+        array_slice = array_slice[0, ...]
+
+    # normalize
+    array_slice = (
+        255
+        * (array_slice - array_slice.min())
+        / (array_slice.max() - array_slice.min())
+    )
+
+    return array_slice.astype(np.uint8)
+
+
+def _four_channel_image(array: NDArray) -> Image:
+    """Convert 4-channel array to Image.
+
+    Parameters
+    ----------
+    array : NDArray
+        Normalized array to convert.
+
+    Returns
+    -------
+    Image
+        Converted array.
+    """
+    colors = color_palette[np.newaxis, np.newaxis, :, :]
+    four_c_array = np.sum(array[..., :4, np.newaxis] * colors, axis=-2).astype(np.uint8)
+
+    return Image.fromarray(four_c_array).convert("RGB")
+
+
+def _convert_to_image(original_shape: tuple[int, ...], array: NDArray) -> Image:
+    """Convert to Image.
+
+    Parameters
+    ----------
+    original_shape : tuple
+        Original shape of the array.
+    array : NDArray
+        Normalized array to convert.
+
+    Returns
+    -------
+    Image
+        Converted array.
+    """
+    n_channels = original_shape[1]
+
+    if n_channels > 1:
+        if n_channels == 3:
+            return Image.fromarray(array).convert("RGB")
+        elif n_channels == 2:
+            # add an empty channel to the numpy array
+            array = np.concatenate([np.zeros_like(array[..., 0:1]), array], axis=-1)
+
+            return Image.fromarray(array).convert("RGB")
+        else:  # more than 4
+            return _four_channel_image(array[..., :4])
+    else:
+        return Image.fromarray(array).convert("L").convert("RGB")
+
+
+def create_cover(directory: Path, array_in: NDArray, array_out: NDArray) -> Path:
+    """Create a cover image from input and output arrays.
+
+    Input and output arrays are expected to be SC(Z)YX. For images with a Z
+    dimension, the middle slice is taken.
+
+    Parameters
+    ----------
+    directory : Path
+        Directory in which to save the cover.
+    array_in : numpy.ndarray
+        Array from which to create the cover image.
+    array_out : numpy.ndarray
+        Array from which to create the cover image.
+
+    Returns
+    -------
+    Path
+        Path to the saved cover image.
+    """
+    # extract slice and normalize arrays
+    slice_in = _get_norm_slice(array_in)
+    slice_out = _get_norm_slice(array_out)
+
+    horizontal_split = slice_in.shape[-1] == slice_out.shape[-1]
+    if not horizontal_split:
+        if slice_in.shape[-2] != slice_out.shape[-2]:
+            raise ValueError("Input and output arrays have different shapes.")
+
+    # convert to Image
+    image_in = _convert_to_image(array_in.shape, slice_in)
+    image_out = _convert_to_image(array_out.shape, slice_out)
+
+    # split horizontally or vertically
+    if horizontal_split:
+        width = image_in.width // 2
+
+        cover = Image.new("RGB", (image_in.width, image_in.height))
+        cover.paste(image_in.crop((0, 0, width, image_in.height)), (0, 0))
+        cover.paste(
+            image_out.crop(
+                (image_in.width - width, 0, image_in.width, image_in.height)
+            ),
+            (width, 0),
+        )
+    else:
+        height = image_in.height // 2
+
+        cover = Image.new("RGB", (image_in.width, image_in.height))
+        cover.paste(image_in.crop((0, 0, image_in.width, height)), (0, 0))
+        cover.paste(
+            image_out.crop(
+                (0, image_in.height - height, image_in.width, image_in.height)
+            ),
+            (0, height),
+        )
+
+    # save
+    cover_path = directory / "cover.png"
+    cover.save(cover_path)
+
+    return cover_path

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -206,7 +206,6 @@ def create_model_description(
     env_path: Union[Path, str],
     covers: list[Union[Path, str]],
     channel_names: list[str] | None = None,
-    model_version: str = "0.1.0",
 ) -> ModelDescr:
     """Create model description.
 
@@ -236,8 +235,6 @@ def create_model_description(
         Paths to cover images.
     channel_names : Optional[list[str]], optional
         Channel names, by default None.
-    model_version : str, default "0.1.0"
-        Model version.
 
     Returns
     -------
@@ -304,7 +301,7 @@ def create_model_description(
                 }
             }
         },
-        version=Version(model_version),
+        version=Version(get_careamics_version()),
         weights=weights_descr,
         attachments=[FileDescr(source=config_path)],
         cite=config.get_algorithm_citations(),

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -281,6 +281,12 @@ def create_model_description(
         ),
     )
 
+    # careamics version
+    # (removing non numeric characters like "*"; might happens when using dev versions)
+    careamics_version = ".".join(
+        [s for s in get_careamics_version().split(".") if s.isnumeric()]
+    )
+
     # overall model description
     model = ModelDescr(
         name=name,
@@ -305,7 +311,7 @@ def create_model_description(
                 }
             }
         },
-        version=Version(get_careamics_version()),
+        version=Version(careamics_version),
         weights=weights_descr,
         attachments=[FileDescr(source=config_path)],
         cite=config.get_algorithm_citations(),

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -1,0 +1,357 @@
+"""Module use to build BMZ model description."""
+
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+from bioimageio.spec._internal.io import extract
+from bioimageio.spec.model import AnyModelDescr, ModelDescr
+from bioimageio.spec.model.v0_5 import (
+    ArchitectureFromLibraryDescr,
+    Author,
+    AxisBase,
+    AxisId,
+    BatchAxis,
+    ChannelAxis,
+    FileDescr,
+    FixedZeroMeanUnitVarianceAlongAxisKwargs,
+    FixedZeroMeanUnitVarianceDescr,
+    Identifier,
+    InputAxis,
+    InputTensorDescr,
+    OutputAxis,
+    OutputTensorDescr,
+    PytorchStateDictWeightsDescr,
+    SpaceInputAxis,
+    SpaceOutputAxis,
+    TensorId,
+    Version,
+    WeightsDescr,
+)
+from pydantic import DirectoryPath
+from torch import __version__ as PYTORCH_VERSION
+
+from careamics.config.configuration import Configuration
+from careamics.config.data import DataConfig, MeanStdConfig
+from careamics.utils.version import get_careamics_version
+
+from ._readme_factory import readme_factory
+
+
+def _create_axes(
+    array: np.ndarray,
+    data_config: DataConfig,
+    channel_names: list[str] | None = None,
+    is_input: bool = True,
+) -> list[AxisBase]:
+    """Create axes description.
+
+    Array shape is expected to be SC(Z)YX.
+
+    Parameters
+    ----------
+    array : np.ndarray
+        Array.
+    data_config : DataModel
+        CAREamics data configuration.
+    channel_names : Optional[list[str]], optional
+        Channel names, by default None.
+    is_input : bool, optional
+        Whether the axes are input axes, by default True.
+
+    Returns
+    -------
+    list[AxisBase]
+        list of axes description.
+
+    Raises
+    ------
+    ValueError
+        If channel names are not provided when channel axis is present.
+    """
+    # axes have to be SC(Z)YX
+    spatial_axes = data_config.axes.replace("S", "").replace("C", "")
+
+    # batch is always present
+    axes_model: list[AxisBase] = [BatchAxis()]
+
+    if "C" in data_config.axes:
+        if channel_names is not None:
+            axes_model.append(
+                ChannelAxis(channel_names=[Identifier(name) for name in channel_names])
+            )
+        else:
+            raise ValueError(
+                f"Channel names must be provided if channel axis is present, axes: "
+                f"{data_config.axes}."
+            )
+    else:
+        # singleton channel
+        axes_model.append(ChannelAxis(channel_names=[Identifier("channel")]))
+
+    # spatial axes
+    for ind, axes in enumerate(spatial_axes):
+        if axes in ["X", "Y", "Z"]:
+            if is_input:
+                axes_model.append(
+                    SpaceInputAxis(id=AxisId(axes.lower()), size=array.shape[2 + ind])
+                )
+            else:
+                axes_model.append(
+                    SpaceOutputAxis(id=AxisId(axes.lower()), size=array.shape[2 + ind])
+                )
+
+    return axes_model
+
+
+def _create_inputs_ouputs(
+    input_array: np.ndarray,
+    output_array: np.ndarray,
+    data_config: DataConfig,
+    input_path: Union[Path, str],
+    output_path: Union[Path, str],
+    channel_names: list[str] | None = None,
+) -> tuple[InputTensorDescr, OutputTensorDescr]:
+    """Create input and output tensor description.
+
+    Input and output paths must point to a `.npy` file.
+
+    Parameters
+    ----------
+    input_array : np.ndarray
+        Input array.
+    output_array : np.ndarray
+        Output array.
+    data_config : DataModel
+        CAREamics data configuration.
+    input_path : Union[Path, str]
+        Path to input .npy file.
+    output_path : Union[Path, str]
+        Path to output .npy file.
+    channel_names : Optional[list[str]], optional
+        Channel names, by default None.
+
+    Returns
+    -------
+    tuple[InputTensorDescr, OutputTensorDescr]
+        Input and output tensor descriptions.
+    """
+    input_axes: list[InputAxis] = _create_axes(
+        input_array, data_config, channel_names
+    )  # type: ignore
+    output_axes: list[OutputAxis] = _create_axes(
+        output_array, data_config, channel_names, False
+    )  # type: ignore
+
+    # mean and std
+    if isinstance(data_config.normalization, MeanStdConfig):
+        assert data_config.normalization.input_means is not None, "Mean cannot be None."
+        assert data_config.normalization.input_stds is not None, "Std cannot be None."
+        means = data_config.normalization.input_means
+        stds = data_config.normalization.input_stds
+
+    # and the mean and std required to invert the normalization
+    # CAREamics denormalization: x = y * (std + eps) + mean
+    # BMZ normalization : x = (y - mean') / (std' + eps)
+    # to apply the BMZ normalization as a denormalization step, we need:
+    eps = 1e-6
+    inv_means = []
+    inv_stds = []
+    if means and stds:
+        for mean, std in zip(means, stds, strict=False):
+            inv_means.append(-mean / (std + eps))
+            inv_stds.append(1 / (std + eps) - eps)
+
+        # create input/output descriptions
+        input_descr = InputTensorDescr(
+            id=TensorId("input"),
+            axes=input_axes,
+            test_tensor=FileDescr(source=input_path),
+            preprocessing=[
+                FixedZeroMeanUnitVarianceDescr(
+                    kwargs=FixedZeroMeanUnitVarianceAlongAxisKwargs(
+                        mean=means, std=stds, axis="channel"
+                    )
+                )
+            ],
+        )
+        output_descr = OutputTensorDescr(
+            id=TensorId("prediction"),
+            axes=output_axes,
+            test_tensor=FileDescr(source=output_path),
+            postprocessing=[
+                FixedZeroMeanUnitVarianceDescr(
+                    kwargs=FixedZeroMeanUnitVarianceAlongAxisKwargs(  # invert norm
+                        mean=inv_means, std=inv_stds, axis="channel"
+                    )
+                )
+            ],
+        )
+
+        return input_descr, output_descr
+    else:
+        raise ValueError("Mean and std cannot be None.")
+
+
+def create_model_description(
+    config: Configuration,
+    name: str,
+    general_description: str,
+    data_description: str,
+    authors: list[dict],
+    inputs: Union[Path, str],
+    outputs: Union[Path, str],
+    weights_path: Union[Path, str],
+    config_path: Union[Path, str],
+    env_path: Union[Path, str],
+    covers: list[Union[Path, str]],
+    channel_names: list[str] | None = None,
+    model_version: str = "0.1.0",
+) -> ModelDescr:
+    """Create model description.
+
+    Parameters
+    ----------
+    config : Configuration
+        CAREamics configuration.
+    name : str
+        Name of the model.
+    general_description : str
+        General description of the model.
+    data_description : str
+        Description of the data the model was trained on.
+    authors : list[Author]
+        Authors of the model.
+    inputs : Union[Path, str]
+        Path to input .npy file.
+    outputs : Union[Path, str]
+        Path to output .npy file.
+    weights_path : Union[Path, str]
+        Path to model weights.
+    config_path : Union[Path, str]
+        Path to model configuration.
+    env_path : Union[Path, str]
+        Path to environment file.
+    covers : list of pathlib.Path or str
+        Paths to cover images.
+    channel_names : Optional[list[str]], optional
+        Channel names, by default None.
+    model_version : str, default "0.1.0"
+        Model version.
+
+    Returns
+    -------
+    ModelDescr
+        Model description.
+    """
+    # documentation
+    doc = readme_factory(
+        config,
+        careamics_version=get_careamics_version(),
+        data_description=data_description,
+    )
+
+    # authors
+    author_list = [Author(**author) for author in authors]
+
+    # inputs, outputs
+    input_descr, output_descr = _create_inputs_ouputs(
+        input_array=np.load(inputs),
+        output_array=np.load(outputs),
+        data_config=config.data_config,
+        input_path=inputs,
+        output_path=outputs,
+        channel_names=channel_names,
+    )
+
+    # weights description
+    architecture_descr = ArchitectureFromLibraryDescr(
+        import_from="careamics.models.unet",
+        callable=f"{config.algorithm_config.model.architecture}",
+        kwargs=config.algorithm_config.model.model_dump(),
+    )
+
+    weights_descr = WeightsDescr(
+        pytorch_state_dict=PytorchStateDictWeightsDescr(
+            source=weights_path,
+            architecture=architecture_descr,
+            pytorch_version=Version(PYTORCH_VERSION),
+            dependencies=FileDescr(source=Path(env_path)),
+        ),
+    )
+
+    # overall model description
+    model = ModelDescr(
+        name=name,
+        authors=author_list,
+        description=general_description,
+        documentation=doc,
+        inputs=[input_descr],
+        outputs=[output_descr],
+        tags=config.get_algorithm_keywords(),
+        links=[
+            "https://github.com/CAREamics/careamics",
+            "https://careamics.github.io/latest/",
+        ],
+        license="BSD-3-Clause",  # type: ignore
+        config={  # type: ignore
+            "bioimageio": {
+                "test_kwargs": {
+                    "pytorch_state_dict": {
+                        "absolute_tolerance": 1e-2,
+                        "relative_tolerance": 1e-2,
+                    }
+                }
+            }
+        },
+        version=Version(model_version),
+        weights=weights_descr,
+        attachments=[FileDescr(source=config_path)],
+        cite=config.get_algorithm_citations(),
+        covers=covers,
+    )
+
+    return model
+
+
+def extract_model_path(model_desc: AnyModelDescr) -> tuple[Path, Path]:
+    """Return the relative path to the weights and configuration files.
+
+    Parameters
+    ----------
+    model_desc : AnyModelDescr
+        Model description.
+
+    Returns
+    -------
+    tuple of (path, path)
+        Weights and configuration paths.
+    """
+    if model_desc.weights.pytorch_state_dict is None:
+        raise ValueError("No model weights found in model description.")
+
+    # get the model directory
+    if isinstance(model_desc.root, Path) and model_desc.root.is_dir():
+        model_dir: DirectoryPath = model_desc.root
+    else:
+        # extract the zip model
+        model_dir = extract(model_desc.root)
+
+    weights_path = model_dir.joinpath(model_desc.weights.pytorch_state_dict.source.path)
+
+    if model_desc.attachments is None:
+        raise ValueError("No configuration file found in model attachments.")
+
+    # find the configuration file
+    for file in model_desc.attachments:
+        file_path = file.source if isinstance(file.source, Path) else file.source.path
+        if file_path is None:
+            continue
+        file_path = Path(file_path)
+        if file_path.name == "careamics.yaml":
+            config_path = model_dir.joinpath(file.source.path)
+            break
+    else:
+        raise ValueError("Configuration file not found.")
+
+    return weights_path, config_path

--- a/src/careamics/model_io/bioimage/model_description.py
+++ b/src/careamics/model_io/bioimage/model_description.py
@@ -194,6 +194,7 @@ def _create_inputs_ouputs(
 
 
 def create_model_description(
+    model_dir: Path,
     config: Configuration,
     name: str,
     general_description: str,
@@ -211,6 +212,8 @@ def create_model_description(
 
     Parameters
     ----------
+    model_dir : Path
+        Model directory.
     config : Configuration
         CAREamics configuration.
     name : str
@@ -243,6 +246,7 @@ def create_model_description(
     """
     # documentation
     doc = readme_factory(
+        model_dir,
         config,
         careamics_version=get_careamics_version(),
         data_description=data_description,

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -88,7 +88,6 @@ def export_to_bmz(
     output_array: np.ndarray,
     covers: list[Union[Path, str]] | None = None,
     channel_names: list[str] | None = None,
-    model_version: str = "0.2.0",
 ) -> None:
     """Export the model to BioImage Model Zoo format.
 
@@ -121,8 +120,6 @@ def export_to_bmz(
         Paths to the cover images.
     channel_names : Optional[list[str]], optional
         Channel names, by default None.
-    model_version : str, default="0.2.0"
-        Model version.
     """
     path_to_archive = Path(path_to_archive)
 
@@ -171,7 +168,6 @@ def export_to_bmz(
             env_path=env_path,
             covers=covers,
             channel_names=channel_names,
-            model_version=model_version,
         )
 
         # test model description

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -182,7 +182,7 @@ def export_to_bmz(
             )
 
         summary: ValidationSummary = test_model(model_description, **test_kwargs)
-        summary.display()
+        summary.display(include_conda_list=False)
         if summary.status == "failed":
             raise ValueError("Model description test failed!")
         else:

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -1,0 +1,242 @@
+"""Function to export to the BioImage Model Zoo format."""
+
+import tempfile
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+from bioimageio.core import load_model_description, test_model
+from bioimageio.spec import ValidationSummary, save_bioimageio_package
+from pydantic import HttpUrl
+from torch import load, save
+
+from careamics.config.configuration import Configuration
+from careamics.config.support import SupportedArchitecture
+from careamics.config.utils.configuration_io import (
+    load_configuration,
+    save_configuration,
+)
+from careamics.lightning.modules import CAREamicsModule, create_module
+
+from .bioimage import (
+    create_model_description,
+    extract_model_path,
+    get_env_file,
+)
+from .bioimage.cover_factory import create_cover
+
+
+def _export_state_dict(model: CAREamicsModule, path: Union[Path, str]) -> Path:
+    """
+    Export the model state dictionary to a file.
+
+    Parameters
+    ----------
+    model : CAREamicsKiln
+        CAREamics model to export.
+    path : Union[Path, str]
+        Path to the file where to save the model state dictionary.
+
+    Returns
+    -------
+    Path
+        Path to the saved model state dictionary.
+    """
+    path = Path(path)
+
+    # make sure it has the correct suffix
+    if path.suffix not in ".pth":
+        path = path.with_suffix(".pth")
+
+    # save model state dictionary
+    # we save through the torch model itself to avoid the initial "model." in the
+    # layers naming, which is incompatible with the way the BMZ load torch state dicts
+    save(model.model.state_dict(), path)
+
+    return path
+
+
+def _load_state_dict(model: CAREamicsModule, path: Union[Path, str]) -> None:
+    """
+    Load a model from a state dictionary.
+
+    Parameters
+    ----------
+    model : CAREamicsKiln
+        CAREamics model to be updated with the weights.
+    path : Union[Path, str]
+        Path to the model state dictionary.
+    """
+    path = Path(path)
+
+    # load model state dictionary
+    # same as in _export_state_dict, we load through the torch model to be compatible
+    # witht bioimageio.core expectations for a torch state dict
+    state_dict = load(path)
+    model.model.load_state_dict(state_dict)
+
+
+def export_to_bmz(
+    model: CAREamicsModule,
+    config: Configuration,
+    path_to_archive: Union[Path, str],
+    model_name: str,
+    general_description: str,
+    data_description: str,
+    authors: list[dict],
+    input_array: np.ndarray,
+    output_array: np.ndarray,
+    covers: list[Union[Path, str]] | None = None,
+    channel_names: list[str] | None = None,
+    model_version: str = "0.2.0",
+) -> None:
+    """Export the model to BioImage Model Zoo format.
+
+    Arrays are expected to be SC(Z)YX with singleton dimensions allowed for S and C.
+
+    `model_name` should consist of letters, numbers, dashes, underscores and parentheses
+    only.
+
+    Parameters
+    ----------
+    model : CAREamicsModule
+        CAREamics model to export.
+    config : Configuration
+        Model configuration.
+    path_to_archive : Union[Path, str]
+        Path to the output file.
+    model_name : str
+        Model name.
+    general_description : str
+        General description of the model.
+    data_description : str
+        Description of the data the model was trained on.
+    authors : list[dict]
+        Authors of the model.
+    input_array : np.ndarray
+        Input array, should not have been normalized.
+    output_array : np.ndarray
+        Output array, should have been denormalized.
+    covers : list of pathlib.Path or str, default=None
+        Paths to the cover images.
+    channel_names : Optional[list[str]], optional
+        Channel names, by default None.
+    model_version : str, default="0.2.0"
+        Model version.
+    """
+    path_to_archive = Path(path_to_archive)
+
+    if path_to_archive.suffix != ".zip":
+        raise ValueError(
+            f"Path to archive must point to a zip file, got {path_to_archive}."
+        )
+
+    if not path_to_archive.parent.exists():
+        path_to_archive.parent.mkdir(parents=True, exist_ok=True)
+
+    # save files in temporary folder
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        temp_path = Path(tmpdirname)
+
+        # create environment file
+        env_path = get_env_file(temp_path)
+
+        # export input and outputs
+        inputs = temp_path / "inputs.npy"
+        np.save(inputs, input_array)
+        outputs = temp_path / "outputs.npy"
+        np.save(outputs, output_array)
+
+        # export configuration
+        config_path = save_configuration(config, temp_path / "careamics.yaml")
+
+        # export model state dictionary
+        weight_path = _export_state_dict(model, temp_path / "weights.pth")
+
+        # create covers if necessary
+        if covers is None:
+            covers = [create_cover(temp_path, input_array, output_array)]
+
+        # create model description
+        model_description = create_model_description(
+            config=config,
+            name=model_name,
+            general_description=general_description,
+            data_description=data_description,
+            authors=authors,
+            inputs=inputs,
+            outputs=outputs,
+            weights_path=weight_path,
+            config_path=config_path,
+            env_path=env_path,
+            covers=covers,
+            channel_names=channel_names,
+            model_version=model_version,
+        )
+
+        # test model description
+        test_kwargs = {}
+        if hasattr(model_description, "config") and isinstance(
+            model_description.config, dict
+        ):
+            bioimageio_config = model_description.config.get("bioimageio", {})
+            test_kwargs = bioimageio_config.get("test_kwargs", {}).get(
+                "pytorch_state_dict", {}
+            )
+
+        summary: ValidationSummary = test_model(model_description, **test_kwargs)
+        summary.display()
+        if summary.status == "failed":
+            raise ValueError("Model description test failed!")
+        else:
+            print("Model description test passed.")
+
+        # save bmz model
+        save_bioimageio_package(model_description, output_path=path_to_archive)
+
+
+def load_from_bmz(
+    path: Union[Path, str, HttpUrl],
+) -> tuple[Configuration, CAREamicsModule]:
+    """Load a model from a BioImage Model Zoo archive.
+
+    Parameters
+    ----------
+    path : Path, str or HttpUrl
+        Path to the BioImage Model Zoo archive. A Http URL must point to a downloadable
+        location.
+
+    Returns
+    -------
+    FCNModel or VAEModel
+        The loaded CAREamics model.
+    Configuration
+        The loaded CAREamics configuration.
+
+    Raises
+    ------
+    ValueError
+        If the path is not a zip file.
+    """
+    # load description, this creates an unzipped folder next to the archive
+    model_desc = load_model_description(path)
+
+    # extract paths
+    weights_path, config_path = extract_model_path(model_desc)
+
+    # load configuration
+    config = load_configuration(config_path)
+
+    # create careamics lightning module
+    if config.algorithm_config.model.architecture == SupportedArchitecture.UNET:
+        model = create_module(config.algorithm_config)
+
+    else:
+        raise ValueError(
+            f"Unsupported architecture {config.algorithm_config.model.architecture}"
+        )
+
+    # load model state dictionary
+    _load_state_dict(model, weights_path)
+
+    return config, model

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -156,6 +156,7 @@ def export_to_bmz(
 
         # create model description
         model_description = create_model_description(
+            model_dir=temp_path,
             config=config,
             name=model_name,
             general_description=general_description,

--- a/src/careamics/model_io/bmz_io.py
+++ b/src/careamics/model_io/bmz_io.py
@@ -182,7 +182,6 @@ def export_to_bmz(
             )
 
         summary: ValidationSummary = test_model(model_description, **test_kwargs)
-        summary.display(include_conda_list=False)
         if summary.status == "failed":
             raise ValueError("Model description test failed!")
         else:

--- a/src/careamics/model_io/model_io_utils.py
+++ b/src/careamics/model_io/model_io_utils.py
@@ -1,0 +1,100 @@
+"""Utility functions to load pretrained models."""
+
+from pathlib import Path
+
+import torch
+
+from careamics.config.configuration import Configuration
+from careamics.config.support import SupportedArchitecture
+from careamics.lightning.modules import CAREamicsModule, create_module
+from careamics.model_io.bmz_io import load_from_bmz
+
+
+def load_pretrained(
+    path: Path | str,
+) -> tuple[Configuration, CAREamicsModule]:
+    """
+    Load a pretrained model from a checkpoint or a BioImage Model Zoo model.
+
+    Expected formats are .ckpt or .zip files.
+
+    Parameters
+    ----------
+    path : Path | str
+        Path to the pretrained model.
+
+    Returns
+    -------
+    tuple[Configuration, CAREamicsModule]
+        tuple of CAREamics model and its configuration.
+
+    Raises
+    ------
+    ValueError
+        If the model format is not supported.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Data path {path} is incorrect or does not exist.")
+
+    if path.suffix == ".ckpt":
+        return _load_checkpoint(path)
+    elif path.suffix == ".zip":
+        return load_from_bmz(path)
+    else:
+        raise ValueError(
+            f"Invalid model format. Expected .ckpt or .zip, got {path.suffix}."
+        )
+
+
+def _load_checkpoint(
+    path: Path | str,
+) -> tuple[Configuration, CAREamicsModule]:
+    """
+    Load a model from a checkpoint and return both model and configuration.
+
+    Parameters
+    ----------
+    path : Path | str
+        Path to the checkpoint.
+
+    Returns
+    -------
+    tuple[Configuration, CAREamicsModule]
+        tuple of CAREamics model and its configuration.
+
+    Raises
+    ------
+    ValueError
+        If the checkpoint file does not contain hyper parameters (configuration).
+    """
+    # load checkpoint
+    # here we might run into issues between devices
+    # see https://pytorch.org/tutorials/recipes/recipes/save_load_across_devices.html
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    checkpoint: dict = torch.load(path, map_location=device)
+
+    # attempt to load configuration
+    try:
+        cfg_dict = checkpoint["hyper_parameters"]
+    except KeyError as e:
+        raise ValueError(
+            f"Invalid checkpoint file. No `hyper_parameters` found in the "
+            f"checkpoint: {checkpoint.keys()}"
+        ) from e
+
+    config = Configuration(**cfg_dict)
+
+    # create careamics lightning module
+    if config.algorithm_config.model.architecture == SupportedArchitecture.UNET:
+        model = create_module(config.algorithm_config)
+
+    else:
+        raise ValueError(
+            f"Unsupported architecture {config.algorithm_config.model.architecture}"
+        )
+
+    # loading model state_dict
+    model.model.load_state_dict(checkpoint)
+
+    return config, model

--- a/src/careamics/references/__init__.py
+++ b/src/careamics/references/__init__.py
@@ -1,0 +1,1 @@
+"""CAREamics algorithm references."""

--- a/src/careamics/references/care/__init__.py
+++ b/src/careamics/references/care/__init__.py
@@ -1,0 +1,10 @@
+"""CARE citation and references."""
+
+from .citations import CARE_REF
+from .descriptions import CARE, CARE_DESCRIPTION
+
+__all__ = [
+    "CARE",
+    "CARE_DESCRIPTION",
+    "CARE_REF",
+]

--- a/src/careamics/references/care/citations.py
+++ b/src/careamics/references/care/citations.py
@@ -1,0 +1,9 @@
+"""CARE references."""
+
+from bioimageio.spec.model.v0_5 import CiteEntry, Doi
+
+CARE_REF = CiteEntry(
+    text='Weigert, Martin, et al. "Content-aware image restoration: pushing the '
+    'limits of fluorescence microscopy." Nature methods 15.12 (2018): 1090-1097.',
+    doi=Doi("10.1038/s41592-018-0216-7"),
+)

--- a/src/careamics/references/care/descriptions.py
+++ b/src/careamics/references/care/descriptions.py
@@ -1,0 +1,13 @@
+"""CAREamics CARE model descriptions."""
+
+CARE = "CARE"
+
+CARE_DESCRIPTION = (
+    "Content-aware image restoration (CARE) is a deep-learning-based "
+    "algorithm that uses a U-Net architecture to restore images. CARE "
+    "is a supervised algorithm that requires pairs of noisy and "
+    "clean images to train the network. The algorithm learns to "
+    "predict the clean image from the noisy image. CARE is "
+    "particularly useful for denoising images acquired in low-light "
+    "conditions, such as fluorescence microscopy images."
+)

--- a/src/careamics/references/n2n/__init__.py
+++ b/src/careamics/references/n2n/__init__.py
@@ -1,0 +1,10 @@
+"""N2N citation and references."""
+
+from .citations import N2N_REF
+from .descriptions import N2N, N2N_DESCRIPTION
+
+__all__ = [
+    "N2N",
+    "N2N_DESCRIPTION",
+    "N2N_REF",
+]

--- a/src/careamics/references/n2n/citations.py
+++ b/src/careamics/references/n2n/citations.py
@@ -1,0 +1,10 @@
+"""N2N references."""
+
+from bioimageio.spec.model.v0_5 import CiteEntry, Doi
+
+N2N_REF = CiteEntry(
+    text="Lehtinen, J., Munkberg, J., Hasselgren, J., Laine, S., Karras, T., "
+    'Aittala, M. and Aila, T., 2018. "Noise2Noise: Learning image restoration '
+    'without clean data". arXiv preprint arXiv:1803.04189.',
+    doi=Doi("10.48550/arXiv.1803.04189"),
+)

--- a/src/careamics/references/n2n/descriptions.py
+++ b/src/careamics/references/n2n/descriptions.py
@@ -1,0 +1,12 @@
+"""CAREamics N2N model descriptions."""
+
+N2N = "Noise2Noise"
+
+N2N_DESCRIPTION = (
+    "Noise2Noise is a deep-learning-based algorithm that uses a U-Net "
+    "architecture to restore images. Noise2Noise is a self-supervised "
+    "algorithm that requires only noisy images to train the network. "
+    "The algorithm learns to predict the clean image from the noisy "
+    "image. Noise2Noise is particularly useful when clean images are "
+    "not available for training."
+)

--- a/src/careamics/references/n2v/__init__.py
+++ b/src/careamics/references/n2v/__init__.py
@@ -1,0 +1,27 @@
+"""N2V algorithm references and descriptions."""
+
+from .citations import N2V2_REF, N2V_REF, STRUCTN2V_REF
+from .descriptions import (
+    N2V,
+    N2V2,
+    N2V2_DESCRIPTION,
+    N2V_DESCRIPTION,
+    STR_N2V2_DESCRIPTION,
+    STR_N2V_DESCRIPTION,
+    STRUCT_N2V,
+    STRUCT_N2V2,
+)
+
+__all__ = [
+    "N2V",
+    "N2V2",
+    "N2V2_DESCRIPTION",
+    "N2V2_REF",
+    "N2V_DESCRIPTION",
+    "N2V_REF",
+    "STRUCTN2V_REF",
+    "STRUCT_N2V",
+    "STRUCT_N2V2",
+    "STR_N2V2_DESCRIPTION",
+    "STR_N2V_DESCRIPTION",
+]

--- a/src/careamics/references/n2v/citations.py
+++ b/src/careamics/references/n2v/citations.py
@@ -1,0 +1,26 @@
+"""N2V references."""
+
+from bioimageio.spec.model.v0_5 import CiteEntry, Doi
+
+N2V_REF = CiteEntry(
+    text='Krull, A., Buchholz, T.O. and Jug, F., 2019. "Noise2Void - Learning '
+    'denoising from single noisy images". In Proceedings of the IEEE/CVF '
+    "conference on computer vision and pattern recognition (pp. 2129-2137).",
+    doi=Doi("10.1109/cvpr.2019.00223"),
+)
+
+N2V2_REF = CiteEntry(
+    text="Höck, E., Buchholz, T.O., Brachmann, A., Jug, F. and Freytag, A., "
+    '2022. "N2V2 - Fixing Noise2Void checkerboard artifacts with modified '
+    'sampling strategies and a tweaked network architecture". In European '
+    "Conference on Computer Vision (pp. 503-518).",
+    doi=Doi("10.1007/978-3-031-25069-9_33"),
+)
+
+STRUCTN2V_REF = CiteEntry(
+    text="Broaddus, C., Krull, A., Weigert, M., Schmidt, U. and Myers, G., 2020."
+    '"Removing structured noise with self-supervised blind-spot '
+    'networks". In 2020 IEEE 17th International Symposium on Biomedical '
+    "Imaging (ISBI) (pp. 159-163).",
+    doi=Doi("10.1109/isbi45749.2020.9098336"),
+)

--- a/src/careamics/references/n2v/descriptions.py
+++ b/src/careamics/references/n2v/descriptions.py
@@ -1,0 +1,48 @@
+"""CAREamics N2V model descriptions."""
+
+N2V = "Noise2Void"
+N2V2 = "N2V2"
+STRUCT_N2V = "StructN2V"
+STRUCT_N2V2 = "StructN2V2"
+
+N2V_DESCRIPTION = (
+    "Noise2Void is a UNet-based self-supervised algorithm that "
+    "uses blind-spot training to denoise images. In short, in every "
+    "patches during training, random pixels are selected and their "
+    "value replaced by a neighboring pixel value. The network is then "
+    "trained to predict the original pixel value. The algorithm "
+    "relies on the continuity of the signal (neighboring pixels have "
+    "similar values) and the pixel-wise independence of the noise "
+    "(the noise in a pixel is not correlated with the noise in "
+    "neighboring pixels)."
+)
+
+N2V2_DESCRIPTION = (
+    "N2V2 is a variant of Noise2Void. "
+    + N2V_DESCRIPTION
+    + "\nN2V2 introduces blur-pool layers and removed skip "
+    "connections in the UNet architecture to remove checkboard "
+    "artefacts, a common artefacts ocurring in Noise2Void."
+)
+
+STR_N2V_DESCRIPTION = (
+    "StructN2V is a variant of Noise2Void. "
+    + N2V_DESCRIPTION
+    + "\nStructN2V uses a linear mask (horizontal or vertical) to replace "
+    "the pixel values of neighbors of the masked pixels by a random "
+    "value. Such masking allows removing 1D structured noise from the "
+    "the images, the main failure case of the original N2V."
+)
+
+STR_N2V2_DESCRIPTION = (
+    "StructN2V2 is a a variant of Noise2Void that uses both "
+    "structN2V and N2V2. "
+    + N2V_DESCRIPTION
+    + "\nStructN2V2 uses a linear mask (horizontal or vertical) to replace "
+    "the pixel values of neighbors of the masked pixels by a random "
+    "value. Such masking allows removing 1D structured noise from the "
+    "the images, the main failure case of the original N2V."
+    "\nN2V2 introduces blur-pool layers and removed skip connections in "
+    "the UNet architecture to remove checkboard artefacts, a common "
+    "artefacts ocurring in Noise2Void."
+)

--- a/src/careamics/references/pn2v/__init__.py
+++ b/src/careamics/references/pn2v/__init__.py
@@ -1,0 +1,27 @@
+"""PN2V citation and references."""
+
+from .citations import N2V2_REF, PN2V_REF, STRUCTN2V_REF
+from .descriptions import (
+    PN2V,
+    PN2V2,
+    PN2V2_DESCRIPTION,
+    PN2V_DESCRIPTION,
+    STRUCT_PN2V,
+    STRUCT_PN2V2,
+    STRUCT_PN2V2_DESCRIPTION,
+    STRUCT_PN2V_DESCRIPTION,
+)
+
+__all__ = [
+    "N2V2_REF",
+    "PN2V",
+    "PN2V2",
+    "PN2V2_DESCRIPTION",
+    "PN2V_DESCRIPTION",
+    "PN2V_REF",
+    "STRUCTN2V_REF",
+    "STRUCT_PN2V",
+    "STRUCT_PN2V2",
+    "STRUCT_PN2V2_DESCRIPTION",
+    "STRUCT_PN2V_DESCRIPTION",
+]

--- a/src/careamics/references/pn2v/citations.py
+++ b/src/careamics/references/pn2v/citations.py
@@ -1,0 +1,26 @@
+"""PN2V references."""
+
+from bioimageio.spec.model.v0_5 import CiteEntry, Doi
+
+PN2V_REF = CiteEntry(
+    text="Krull, A., Vicar, T., Prakash, M., Lalit, M. and Jug, F., 2020. "
+    '"Probabilistic noise2void: Unsupervised content-aware denoising". '
+    "Frontiers in Computer Science, 2, p.5.",
+    doi=Doi("10.3389/fcomp.2020.00005"),
+)
+
+N2V2_REF = CiteEntry(
+    text="Höck, E., Buchholz, T.O., Brachmann, A., Jug, F. and Freytag, A., "
+    '2022. "N2V2 - Fixing Noise2Void checkerboard artifacts with modified '
+    'sampling strategies and a tweaked network architecture". In European '
+    "Conference on Computer Vision (pp. 503-518).",
+    doi=Doi("10.1007/978-3-031-25069-9_33"),
+)
+
+STRUCTN2V_REF = CiteEntry(
+    text="Broaddus, C., Krull, A., Weigert, M., Schmidt, U. and Myers, G., 2020."
+    '"Removing structured noise with self-supervised blind-spot '
+    'networks". In 2020 IEEE 17th International Symposium on Biomedical '
+    "Imaging (ISBI) (pp. 159-163).",
+    doi=Doi("10.1109/isbi45749.2020.9098336"),
+)

--- a/src/careamics/references/pn2v/descriptions.py
+++ b/src/careamics/references/pn2v/descriptions.py
@@ -1,0 +1,47 @@
+"""CAREamics PN2V model descriptions."""
+
+PN2V = "Probabilistic Noise2Void"
+PN2V2 = "PN2V2"
+STRUCT_PN2V = "StructPN2V"
+STRUCT_PN2V2 = "StructPN2V2"
+
+PN2V_DESCRIPTION = (
+    "Probabilistic Noise2Void (PN2V) is a UNet-based self-supervised algorithm that "
+    "extends Noise2Void by incorporating a probabilistic noise model to estimate the "
+    "posterior distribution of each pixel more precisely. Like N2V, it uses blind-spot "
+    "training where random pixels are selected in patches during training and their "
+    "value replaced by a neighboring pixel value. The model is then trained to predict "
+    "the original pixel value. PN2V additionally uses a noise model to better capture "
+    "the noise characteristics and provide more accurate denoising by modeling the "
+    "likelihood of pixel intensities."
+)
+
+PN2V2_DESCRIPTION = (
+    "PN2V2 is a variant of Probabilistic Noise2Void. "
+    + PN2V_DESCRIPTION
+    + "\nPN2V2 introduces blur-pool layers and removed skip "
+    "connections in the UNet architecture to remove checkboard "
+    "artefacts, a common artefacts occurring in Noise2Void variants."
+)
+
+STRUCT_PN2V_DESCRIPTION = (
+    "StructPN2V is a variant of Probabilistic Noise2Void. "
+    + PN2V_DESCRIPTION
+    + "\nStructPN2V uses a linear mask (horizontal or vertical) to replace "
+    "the pixel values of neighbors of the masked pixels by a random "
+    "value. Such masking allows removing 1D structured noise from the "
+    "the images, the main failure case of the original N2V variants."
+)
+
+STRUCT_PN2V2_DESCRIPTION = (
+    "StructPN2V2 is a variant of Probabilistic Noise2Void that uses both "
+    "structN2V and N2V2. "
+    + PN2V_DESCRIPTION
+    + "\nStructPN2V2 uses a linear mask (horizontal or vertical) to replace "
+    "the pixel values of neighbors of the masked pixels by a random "
+    "value. Such masking allows removing 1D structured noise from the "
+    "the images, the main failure case of the original N2V variants."
+    "\nPN2V2 introduces blur-pool layers and removed skip connections in "
+    "the UNet architecture to remove checkboard artefacts, a common "
+    "artefacts occurring in Noise2Void variants."
+)

--- a/tests/compat/model_io/test_bmz_io_compat.py
+++ b/tests/compat/model_io/test_bmz_io_compat.py
@@ -11,7 +11,7 @@ from careamics.compat.model_io.bmz_io import _export_state_dict, _load_state_dic
 pytestmark = pytest.mark.mps_gh_fail
 
 
-def test_state_dict_io(tmp_path, ordered_array, pre_trained):
+def test_state_dict_io_compat(tmp_path, ordered_array, pre_trained):
     """Test exporting and loading a state dict."""
     # training data
     train_array = ordered_array((32, 32))
@@ -36,7 +36,7 @@ def test_state_dict_io(tmp_path, ordered_array, pre_trained):
     np.testing.assert_almost_equal(predicted_loaded[0], predicted, decimal=3)
 
 
-def test_bmz_io(tmp_path, ordered_array, pre_trained):
+def test_bmz_io_compat(tmp_path, ordered_array, pre_trained):
     """Test exporting and loading to the BMZ."""
     # training data
     train_array = ordered_array((32, 32))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -407,7 +407,7 @@ def pre_trained_v2(tmp_path):
     careamist.train(train_data=train_array)
 
     # check that it trained
-    pre_trained_path: Path = tmp_path / "checkpoints" / "test_last.ckpt"
+    pre_trained_path: Path = tmp_path / "checkpoints" / "test_0" / "test_last.ckpt"
     assert pre_trained_path.exists()
 
     return pre_trained_path

--- a/tests/model_io/test_bmz_io.py
+++ b/tests/model_io/test_bmz_io.py
@@ -1,0 +1,83 @@
+import numpy as np
+import pytest
+import torch
+from bioimageio.spec import InvalidDescr, load_description
+from torch import Tensor
+
+from careamics import CAREamist
+from careamics.model_io import export_to_bmz, load_pretrained
+from careamics.model_io.bmz_io import _export_state_dict, _load_state_dict
+
+pytestmark = pytest.mark.mps_gh_fail
+
+
+def test_state_dict_io(tmp_path, ordered_array, pre_trained_v2):
+    """Test exporting and loading a state dict."""
+    # training data
+    train_array = ordered_array((32, 32))
+    path = tmp_path / "model.pth"
+
+    # instantiate CAREamist
+    careamist = CAREamist(checkpoint_path=pre_trained_v2, work_dir=tmp_path)
+
+    # predict (no tiling and no tta)
+    predicted_output, _ = careamist.predict(train_array)
+    predicted = np.concatenate(predicted_output, axis=0)
+
+    # save model
+    _export_state_dict(careamist.model, path)
+    assert path.exists()
+
+    # load model
+    _load_state_dict(careamist.model, path)
+
+    # predict (no tiling and no tta)
+    predicted_loaded, _ = careamist.predict(train_array)
+    np.testing.assert_almost_equal(predicted_loaded[0], predicted, decimal=3)
+
+
+def test_bmz_io(tmp_path, ordered_array, pre_trained_v2):
+    """Test exporting and loading to the BMZ."""
+    # training data
+    train_array = ordered_array((32, 32))
+
+    # instantiate CAREamist
+    careamist = CAREamist(checkpoint_path=pre_trained_v2, work_dir=tmp_path)
+
+    # predict (no tiling and no tta)
+    predicted_output, _ = careamist.predict(train_array)
+    predicted = np.concatenate(predicted_output, axis=0)
+
+    # export to BioImage Model Zoo
+    path = tmp_path / "other_folder" / "model.zip"
+    export_to_bmz(
+        model=careamist.model,
+        config=careamist.config,
+        path_to_archive=path,
+        model_name="TopModel",
+        general_description="A model that just walked in.",
+        data_description="My data.",
+        authors=[{"name": "Amod", "affiliation": "El"}],
+        input_array=train_array[np.newaxis, np.newaxis, ...],
+        output_array=predicted[np.newaxis, np.newaxis, ...],
+        model_version="0.2.0",
+    )
+    assert path.exists()
+
+    # load description
+    description = load_description(path)
+    assert not isinstance(description, InvalidDescr)
+    assert str(description.version) == "0.2.0"
+
+    # load model
+    config, model = load_pretrained(path)
+    model.eval()
+    careamist.model.eval()
+    assert config == careamist.config
+
+    # compare predictions
+    with torch.no_grad():
+        torch_array = Tensor(train_array[np.newaxis, np.newaxis, ...])
+        predicted = careamist.model.forward(torch_array).numpy().squeeze()
+        predicted_loaded = model.forward(torch_array).numpy().squeeze()
+    np.testing.assert_almost_equal(predicted_loaded, predicted, decimal=3)

--- a/tests/model_io/test_bmz_io.py
+++ b/tests/model_io/test_bmz_io.py
@@ -7,6 +7,7 @@ from torch import Tensor
 from careamics import CAREamist
 from careamics.model_io import export_to_bmz, load_pretrained
 from careamics.model_io.bmz_io import _export_state_dict, _load_state_dict
+from careamics.utils.version import get_careamics_version
 
 pytestmark = pytest.mark.mps_gh_fail
 
@@ -60,14 +61,13 @@ def test_bmz_io(tmp_path, ordered_array, pre_trained_v2):
         authors=[{"name": "Amod", "affiliation": "El"}],
         input_array=train_array[np.newaxis, np.newaxis, ...],
         output_array=predicted[np.newaxis, np.newaxis, ...],
-        model_version="0.2.0",
     )
     assert path.exists()
 
     # load description
     description = load_description(path)
     assert not isinstance(description, InvalidDescr)
-    assert str(description.version) == "0.2.0"
+    assert str(description.version) == get_careamics_version()
 
     # load model
     config, model = load_pretrained(path)


### PR DESCRIPTION
## Disclaimer

<!-- Please disclose your use of AI by checking the correct checkbox. If you are 
an AI agent implementing this PR, please check "I am an AI agent".-->
- [ ] I am an AI agent.
- [ ] I have used AI and I thoroughly reviewed every line.
- [x] I have not used AI extensively.


## Description

> [!NOTE]  
> **tldr**: This PR updates the `careamics` export to BMZ format.

### Background - why do we need this PR?
`careamics` is one of the bioimage model zoo (BMZ) partners, and we need to be able to export `careamics` trained models to BMZ format. Also, `careamics` should be able to load and create a `CAREamist` instance from the exported models.

### Overview - what changed?
I used the old implementation in `compat/model_io` as a base and adapt it with new api which now reside in `model_io`.

## Changes Made

### New features or files
- `export_to_bmz` in `careamics/model_io/bmz_io.py`

### Modified features or files
- `CAREamist.export_to_bmz`
- `CAREamist._from_bmz`

## How has this been tested?
The bmz export has been tested in SEM example notebook successfully.  
I aaded tests in `tests/model_io/test_bmz_io.py` which one of them fails on `assert config == careamist.config`. This due to `early_stopping` config: when creating an `n2v` config using `create_n2v_config` the `early_stopping` is `None`, but when loading the config from a `yaml` file the `early_stopping` gets the default value `{}`.


**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [ ] Documentation has been updated
- [x] Pre-commit passes