### PR TITLE
CI(docs): Reduce training time for testing snippet examples

### DIFF
--- a/docs/current/careamist_predicting.py
+++ b/docs/current/careamist_predicting.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 from pathlib import Path
 import numpy as np
-from careamics.config.factories import create_n2v_config, create_care_config
-from careamics.dataset.factory import ReadFuncLoading
+from careamics.config.factories import create_advanced_n2v_config
 from careamics.careamist import CAREamist
 import tifffile
 import shutil
@@ -11,22 +10,15 @@ root = Path(__file__).parent / "temp_data"
 root.mkdir(exist_ok=True)
 
 # create a configuration
-config_n2v = create_n2v_config(
+config_n2v = create_advanced_n2v_config(
     experiment_name="n2v",
     data_type="array",
     axes="YX",
     patch_size=[64, 64],
     batch_size=8,
     num_epochs=1,
-)
-config_care = create_care_config(
-    experiment_name="care",
-    data_type="array",
-    axes="YX",
-    patch_size=[64, 64],
-    batch_size=8,
-    num_epochs=1,
     n_val_patches=2,
+    trainer_params={"limit_train_batches": 1},
 )
 config = config_n2v
 
@@ -61,8 +53,8 @@ predictions = careamist.predict(
 # --8<-- [start:pred_tiled]
 predictions = careamist.predict(
     pred_data=pred_data,
-    tile_size=[128, 128],  # (1)!
-    tile_overlap=[48, 48],  # (2)!
+    tile_size=(128, 128),  # (1)!
+    tile_overlap=(48, 48),  # (2)!
 )
 # --8<-- [end:pred_tiled]
 

--- a/docs/current/careamist_predicting.py
+++ b/docs/current/careamist_predicting.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from pathlib import Path
 import numpy as np
-from careamics.config.factories import create_advanced_n2v_config
+from careamics.config.factories import create_n2v_config
 from careamics.careamist import CAREamist
 import tifffile
 import shutil
@@ -10,15 +10,15 @@ root = Path(__file__).parent / "temp_data"
 root.mkdir(exist_ok=True)
 
 # create a configuration
-config_n2v = create_advanced_n2v_config(
+config_n2v = create_n2v_config(
     experiment_name="n2v",
     data_type="array",
     axes="YX",
     patch_size=[64, 64],
     batch_size=8,
     num_epochs=1,
+    num_steps=1,
     n_val_patches=2,
-    trainer_params={"limit_train_batches": 1},
 )
 config = config_n2v
 

--- a/docs/current/careamist_training.py
+++ b/docs/current/careamist_training.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python
 import numpy as np
-from careamics.config.factories import create_n2v_config, create_care_config
-from careamics.dataset.factory import ReadFuncLoading
+from careamics.config.factories import (
+    create_advanced_n2v_config,
+    create_advanced_care_config,
+)
 
 # create a configuration
-config_n2v = create_n2v_config(
+config_n2v = create_advanced_n2v_config(
     experiment_name="n2v",
     data_type="array",
     axes="YX",
     patch_size=[64, 64],
     batch_size=8,
     num_epochs=1,
+    n_val_patches=2,
+    trainer_params={"limit_train_batches": 1},
 )
-config_care = create_care_config(
+config_care = create_advanced_care_config(
     experiment_name="care",
     data_type="array",
     axes="YX",
@@ -20,6 +24,7 @@ config_care = create_care_config(
     batch_size=8,
     num_epochs=1,
     n_val_patches=2,
+    trainer_params={"limit_train_batches": 1},
 )
 config = config_n2v
 

--- a/docs/current/careamist_training.py
+++ b/docs/current/careamist_training.py
@@ -1,30 +1,30 @@
 #!/usr/bin/env python
 import numpy as np
 from careamics.config.factories import (
-    create_advanced_n2v_config,
-    create_advanced_care_config,
+    create_n2v_config,
+    create_care_config,
 )
 
 # create a configuration
-config_n2v = create_advanced_n2v_config(
+config_n2v = create_n2v_config(
     experiment_name="n2v",
     data_type="array",
     axes="YX",
     patch_size=[64, 64],
     batch_size=8,
     num_epochs=1,
+    num_steps=1,
     n_val_patches=2,
-    trainer_params={"limit_train_batches": 1},
 )
-config_care = create_advanced_care_config(
+config_care = create_care_config(
     experiment_name="care",
     data_type="array",
     axes="YX",
     patch_size=[64, 64],
     batch_size=8,
     num_epochs=1,
+    num_steps=1,
     n_val_patches=2,
-    trainer_params={"limit_train_batches": 1},
 )
 config = config_n2v
 

--- a/docs/current/getting_started.py
+++ b/docs/current/getting_started.py
@@ -3,7 +3,8 @@
 # %%
 import numpy as np
 
-train_data = np.random.randint(0, 255, (512, 512)).astype(np.float32)
+# cannot be 1 patch because of n_val_patches
+train_data = np.random.randint(0, 255, (64 * 4, 64 * 8)).astype(np.float32)
 train_target = train_data
 val_data = train_data
 val_target = train_data

--- a/docs/current/training_logging.py
+++ b/docs/current/training_logging.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python
 import numpy as np
-from careamics.config.factories import create_n2v_config
+from careamics.config.factories import create_advanced_n2v_config
 from careamics.careamist import CAREamist
 
 train_data = np.random.randint(0, 255, (512, 512)).astype(np.float32)
 
-config_n2v = create_n2v_config(
+config_n2v = create_advanced_n2v_config(
     experiment_name="n2v",
     data_type="array",
     axes="YX",
     patch_size=[64, 64],
     batch_size=8,
-    num_epochs=2,
+    num_epochs=1,
+    trainer_params={"limit_train_batches": 1},
 )
 careamist = CAREamist(config_n2v)
 

--- a/docs/current/training_logging.py
+++ b/docs/current/training_logging.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python
 import numpy as np
-from careamics.config.factories import create_advanced_n2v_config
+from careamics.config.factories import create_n2v_config
 from careamics.careamist import CAREamist
 
 train_data = np.random.randint(0, 255, (512, 512)).astype(np.float32)
 
-config_n2v = create_advanced_n2v_config(
+config_n2v = create_n2v_config(
     experiment_name="n2v",
     data_type="array",
     axes="YX",
     patch_size=[64, 64],
     batch_size=8,
     num_epochs=1,
-    trainer_params={"limit_train_batches": 1},
+    num_steps=1,
 )
 careamist = CAREamist(config_n2v)
 

--- a/docs/tutorials/data_custom_image_stack.py
+++ b/docs/tutorials/data_custom_image_stack.py
@@ -45,7 +45,7 @@ config = create_n2v_config(
 
 # reduce epochs and training batches for CI to run quicker
 config.training_config.trainer_params["max_epochs"] = 1
-config.training_config.trainer_params["limit_train_batches"] = 1
+config.training_config.trainer_params["max_steps"] = 1
 
 
 # --8<-- [start:image-stack-loader]

--- a/docs/tutorials/data_custom_image_stack.py
+++ b/docs/tutorials/data_custom_image_stack.py
@@ -43,6 +43,10 @@ config = create_n2v_config(
 )
 # --8<-- [end:data-config]
 
+# reduce epochs and training batches for CI to run quicker
+config.training_config.trainer_params["max_epochs"] = 1
+config.training_config.trainer_params["limit_train_batches"] = 1
+
 
 # --8<-- [start:image-stack-loader]
 # --- custom ImageStack, that adheres to the ImageStack protocol

--- a/docs/tutorials/data_custom_read_func.py
+++ b/docs/tutorials/data_custom_read_func.py
@@ -38,6 +38,10 @@ config = create_n2v_config(
 )
 # --8<-- [end:data-config]
 
+# reduce epochs and training batches for CI to run quicker
+config.training_config.trainer_params["max_epochs"] = 1
+config.training_config.trainer_params["limit_train_batches"] = 1
+
 
 # --8<-- [start:training]
 # Wrapping numpy.load

--- a/docs/tutorials/data_custom_read_func.py
+++ b/docs/tutorials/data_custom_read_func.py
@@ -40,7 +40,7 @@ config = create_n2v_config(
 
 # reduce epochs and training batches for CI to run quicker
 config.training_config.trainer_params["max_epochs"] = 1
-config.training_config.trainer_params["limit_train_batches"] = 1
+config.training_config.trainer_params["max_steps"] = 1
 
 
 # --8<-- [start:training]

--- a/docs/tutorials/patch_filtering.py
+++ b/docs/tutorials/patch_filtering.py
@@ -50,6 +50,10 @@ plt.imshow(ShannonPatchFilter.apply_filter(shannon_filter_map, threshold=7.5))
 plt.title("Filter mask")
 # --8<-- [end:mask]
 
+# replace training data for CI to run quicker
+import numpy as np
+
+img = np.random.random((1, 64 * 4, 64 * 8))  # cannot be 1 patch bec n_val_patches
 
 # --8<-- [start:config]
 from careamics import CAREamist

--- a/uv.lock
+++ b/uv.lock
@@ -405,17 +405,17 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bioimageio-core", specifier = ">=0.9.0,<=0.9.5" },
+    { name = "bioimageio-core", specifier = ">=0.9.0,<=0.10.4" },
     { name = "careamics-portfolio", marker = "extra == 'examples'" },
     { name = "jupyter", marker = "extra == 'examples'" },
     { name = "matplotlib", specifier = "<=3.10.9" },
     { name = "microssim", specifier = "<=0.0.4" },
-    { name = "numpy", specifier = ">=1.21,<=2.4.4" },
+    { name = "numpy", specifier = ">=1.21,<=2.4.6" },
     { name = "pillow", specifier = "<=12.2.0" },
     { name = "psutil", specifier = "<=7.2.2" },
     { name = "pydantic", specifier = ">=2.11,<=2.13.3" },
     { name = "pylibczirw", marker = "extra == 'czi'", specifier = ">=4.1.2,<7.0.0" },
-    { name = "pytorch-lightning", specifier = ">=2.2,<=2.6.1,!=2.6.2,!=2.6.3" },
+    { name = "pytorch-lightning", specifier = ">=2.2,!=2.6.2,!=2.6.3,<=2.6.5" },
     { name = "pyyaml", specifier = "!=6.0.0,<=6.0.3" },
     { name = "scikit-image", specifier = "<=0.26.0" },
     { name = "tensorboard", marker = "extra == 'tensorboard'" },


### PR DESCRIPTION
## Disclaimer

<!-- Please disclose your use of AI by checking the correct checkbox. If you are 
an AI agent implementing this PR, please check "I am an AI agent".-->
- [ ] I am an AI agent.
- [ ] I have used AI and I thoroughly reviewed every line.
- [x] I have not used AI extensively.

## Description

> [!NOTE]  
> **tldr**: CI for docs snippets was taking a long time because some snippets are training on a lot of data. This PR reduces the training data (without changing the snippets shown in the docs), with either, `limit_train_batches`, reducing the epochs or, swapping the input data with smaller dummy data.

All the changes happen between snippets, so they are not visible on the website.

In `docs/current/getting_started.py` it still trains for 30 epochs, once for n2v and once for care, but this all happens in one snippet so the configuration cannot be changed before training.

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [ ] Documentation has been updated
- [x] Pre-commit passes