### PR TITLE
Chore: change data source from HT to Zenodo

### DIFF
--- a/docs/current/lightning_api.py
+++ b/docs/current/lightning_api.py
@@ -14,8 +14,14 @@ from careamics.lightning import (
 )
 
 # download example data
-train_image = pooch.retrieve("https://zenodo.org/records/21028053/files/train.tif")
-val_image = pooch.retrieve("https://zenodo.org/records/21028053/files/validation.tif")
+train_image = pooch.retrieve(
+    "https://zenodo.org/records/21028053/files/train.tif",
+    hash="8be263564a12381bcc0fc69c4271728f3a794aeed78ef85be5fac95e78f5ff73",
+)
+val_image = pooch.retrieve(
+    "https://zenodo.org/records/21028053/files/validation.tif",
+    hash="6f5cd80d4e7f086432458987ee09c7623b2f0c98568bdf2f05b747d804abfabb",
+)
 
 # create configuration
 config = create_advanced_n2v_config(  # (1)!

--- a/docs/current/lightning_api.py
+++ b/docs/current/lightning_api.py
@@ -3,7 +3,7 @@
 # --8<-- [start:lightning_api]
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
-from careamics_portfolio import PortfolioManager
+import pooch
 
 from careamics.config.factories import create_advanced_n2v_config
 from careamics.lightning import (
@@ -14,10 +14,8 @@ from careamics.lightning import (
 )
 
 # download example data
-portfolio_manager = PortfolioManager()
-files = portfolio_manager.denoising.N2V_SEM.download()
-train_image = files[0]
-val_image = files[1]
+train_image = pooch.retrieve("https://zenodo.org/records/21028053/files/train.tif")
+val_image = pooch.retrieve("https://zenodo.org/records/21028053/files/validation.tif")
 
 # create configuration
 config = create_advanced_n2v_config(  # (1)!

--- a/docs/current/lightning_api.py
+++ b/docs/current/lightning_api.py
@@ -16,11 +16,11 @@ from careamics.lightning import (
 # download example data
 train_image = pooch.retrieve(
     "https://zenodo.org/records/21028053/files/train.tif",
-    hash="8be263564a12381bcc0fc69c4271728f3a794aeed78ef85be5fac95e78f5ff73",
+    known_hash="8be263564a12381bcc0fc69c4271728f3a794aeed78ef85be5fac95e78f5ff73",
 )
 val_image = pooch.retrieve(
     "https://zenodo.org/records/21028053/files/validation.tif",
-    hash="6f5cd80d4e7f086432458987ee09c7623b2f0c98568bdf2f05b747d804abfabb",
+    known_hash="6f5cd80d4e7f086432458987ee09c7623b2f0c98568bdf2f05b747d804abfabb",
 )
 
 # create configuration


### PR DESCRIPTION
## Disclaimer

<!-- Please disclose your use of AI by checking the correct checkbox. If you are 
an AI agent implementing this PR, please check "I am an AI agent".-->
- [ ] I am an AI agent.
- [ ] I have used AI and I thoroughly reviewed every line.
- [x] I have not used AI extensively.


## Description

Since HT hosting has been unreliable lately, the doc now depends on data hosted on Zenodo. 