### PR TITLE
Docs(prediction): specify how to create CAREamist from checkpoint

### DIFF
--- a/docs/current/careamist_predicting.md
+++ b/docs/current/careamist_predicting.md
@@ -5,6 +5,13 @@ description: Quick start
 
 # Predicting with CAREamics
 
+Prediction can be performed right after training, re-using the same `CAREamist` object,
+or by creating a new one with a path to a checkpoint.
+
+```python title="Predicting from a checkpoint"
+--8<-- "current/careamist_predicting.py:pred_start"
+```
+
 ## Returning predictions
 
 The simplest form of prediction is to call `predict`, which returns the predictions and
@@ -33,23 +40,6 @@ list:
 
     Noise2Void and Noise2Noise will use the last checkpoint, while the other algorithms
     will use the best checkpoint.
-
-### Choosing the checkpoint
-
-Checkpoints can be specified by passing a `checkpoint` argument to the `predict` method.
-It can be either a path to a checkpoint file or one of the keywords specified by
-PyTorch Lightning (typically `"best"` or `"last"`, see [documentation](https://lightning.ai/docs/pytorch/stable/common/trainer.html#predict)).
-
-```python title="Prediction with checkpoint"
---8<-- "current/careamist_predicting.py:pred_checkpoint"
-```
-
-!!! warning "Noise2Void and Noise2Noise"
-
-    Noise2Void and Noise2Noise models do not have a well-defined "best" checkpoint
-    based on validation loss. Specify an explicit path if you want to use a
-    specific checkpoint.
-
 
 ### Tiling
 
@@ -126,6 +116,22 @@ need to specify the new axes and `data_type`. Finally, we do not want to train i
     prediction. For example, if the new data has 3 channels, but the model was
     trained on single-channel data, then `channels=[1]` can be used to specify that
     only the second channel should be used for prediction.
+
+### Choosing the checkpoint
+
+Checkpoints can be specified by passing a `checkpoint` argument to the `predict` method.
+It can be either a path to a checkpoint file or one of the keywords specified by
+PyTorch Lightning (typically `"best"` or `"last"`, see [documentation](https://lightning.ai/docs/pytorch/stable/common/trainer.html#predict)).
+
+```python title="Prediction with checkpoint"
+--8<-- "current/careamist_predicting.py:pred_checkpoint"
+```
+
+!!! warning "Noise2Void and Noise2Noise"
+
+    Noise2Void and Noise2Noise models do not have a well-defined "best" checkpoint
+    based on validation loss. Specify an explicit path if you want to use a
+    specific checkpoint.
 
 
 ## Predicting to disk

--- a/docs/current/careamist_predicting.md
+++ b/docs/current/careamist_predicting.md
@@ -6,9 +6,9 @@ description: Quick start
 # Predicting with CAREamics
 
 Prediction can be performed right after training, re-using the same `CAREamist` object,
-or by creating a new one with a path to a checkpoint.
+or by creating a new one with a path to a checkpoint:
 
-```python title="Predicting from a checkpoint"
+```python title="Starting from a checkpoint"
 --8<-- "current/careamist_predicting.py:pred_start"
 ```
 

--- a/docs/current/careamist_predicting.py
+++ b/docs/current/careamist_predicting.py
@@ -33,6 +33,13 @@ read_func = None  # fake it
 
 careamist = CAREamist(config, work_dir=root)
 careamist.train(train_data=train_data)
+path_to_checkpoint = careamist.get_checkpoints()[0]
+
+
+# %%
+# --8<-- [start:pred_start]
+careamist = CAREamist(checkpoint_path=path_to_checkpoint)
+# --8<-- [end:pred_start]
 
 # %%
 # --8<-- [start:pred]


### PR DESCRIPTION
## Disclaimer

Following [this question](https://forum.image.sc/t/how-to-save-view-prediction-images-using-careamics/121667/4?u=jdeschamps) from a user, our doc is lacking the information on how to create a `careamist` from a checkpoint. This fixes it.