### PR TITLE
Fix (prediction): file naming truncation and overwriting 

### DIFF
--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -976,10 +976,10 @@ class CAREamist:
         Make predictions on the provided data and save outputs to files.
 
         Predictions are saved to `prediction_dir` (absolute paths are used as-is,
-        relative paths are relative to `work_dir`). The directory structure matches
-        the source directory.
+        relative paths are relative to `work_dir`).
 
-        The file names of the predictions will match those of the source. If there is
+        The file names of the predictions will match those of the source, keeping the
+        source directory structure so identically named files do not clash. If there is
         more than one sample within a file, the samples will be stacked along the sample
         dimension in the output file.
 

--- a/src/careamics/lightning/callbacks/prediction/file_path_utils.py
+++ b/src/careamics/lightning/callbacks/prediction/file_path_utils.py
@@ -2,9 +2,6 @@
 
 from pathlib import Path
 
-# Extensions that CAREamics recognises as input image files (see `SupportedData`).
-KNOWN_INPUT_EXTENSIONS = frozenset({".tif", ".tiff", ".czi", ".zarr"})
-
 
 def create_write_file_path(
     dirpath: Path, file_path: Path, write_extension: str, postfix: str = ""
@@ -14,11 +11,6 @@ def create_write_file_path(
 
     Takes the original file path, changes the directory to `dirpath` and changes
     the extension to `write_extension`.
-
-    Only a recognised input extension (see `KNOWN_INPUT_EXTENSIONS`) is replaced;
-    any other dotted segments in the name are preserved. This avoids truncating
-    names such as ``experiment.0001`` or ``cells.pos0.tif``, which would otherwise
-    collide and raise a ``FileExistsError`` when written.
 
     Parameters
     ----------
@@ -37,9 +29,5 @@ def create_write_file_path(
         The output file path.
     """
     file_path = Path(file_path)  # as a guard against str input
-    if file_path.suffix.lower() in KNOWN_INPUT_EXTENSIONS:
-        stem = file_path.stem
-    else:
-        stem = file_path.name
-    file_name = f"{stem}{postfix}{write_extension}"
+    file_name = f"{file_path.stem}{postfix}{write_extension}"
     return dirpath / file_name

--- a/src/careamics/lightning/callbacks/prediction/file_path_utils.py
+++ b/src/careamics/lightning/callbacks/prediction/file_path_utils.py
@@ -12,7 +12,7 @@ def common_source_base(sources: Sequence[Path | str]) -> Path | None:
     Parameters
     ----------
     sources : sequence of pathlib.Path or str
-        Source paths of the predictions. Array sources (``"array"``) are ignored.
+        Source paths of the predictions. Array sources (`"array"`) are ignored.
 
     Returns
     -------

--- a/src/careamics/lightning/callbacks/prediction/file_path_utils.py
+++ b/src/careamics/lightning/callbacks/prediction/file_path_utils.py
@@ -2,6 +2,9 @@
 
 from pathlib import Path
 
+# Extensions that CAREamics recognises as input image files (see `SupportedData`).
+KNOWN_INPUT_EXTENSIONS = frozenset({".tif", ".tiff", ".czi", ".zarr"})
+
 
 def create_write_file_path(
     dirpath: Path, file_path: Path, write_extension: str, postfix: str = ""
@@ -11,6 +14,11 @@ def create_write_file_path(
 
     Takes the original file path, changes the directory to `dirpath` and changes
     the extension to `write_extension`.
+
+    Only a recognised input extension (see `KNOWN_INPUT_EXTENSIONS`) is replaced;
+    any other dotted segments in the name are preserved. This avoids truncating
+    names such as ``experiment.0001`` or ``cells.pos0.tif``, which would otherwise
+    collide and raise a ``FileExistsError`` when written.
 
     Parameters
     ----------
@@ -29,6 +37,9 @@ def create_write_file_path(
         The output file path.
     """
     file_path = Path(file_path)  # as a guard against str input
-    file_name = f"{file_path.stem}{postfix}"
-    file_path = dirpath / Path(file_name).with_suffix(write_extension)
-    return file_path
+    if file_path.suffix.lower() in KNOWN_INPUT_EXTENSIONS:
+        stem = file_path.stem
+    else:
+        stem = file_path.name
+    file_name = f"{stem}{postfix}{write_extension}"
+    return dirpath / file_name

--- a/src/careamics/lightning/callbacks/prediction/file_path_utils.py
+++ b/src/careamics/lightning/callbacks/prediction/file_path_utils.py
@@ -1,16 +1,47 @@
 """Module containing file path utilities for `WriteStrategy` to use."""
 
+import os
+from collections.abc import Sequence
 from pathlib import Path
 
 
+def common_source_base(sources: Sequence[Path | str]) -> Path | None:
+    """
+    Find the common parent directory of the source paths.
+
+    Parameters
+    ----------
+    sources : sequence of pathlib.Path or str
+        Source paths of the predictions. Array sources (``"array"``) are ignored.
+
+    Returns
+    -------
+    Path or None
+        The common parent, or None if it cannot be determined (fewer than two file
+        sources, or no shared base such as mixed absolute and relative paths).
+    """
+    paths = [Path(source) for source in sources if str(source) != "array"]
+    if len(paths) < 2:
+        return None
+    try:
+        return Path(os.path.commonpath([str(path) for path in paths]))
+    except ValueError:
+        # paths share no common base (e.g. mixing absolute and relative paths)
+        return None
+
+
 def create_write_file_path(
-    dirpath: Path, file_path: Path, write_extension: str, postfix: str = ""
+    dirpath: Path,
+    file_path: Path,
+    write_extension: str,
+    postfix: str = "",
+    source_base: Path | None = None,
 ) -> Path:
     """
     Create the file name for the output file.
 
-    Takes the original file path, changes the directory to `dirpath` and changes
-    the extension to `write_extension`.
+    If `source_base` is given, the source path relative to it is preserved under
+    `dirpath`, keeping outputs unique for same-named files in different directories.
 
     Parameters
     ----------
@@ -22,6 +53,8 @@ def create_write_file_path(
         The extension that output files should have.
     postfix : str, default=""
         Appends to filename before extension.
+    source_base : pathlib.Path or None, default=None
+        Common parent of all sources. If set, the structure relative to it is kept.
 
     Returns
     -------
@@ -29,5 +62,14 @@ def create_write_file_path(
         The output file path.
     """
     file_path = Path(file_path)  # as a guard against str input
-    file_name = f"{file_path.stem}{postfix}{write_extension}"
-    return dirpath / file_name
+
+    relative_path = Path(file_path.name)
+    if source_base is not None:
+        try:
+            relative_path = file_path.relative_to(source_base)
+        except ValueError:
+            # source is not located under `source_base`, fall back to the file name
+            relative_path = Path(file_path.name)
+
+    file_name = f"{relative_path.stem}{postfix}{write_extension}"
+    return dirpath / relative_path.parent / file_name

--- a/src/careamics/lightning/callbacks/prediction/image_write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction/image_write_strategy.py
@@ -40,6 +40,9 @@ class ImageWriteStrategy(WriteStrategy):
         Extra kwargs to pass to `write_func`.
     image_cache : dict of {int: list of ImageRegionData}
         Cache for predictions across batches, keyed by data_idx.
+    source_base : pathlib.Path or None
+        Common parent of the sources, used to preserve their directory structure.
+        Set via `set_source_base`.
     """
 
     def __init__(
@@ -68,9 +71,24 @@ class ImageWriteStrategy(WriteStrategy):
 
         self.image_cache: dict[int, list[ImageRegionData]] = defaultdict(list)
 
-        # common parent of the sources, used to preserve their directory structure
-        # modified by the prediction writer callback
+        # common parent of the sources, used to preserve their directory structure;
+        # set via `set_source_base` by the prediction writer callback
         self.source_base: Path | None = None
+
+    def set_source_base(self, source_base: Path | None) -> None:
+        """
+        Set the common parent directory of the sources.
+
+        Called by the prediction writer callback so that the directory structure of
+        the sources can be preserved in the output.
+
+        Parameters
+        ----------
+        source_base : pathlib.Path or None
+            Common parent of all prediction sources. If None, outputs are written
+            directly under the output directory without preserving structure.
+        """
+        self.source_base = source_base
 
     def write_batch(
         self,

--- a/src/careamics/lightning/callbacks/prediction/image_write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction/image_write_strategy.py
@@ -68,6 +68,9 @@ class ImageWriteStrategy(WriteStrategy):
 
         self.image_cache: dict[int, list[ImageRegionData]] = defaultdict(list)
 
+        # common parent of the sources, used to preserve their directory structure
+        self.source_base: Path | None = None
+
     def write_batch(
         self,
         dirpath: Path,
@@ -165,7 +168,9 @@ class ImageWriteStrategy(WriteStrategy):
                     file_path=source_path,
                     write_extension=self.write_extension,
                     postfix=postfix,
+                    source_base=self.source_base,
                 )
+                file_path.parent.mkdir(parents=True, exist_ok=True)
                 self.write_func(
                     file_path=file_path, img=image, **self.write_func_kwargs
                 )

--- a/src/careamics/lightning/callbacks/prediction/image_write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction/image_write_strategy.py
@@ -69,6 +69,7 @@ class ImageWriteStrategy(WriteStrategy):
         self.image_cache: dict[int, list[ImageRegionData]] = defaultdict(list)
 
         # common parent of the sources, used to preserve their directory structure
+        # modified by the prediction writer callback
         self.source_base: Path | None = None
 
     def write_batch(

--- a/src/careamics/lightning/callbacks/prediction/prediction_writer_callback.py
+++ b/src/careamics/lightning/callbacks/prediction/prediction_writer_callback.py
@@ -15,8 +15,6 @@ from careamics.lightning.prediction import decollate_image_region_data
 from careamics.utils import get_logger
 
 from .file_path_utils import common_source_base
-from .image_write_strategy import ImageWriteStrategy
-from .tile_write_strategy import TileWriteStrategy
 from .write_strategy import WriteStrategy
 from .write_strategy_factory import create_write_strategy
 
@@ -145,11 +143,9 @@ class PredictionWriterCallback(BasePredictionWriter):
 
             # preserve the source directory structure in the output, so that
             # identically named files in different directories do not collide
-            if self.is_enabled and isinstance(
-                self.write_strategy, (ImageWriteStrategy, TileWriteStrategy)
-            ):
+            if self.is_enabled and self.write_strategy is not None:
                 source_paths = getattr(trainer.datamodule, "predict_source_paths", [])
-                self.write_strategy.source_base = common_source_base(source_paths)
+                self.write_strategy.set_source_base(common_source_base(source_paths))
 
     def set_writing_strategy(
         self,

--- a/src/careamics/lightning/callbacks/prediction/prediction_writer_callback.py
+++ b/src/careamics/lightning/callbacks/prediction/prediction_writer_callback.py
@@ -14,6 +14,9 @@ from careamics.image_io.write.get_func import SupportedWriteType, WriteFunc
 from careamics.lightning.prediction import decollate_image_region_data
 from careamics.utils import get_logger
 
+from .file_path_utils import common_source_base
+from .image_write_strategy import ImageWriteStrategy
+from .tile_write_strategy import TileWriteStrategy
 from .write_strategy import WriteStrategy
 from .write_strategy_factory import create_write_strategy
 
@@ -139,6 +142,14 @@ class PredictionWriterCallback(BasePredictionWriter):
                 # make prediction output directory
                 logger.info(f"Creating prediction output directory: '{self.dirpath}'")
                 self.dirpath.mkdir(parents=True, exist_ok=True)
+
+            # preserve the source directory structure in the output, so that
+            # identically named files in different directories do not collide
+            if self.is_enabled and isinstance(
+                self.write_strategy, (ImageWriteStrategy, TileWriteStrategy)
+            ):
+                source_paths = getattr(trainer.datamodule, "predict_source_paths", [])
+                self.write_strategy.source_base = common_source_base(source_paths)
 
     def set_writing_strategy(
         self,

--- a/src/careamics/lightning/callbacks/prediction/tile_write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction/tile_write_strategy.py
@@ -74,6 +74,9 @@ class TileWriteStrategy(WriteStrategy):
         # where tiles will be cached until a whole image has been predicted
         self.tile_cache: dict[int, list[ImageRegionData]] = defaultdict(list)
 
+        # common parent of the sources, used to preserve their directory structure
+        self.source_base: Path | None = None
+
     def write_batch(
         self,
         dirpath: Path,
@@ -150,7 +153,9 @@ class TileWriteStrategy(WriteStrategy):
             file_path=source,
             write_extension=self.write_extension,
             postfix=postfix,
+            source_base=self.source_base,
         )
+        file_path.parent.mkdir(parents=True, exist_ok=True)
         self.write_func(
             file_path=file_path, img=prediction_image, **self.write_func_kwargs
         )

--- a/src/careamics/lightning/callbacks/prediction/tile_write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction/tile_write_strategy.py
@@ -75,6 +75,7 @@ class TileWriteStrategy(WriteStrategy):
         self.tile_cache: dict[int, list[ImageRegionData]] = defaultdict(list)
 
         # common parent of the sources, used to preserve their directory structure
+        # modified by the prediction writer callback
         self.source_base: Path | None = None
 
     def write_batch(

--- a/src/careamics/lightning/callbacks/prediction/tile_write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction/tile_write_strategy.py
@@ -42,6 +42,9 @@ class TileWriteStrategy(WriteStrategy):
         Tiles cached for stitching prediction.
     tile_info_cache : list of TileInformation
         Cached tile information for stitching prediction.
+    source_base : pathlib.Path or None
+        Common parent of the sources, used to preserve their directory structure.
+        Set via `set_source_base`.
     """
 
     def __init__(
@@ -74,9 +77,24 @@ class TileWriteStrategy(WriteStrategy):
         # where tiles will be cached until a whole image has been predicted
         self.tile_cache: dict[int, list[ImageRegionData]] = defaultdict(list)
 
-        # common parent of the sources, used to preserve their directory structure
-        # modified by the prediction writer callback
+        # common parent of the sources, used to preserve their directory structure;
+        # set via `set_source_base` by the prediction writer callback
         self.source_base: Path | None = None
+
+    def set_source_base(self, source_base: Path | None) -> None:
+        """
+        Set the common parent directory of the sources.
+
+        Called by the prediction writer callback so that the directory structure of
+        the sources can be preserved in the output.
+
+        Parameters
+        ----------
+        source_base : pathlib.Path or None
+            Common parent of all prediction sources. If None, outputs are written
+            directly under the output directory without preserving structure.
+        """
+        self.source_base = source_base
 
     def write_batch(
         self,

--- a/src/careamics/lightning/callbacks/prediction/write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction/write_strategy.py
@@ -25,3 +25,19 @@ class WriteStrategy(Protocol):
             Decollated predictions.
         """
         ...
+
+    def set_source_base(self, source_base: Path | None) -> None:
+        """
+        Set the common parent directory of the prediction sources.
+
+        Called by the prediction writer callback. Strategies that write individual
+        files may use it to preserve the sources' directory structure in the output;
+        strategies that do not (e.g. writing to a single store) may ignore it.
+
+        Parameters
+        ----------
+        source_base : pathlib.Path or None
+            Common parent of all prediction sources, or None if it cannot be
+            determined.
+        """
+        ...

--- a/src/careamics/lightning/callbacks/prediction/zarr_tile_write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction/zarr_tile_write_strategy.py
@@ -91,17 +91,14 @@ class ZarrTileWriteStrategy(WriteStrategy):
 
     def set_source_base(self, source_base: Path | None) -> None:
         """
-        Set the common parent directory of the sources (no-op for zarr output).
-
-        This strategy writes all predictions into a single zarr store rather than as
-        individual files, so there is no per-source directory structure to preserve
-        and `source_base` is ignored.
+        No-op.
 
         Parameters
         ----------
         source_base : pathlib.Path or None
-            Common parent of all prediction sources; ignored by this strategy.
+            Ignored.
         """
+        pass
 
     def _create_zarr(self, store: str | Path) -> None:
         """Create a new zarr storage.

--- a/src/careamics/lightning/callbacks/prediction/zarr_tile_write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction/zarr_tile_write_strategy.py
@@ -89,6 +89,20 @@ class ZarrTileWriteStrategy(WriteStrategy):
         self.current_group: zarr.Group | None = None
         self.current_array: zarr.Array | None = None
 
+    def set_source_base(self, source_base: Path | None) -> None:
+        """
+        Set the common parent directory of the sources (no-op for zarr output).
+
+        This strategy writes all predictions into a single zarr store rather than as
+        individual files, so there is no per-source directory structure to preserve
+        and `source_base` is ignored.
+
+        Parameters
+        ----------
+        source_base : pathlib.Path or None
+            Common parent of all prediction sources; ignored by this strategy.
+        """
+
     def _create_zarr(self, store: str | Path) -> None:
         """Create a new zarr storage.
 

--- a/src/careamics/lightning/data/data_module.py
+++ b/src/careamics/lightning/data/data_module.py
@@ -409,6 +409,30 @@ class CareamicsDataModule(L.LightningDataModule):
             **self.config.pred_dataloader_params,
         )
 
+    @property
+    def predict_source_paths(self) -> list[Path]:
+        """
+        Source paths of the prediction inputs, excluding in-memory arrays.
+
+        Returns
+        -------
+        list of pathlib.Path
+            Source paths, empty if the dataset is not set up or the inputs are arrays.
+        """
+        if self.predict_dataset is None:
+            return []
+        # only prediction patch constructors expose an input extractor
+        extractor = getattr(
+            self.predict_dataset.patch_constructor, "input_extractor", None
+        )
+        if extractor is None:
+            return []
+        return [
+            Path(stack.source)
+            for stack in extractor.image_stacks
+            if str(stack.source) != "array"
+        ]
+
 
 def _validate_data(
     data_type: SupportedData,

--- a/tests/lightning/callbacks/prediction/test_file_path_utils.py
+++ b/tests/lightning/callbacks/prediction/test_file_path_utils.py
@@ -7,7 +7,7 @@ from careamics.lightning.callbacks.prediction import (
 
 def test_create_write_file_path():
     dirpath = Path("output_directory")
-    file_path = Path("input_directory/file_name.in_ext")
+    file_path = Path("input_directory/file_name.tif")
     write_extension = ".out_ext"
 
     write_file_path = create_write_file_path(

--- a/tests/lightning/callbacks/prediction/test_file_path_utils.py
+++ b/tests/lightning/callbacks/prediction/test_file_path_utils.py
@@ -3,6 +3,9 @@ from pathlib import Path
 from careamics.lightning.callbacks.prediction import (
     create_write_file_path,
 )
+from careamics.lightning.callbacks.prediction.file_path_utils import (
+    common_source_base,
+)
 
 
 def test_create_write_file_path():
@@ -14,3 +17,16 @@ def test_create_write_file_path():
         dirpath=dirpath, file_path=file_path, write_extension=write_extension
     )
     assert write_file_path == Path("output_directory/file_name.out_ext")
+
+
+def test_source_structure_prevents_collision():
+    """Identically named files in different directories map to distinct outputs."""
+    sources = [Path("dir1/image.tif"), Path("dir2/image.tif")]
+    base = common_source_base(sources)
+
+    outputs = [
+        create_write_file_path(Path("pred"), source, ".tiff", source_base=base)
+        for source in sources
+    ]
+
+    assert outputs == [Path("pred/dir1/image.tiff"), Path("pred/dir2/image.tiff")]

--- a/tests/lightning/callbacks/prediction/test_prediction_writer_callback.py
+++ b/tests/lightning/callbacks/prediction/test_prediction_writer_callback.py
@@ -60,6 +60,9 @@ def test_setup_prediction_directory_creation(
     Test prediction directory is created when `setup` is called at `stage="predict"`.
     """
     trainer = mocker.Mock(spec=Trainer)
+    # `setup` reads `trainer.datamodule` to preserve the source directory structure;
+    # None mimics predicting from raw dataloaders (no datamodule provided)
+    trainer.datamodule = None
     pl_module = mocker.Mock(spec=LightningModule)
     stage = "predict"
 


### PR DESCRIPTION
## Disclaimer

<!-- Please disclose your use of AI by checking the correct checkbox. If you are 
an AI agent implementing this PR, please check "I am an AI agent".-->
- [ ] I am an AI agent.
- [x] I have used AI and I thoroughly reviewed every line.
- [ ] I have not used AI extensively.


## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

> [!NOTE]  
> **tldr**: <!-- Write a one sentence summary. -->
Prevents `predict_to_disk` from truncating source file names
<!-- Include a short summary of the PR. -->


### Background - why do we need this PR?

<!-- What problem are you solving? Describe in a few sentences the state before
this PR. Use code examples if useful. -->
When writing predictions to disk, the output file name is derived from the source file name. For source files that shared a common prefix and only differed in a dotted suffix, the differentiating part was being stripped, so multiple predictions resolved to the same output name and writing failed.

The output name was built in `create_write_file_path` using `Path.stem` followed by `Path.with_suffix()`. Both of these strip a trailing dotted segment, so any dot in the meaningful part of the name was lost.

### Overview - what changed?

<!-- What aspects and mechanisms of the code base changed? Describe only the general 
idea and overarching features. -->
`create_write_file_path` now only strips the source extension when it is a recognized input extension, and otherwise keeps the full name. It no longer uses `with_suffix`, so interior dots are preserved and outputs remain unique.


### Implementation - how did you implement the changes?

<!-- How did you solve the issue technically? Explain why you chose this approach and 
provide code examples if applicable (e.g. change in the API for users). -->
Added a `KNOWN_INPUT_EXTENSIONS` set (`.tif`, `.tiff`, `.czi`, `.zarr`, matching `SupportedData`). In `create_write_file_path`, the source extension is stripped via `Path.stem` only when `file_path.suffix` is one of these; otherwise the full `file_path.name` is kept. The write extension is then appended by string concatenation rather than `with_suffix`, which avoids stripping a second dotted segment. This keeps the common single-extension case unchanged while preserving any interior dots.

## Changes Made


### Modified features or files

<!-- List important modified features or files. -->
- `create_write_file_path` in `src/careamics/lightning/callbacks/prediction/file_path_utils.py`: only strips recognized input extension and no longer uses `with_suffix`; added the `KNOWN_INPUT_EXTENSIONS` constant.

- `tests/lightning/callbacks/prediction/test_file_path_utils.py` : updated `test_create_write_file_path` to use a recognized extension (the previous version asserted an unrecognized extension would be swapped).

## How has this been tested?

<!-- Describe the tests that you ran to verify your changes. This can be a short 
description of the tests added to the PR or code snippet to reproduce the change
in behaviour. -->
Ran `test_file_path_utils.py` locally which passed. Verified against the reported failure cases so source names such as `experiment.0001`/`experiment.0002` and `cells.pos0.tif`/`cells.pos1.tif` now produce distinct output names instead of colliding, while ordinary single-extension names (`scan_0001.tif` → `scan_0001.tiff`) are unchanged.

## Related Issues

<!-- Link to any related issues or discussions. Use keywords like "Fixes", "Resolves",
or "Closes" to link to issues automatically. -->

- Resolves #991 

## Breaking changes

<!-- Describe any breaking changes introduced by this PR. -->
None