### PR TITLE
Fix(checkpoints): allow checkpoints exported after prediction to be loaded

### DIFF
--- a/docs/current/lightning_api.md
+++ b/docs/current/lightning_api.md
@@ -29,8 +29,11 @@ are setting up Noise2Void, but the same can be done for CARE and N2N using the `
 For more details, refer to the [data documentation]().
 5. Careamics configuration has its own default set of parameters for the `ModelCheckpoint`
 callback (and `EarlyStopping`). You can either use those or set up your own.
-6. The `ConfigSaverCallback` callback is used to log the configuration in the 
-checkpoints.
+6. The `ConfigSaverCallback` callback stores the CAREamics configuration in the
+checkpoints. It is optional in the Lightning API, add it if you want to load the
+checkpoint with the CAREamist API and recover the training data and training configs.
+Without it, the checkpoint can still be loaded, but the training configuration falls back
+to its defaults.
 7. Similarly, the configuration create training parameters configuration. You can set your
 own rather than reusing those.
 8. As in any Lightning script, pass the model and datamodule to the trainer and call `fit` to start training.

--- a/docs/current/lightning_api.py
+++ b/docs/current/lightning_api.py
@@ -50,7 +50,10 @@ callbacks = [
         **config.training_config.checkpoint_params,
     ),
     ConfigSaverCallback(
-        config.version, config.experiment_name, config.training_config
+        config.version,
+        config.experiment_name,
+        config.training_config,
+        config.data_config,
     ),  # (6)!
 ]
 
@@ -100,7 +103,12 @@ callbacks = [
         filename=f"{config.experiment_name}_{{epoch:02d}}_step_{{step}}",
         **config.training_config.checkpoint_params,
     ),
-    ConfigSaverCallback(config.version, config.experiment_name, config.training_config),
+    ConfigSaverCallback(
+        config.version,
+        config.experiment_name,
+        config.training_config,
+        config.data_config,
+    ),
     pred_writer,  # (2)!
 ]
 

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -385,6 +385,7 @@ class CAREamist:
                 config.version,
                 config.get_safe_experiment_name(),
                 config.training_config,
+                config.data_config,
             ),
         ]
 

--- a/src/careamics/lightning/callbacks/config_saver_callback.py
+++ b/src/careamics/lightning/callbacks/config_saver_callback.py
@@ -5,6 +5,7 @@ from typing import Any
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import Callback
 
+from careamics.config.data.data_config import DataConfig
 from careamics.config.lightning.training_configuration import TrainingConfig
 
 
@@ -14,6 +15,8 @@ class ConfigSaverCallback(Callback):
 
     This callback automatically stores CAREamics version, experiment name,
     and training configuration in the checkpoint file for reproducibility.
+    It also persists the training data configuration into the checkpoint,
+    independently of the datamodule currently active on the trainer.
 
     Parameters
     ----------
@@ -23,6 +26,8 @@ class ConfigSaverCallback(Callback):
         Name of the experiment.
     training_config : TrainingConfig
         Training configuration to store in checkpoint.
+    data_config : DataConfig
+        Training data configuration to store in checkpoint.
 
     Attributes
     ----------
@@ -32,6 +37,8 @@ class ConfigSaverCallback(Callback):
         Name of the experiment.
     training_config : TrainingConfig
         Training configuration to store in checkpoint.
+    data_config : DataConfig
+        Training data configuration to store in checkpoint.
     """
 
     def __init__(
@@ -39,6 +46,7 @@ class ConfigSaverCallback(Callback):
         careamics_version: str,
         experiment_name: str,
         training_config: TrainingConfig,
+        data_config: DataConfig,
     ):
         """
         Initialize the callback.
@@ -51,11 +59,14 @@ class ConfigSaverCallback(Callback):
             Name of the experiment.
         training_config : TrainingConfig
             Training configuration to store in checkpoint.
+        data_config : DataConfig
+            Training data configuration to store in checkpoint.
         """
         super().__init__()
         self.careamics_version = careamics_version
         self.experiment_name = experiment_name
         self.training_config = training_config
+        self.data_config = data_config
 
     def on_save_checkpoint(
         self, trainer: Trainer, pl_module: LightningModule, checkpoint: dict[str, Any]
@@ -79,3 +90,9 @@ class ConfigSaverCallback(Callback):
             "experiment_name": self.experiment_name,
             "training_config": self.training_config.model_dump(mode="json"),
         }
+
+        # Persist the training data config
+        checkpoint.setdefault("datamodule_hyper_parameters", {})
+        checkpoint["datamodule_hyper_parameters"]["data_config"] = (
+            self.data_config.model_dump(mode="json")
+        )

--- a/src/careamics/lightning/callbacks/config_saver_callback.py
+++ b/src/careamics/lightning/callbacks/config_saver_callback.py
@@ -15,8 +15,8 @@ class ConfigSaverCallback(Callback):
 
     This callback automatically stores CAREamics version, experiment name,
     and training configuration in the checkpoint file for reproducibility.
-    It also persists the training data configuration into the checkpoint,
-    independently of the datamodule currently active on the trainer.
+    If a training data configuration is provided, it is also persisted into the
+    checkpoint independently of the datamodule currently active on the trainer.
 
     Parameters
     ----------
@@ -26,8 +26,11 @@ class ConfigSaverCallback(Callback):
         Name of the experiment.
     training_config : TrainingConfig
         Training configuration to store in checkpoint.
-    data_config : DataConfig
-        Training data configuration to store in checkpoint.
+    data_config : DataConfig | None, default=None
+        Training data configuration to store in checkpoint. If provided, it is
+        written into the checkpoint regardless of which datamodule is active on
+        the trainer, ensuring the checkpoint keeps the training data config even
+        when saved after prediction.
 
     Attributes
     ----------
@@ -37,7 +40,7 @@ class ConfigSaverCallback(Callback):
         Name of the experiment.
     training_config : TrainingConfig
         Training configuration to store in checkpoint.
-    data_config : DataConfig
+    data_config : DataConfig | None
         Training data configuration to store in checkpoint.
     """
 
@@ -46,7 +49,7 @@ class ConfigSaverCallback(Callback):
         careamics_version: str,
         experiment_name: str,
         training_config: TrainingConfig,
-        data_config: DataConfig,
+        data_config: DataConfig | None = None,
     ):
         """
         Initialize the callback.
@@ -59,8 +62,10 @@ class ConfigSaverCallback(Callback):
             Name of the experiment.
         training_config : TrainingConfig
             Training configuration to store in checkpoint.
-        data_config : DataConfig
-            Training data configuration to store in checkpoint.
+        data_config : DataConfig | None, default=None
+            Training data configuration to store in checkpoint. If provided, it is
+            written into the checkpoint regardless of which datamodule is active on
+            the trainer.
         """
         super().__init__()
         self.careamics_version = careamics_version
@@ -91,8 +96,9 @@ class ConfigSaverCallback(Callback):
             "training_config": self.training_config.model_dump(mode="json"),
         }
 
-        # Persist the training data config
-        checkpoint.setdefault("datamodule_hyper_parameters", {})
-        checkpoint["datamodule_hyper_parameters"]["data_config"] = (
-            self.data_config.model_dump(mode="json")
-        )
+        # Persist the training data config if provided
+        if self.data_config is not None:
+            checkpoint.setdefault("datamodule_hyper_parameters", {})
+            checkpoint["datamodule_hyper_parameters"]["data_config"] = (
+                self.data_config.model_dump(mode="json")
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from pytorch_lightning import Callback, Trainer
 
 from careamics.config.configuration import Configuration
+from careamics.config.data.data_config import DataConfig
 from careamics.config.factories import (
     create_advanced_care_config,
     create_advanced_n2v_config,
@@ -426,6 +427,7 @@ def _checkpoint_trainer(request):
 
     def _get_trainer_and_info(
         algorithm: str,
+        data_config: DataConfig,
     ) -> tuple[Trainer, ConfigSaverCallback | None]:
         if request.param:
             info_callback = ConfigSaverCallback(
@@ -434,6 +436,7 @@ def _checkpoint_trainer(request):
                 training_config=TrainingConfig(
                     **default_training_dict(algorithm=algorithm)
                 ),
+                data_config=data_config,
             )
             callbacks: list[Callback] = [info_callback]
         else:
@@ -511,7 +514,7 @@ def checkpoint(
 
     module = module_cls(config.algorithm_config)
     dmodule = CareamicsDataModule(data_config=config.data_config, **data)
-    trainer, info_callback = _checkpoint_trainer(request.param)
+    trainer, info_callback = _checkpoint_trainer(request.param, config.data_config)
     trainer.fit(model=module, datamodule=dmodule)
     ckpt_path = tmp_path / "checkpoint_test_fixture.ckpt"
     trainer.save_checkpoint(ckpt_path)


### PR DESCRIPTION
## Disclaimer

<!-- Please disclose your use of AI by checking the correct checkbox. If you are 
an AI agent implementing this PR, please check "I am an AI agent".-->
- [ ] I am an AI agent.
- [x] I have used AI and I thoroughly reviewed every line.
- [ ] I have not used AI extensively.


## Description

<!-- This section provides the necessary background and information for reviewers to
understand the code and have the correct mindset when examining changes. -->

> [!NOTE]  
> **tldr**: <!-- Write a one sentence summary. -->
Persist the training data config into every checkpoint saved through the CAREamics trainer, so a checkpoint saved after prediction no longer loses data_config and stays loadable.


### Background - why do we need this PR?

PyTorch Lightning's Trainer populates checkpoint["datamodule_hyper_parameters"] from whichever datamodule is active on the trainer when the checkpoint is saved. In CAREamics, CareamicsDataModule only writes data_config into its hyperparameters during setup("fit"/"validate") — never during setup("predict"). After a predict() call the trainer's active datamodule is the prediction datamodule, whose hyperparameters do not contain data_config. Any checkpoint saved at that point has an empty/incomplete datamodule_hyper_parameters, and load_config_from_checkpoint then fails because it requires checkpoint["datamodule_hyper_parameters"]["data_config"].

### Overview - what changed?

<!-- What aspects and mechanisms of the code base changed? Describe only the general 
idea and overarching features. -->
The ConfigSaverCallback now persists the training data_config into the checkpoint, independently of which datamodule is currently active on the trainer. This guarantees that any checkpoint saved through the CAREamics trainer, whether after training or after prediction, always carries the training data config and remains loadable.

### Implementation - how did you implement the changes?

<!-- How did you solve the issue technically? Explain why you chose this approach and 
provide code examples if applicable (e.g. change in the API for users). -->


## Changes Made

`ConfigSaverCallback` takes an optional data_config parameter and writes it into checkpoint["datamodule_hyper_parameters"]["data_config"], overriding whatever the active datamodule left behind. CAREamist passes config.data_config when constructing the callback. Because normalization statistics are resolved in place into that same DataConfig object during setup("fit"), the callback's reference already carries the computed means/stds by the time a checkpoint is saved.

### Modified features or files

<!-- List important modified features or files. -->
- `ConfigSaverCallback` (src/careamics/lightning/callbacks/config_saver_callback.py): added optional data_config parameter; on_save_checkpoint now persists the training data_config into datamodule_hyper_parameters when provided
- `CAREamist._define_callbacks (src/careamics/careamist.py)`: passes `config.data_config` to `ConfigSaverCallback`
- `docs/current/lightning_api.py`: updated both ConfigSaverCallback constructions to pass config.data_config
- `tests/conftest.py`: the checkpoint fixture now supplies data_config when constructing ConfigSaverCallback

### Removed features or files

<!-- List removed features or files. -->
None

## How has this been tested?

<!-- Describe the tests that you ran to verify your changes. This can be a short 
description of the tests added to the PR or code snippet to reproduce the change
in behaviour. -->

- All tests in `tests/lightning/utils/test_load_checkpoint.py` and `tests/test_careamist_predict.py` pass locally
- Manually verified the issue scenario: after `train()` → `predict(..., tile_size=...)` → `trainer.save_checkpoint()`, the checkpoint contains `datamodule_hyper_parameters["data_config"]`, is loadable, and reports mode `"training"` (not `"predicting"`)
- The documented Lightning API guide test (`docs/test_guides.py::test_script_execution[Scripts.lightning_api]`) passes locally

## Related Issues

<!-- Link to any related issues or discussions. Use keywords like "Fixes", "Resolves",
or "Closes" to link to issues automatically. -->

- Resolves #939 

## Breaking changes

<!-- Describe any breaking changes introduced by this PR. -->

None. ConfigSaverCallback gains an optional `data_config` argument (default None) so existing constructions are fine unchanged and only skip persisting the data config when it is not supplied.

## Additional Notes and Examples

<!-- Provide any additional information that will help reviewers understand the
changes. This can be links to documentations, forum posts, past discussions etc.-->

---

**Please ensure your PR meets the following requirements:**

- [x] Code builds and passes tests locally, including doctests
- [ ] New tests have been added (for bug fixes/features)
- [x] Documentation has been updated
- [x] Pre-commit passes