### PR TITLE
Chore: clean up outdated v0.2 references

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: 26.1.0
     hooks:
       - id: black
-        exclude: "^src/careamics/careamist_v2.py"
+        exclude: "^src/careamics/careamist.py"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.19.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ API using the core Lightning components directly.
 
 CAREamics is built around a modular architecture with the following key components:
 - Pydantic models for configuration (`careamics/config`)
-- `CAREamist` class as main entry point for users (`careamics/careamist_v2.py`)
+- `CAREamist` class as main entry point for users (`careamics/careamist.py`)
 - A flexible and modular dataset (`careamics/dataset`)
 - A set of algorithm-specific Lightning modules (`careamics/lightning/dataset/lightning_modules`)
 
@@ -27,7 +27,7 @@ CAREamics is built around a modular architecture with the following key componen
 - `careamics.config.ng_configs`: Module with all algorithm-specific configurations
 - `careamics.config.ng_factories`: Convenience functions to create configurations
 
-**CAREamist (`careamics/careamist_v2.py`)**
+**CAREamist (`careamics/careamist.py`)**
 
 Main class that orchestrates the training and inference workflows, its API is not
 expected to change.


### PR DESCRIPTION
modified the following files to remove stale references to careamist_v2.py and switch back to careamist.py:
- .pre-commit-config.yaml
- AGENTS.md

Resolves #998 