### PR TITLE
Feat(Segmentation): algorithm-dependent model constraints

### DIFF
--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -671,7 +671,7 @@ class CAREamist:
             train_data_target=train_data_target,
             val_data_target=val_data_target,
             train_data_mask=filtering_mask,
-            model_constraints=get_model_constraints(self.config.algorithm_config.model),
+            model_constraints=get_model_constraints(self.config.algorithm_config),
             loading=loading,  # type: ignore
         )
 
@@ -781,7 +781,7 @@ class CAREamist:
             data_config=pred_data_config,
             pred_data=pred_data,
             pred_data_target=pred_data_target,
-            model_constraints=get_model_constraints(self.config.algorithm_config.model),
+            model_constraints=get_model_constraints(self.config.algorithm_config),
             loading=loading,
         )
 

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -672,7 +672,7 @@ class CAREamist:
             train_data_target=train_data_target,
             val_data_target=val_data_target,
             train_data_mask=filtering_mask,
-            model_constraints=get_model_constraints(self.config.algorithm_config.model),
+            model_constraints=get_model_constraints(self.config.algorithm_config),
             loading=loading,  # type: ignore
         )
 
@@ -782,7 +782,7 @@ class CAREamist:
             data_config=pred_data_config,
             pred_data=pred_data,
             pred_data_target=pred_data_target,
-            model_constraints=get_model_constraints(self.config.algorithm_config.model),
+            model_constraints=get_model_constraints(self.config.algorithm_config),
             loading=loading,
         )
 

--- a/src/careamics/config/configuration.py
+++ b/src/careamics/config/configuration.py
@@ -168,7 +168,7 @@ class Configuration(BaseModel, Generic[AlgorithmConfig]):
         if not hasattr(self.data_config.patching, "patch_size"):
             return self
 
-        model_constraints = get_model_constraints(self.algorithm_config.model)
+        model_constraints = get_model_constraints(self.algorithm_config)
         model_constraints.validate_spatial_shape(self.data_config.patching.patch_size)
 
         return self
@@ -184,7 +184,7 @@ class Configuration(BaseModel, Generic[AlgorithmConfig]):
             Validated configuration.
         """
         if self.data_config.channels is not None:
-            model_constraints = get_model_constraints(self.algorithm_config.model)
+            model_constraints = get_model_constraints(self.algorithm_config)
             model_constraints.validate_input_channels(len(self.data_config.channels))
 
         return self

--- a/src/careamics/config/support/supported_algorithms.py
+++ b/src/careamics/config/support/supported_algorithms.py
@@ -12,6 +12,7 @@ class SupportedAlgorithm(StrEnum):
     configurations.
     """
 
+    # --- unet-based algorithms
     N2V = "n2v"
     """Noise2Void algorithm, a self-supervised approach based on blind denoising."""
 
@@ -23,18 +24,16 @@ class SupportedAlgorithm(StrEnum):
     """Noise2Noise algorithm, a self-supervised denoising scheme based on comparing
     noisy images of the same sample."""
 
-    MUSPLIT = "musplit"  # TODO remove
-    """An image splitting approach based on ladder VAE architectures."""
+    PN2V = "pn2v"
+    """Probabilistic Noise2Void. A extension of Noise2Void using noise models."""
 
+    SEG = "seg"
+    """UNet-based semantic segmentation."""
+
+    # --- vae-based algorithms
     MICROSPLIT = "microsplit"
-    """A micro-level image splitting approach based on ladder VAE architectures."""
-
-    DENOISPLIT = "denoisplit"
     """An image splitting and denoising approach based on ladder VAE architectures."""
 
     HDN = "hdn"
-    """Hierarchical Denoising Network, an unsupervised denoising algorithm"""
-
-    PN2V = "pn2v"
-    """Probabilistic Noise2Void. A extension of Noise2Void is not restricted to Gaussian
-    noise models or Gaussian intensity predictions."""
+    """Hierarchical DivNoising, an unsupervised denoising algorithm capable of removing
+    structured noise."""

--- a/src/careamics/models/constraints/model_constraints_factory.py
+++ b/src/careamics/models/constraints/model_constraints_factory.py
@@ -1,17 +1,25 @@
 """Model constraints factory."""
 
-from careamics.config.architectures import UNetConfig
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from careamics.config.support import SupportedAlgorithm
+
+if TYPE_CHECKING:
+    from careamics.config.factories.config_discriminators import AlgorithmConfig
 
 from .model_constraints import ModelConstraints
+from .seg_unet_constraints import SegUNetConstraints
 from .unet_constraints import UNetConstraints
 
 
-def get_model_constraints(model_config: UNetConfig) -> ModelConstraints:
+def get_model_constraints(algorithm_config: AlgorithmConfig) -> ModelConstraints:
     """Get the model constraints for the given model configuration.
 
     Parameters
     ----------
-    model_config : UNetConfig
+    algorithm_config : AlgorithmConfig
         The model configuration.
 
     Returns
@@ -24,10 +32,13 @@ def get_model_constraints(model_config: UNetConfig) -> ModelConstraints:
     ValueError
         If the model type is not supported.
     """
-    match model_config.architecture:
-        case "UNet":
-            return UNetConstraints(model_config)
+    match algorithm_config.algorithm:
+        case SupportedAlgorithm.SEG:
+            return SegUNetConstraints(algorithm_config.model)
+        case SupportedAlgorithm.CARE | SupportedAlgorithm.N2N | SupportedAlgorithm.N2V:
+            return UNetConstraints(algorithm_config.model)
         case _:
             raise ValueError(
-                f"Model type {model_config.architecture} is not supported."
+                f"Algorithm {algorithm_config.algorithm} has no corresponding model"
+                f"constraints."
             )

--- a/src/careamics/models/constraints/seg_unet_constraints.py
+++ b/src/careamics/models/constraints/seg_unet_constraints.py
@@ -1,12 +1,14 @@
-"""UNet model constraints."""
+"""Segmentation UNet model constraints."""
 
 from collections.abc import Sequence
 
 from careamics.config.architectures import UNetConfig
 
 
-class UNetConstraints:
-    """UNet model constraints on input and output tensors.
+# TODO the SegUnet is now testing the number of channels of the target, meaning
+# that it acts more as a task constraint validator than a model one.
+class SegUNetConstraints:
+    """SegmentationUNet model constraints on input and output tensors.
 
     Parameters
     ----------
@@ -60,13 +62,14 @@ class UNetConstraints:
         ValueError
             If the number of channels is not compatible with the model constraints.
         """
-        # validate target channels
-        if n_channels != self.model_config.get_num_output_channels():
+        # in segmentation the targets will have n_channels = 1, while the model will
+        # output multiple classes as channels
+        if n_channels != 1:
             raise ValueError(
                 f"Number of channels in target image ({n_channels}) does not match the "
-                f"number of output channels expected by the model configuration "
-                f"({self.model_config.get_num_output_channels()}). Adjust the number of"
-                f" output channels in the configuration to match your data."
+                f"number of channels expected for segmentation targets (1). If your "
+                f"targets are one-hot encoded, adjust your data to have a single "
+                f"channel with integer class labels."
             )
 
     def validate_spatial_shape(self, input_shape: Sequence[int]) -> None:

--- a/src/careamics/models/constraints/seg_unet_constraints.py
+++ b/src/careamics/models/constraints/seg_unet_constraints.py
@@ -1,14 +1,14 @@
 """Segmentation UNet model constraints."""
 
-from collections.abc import Sequence
-
 from careamics.config.architectures import UNetConfig
+
+from .unet_constraints import UNetConstraints
 
 
 # TODO the SegUnet is now testing the number of channels of the target, meaning
 # that it acts more as a task constraint validator than a model one.
-class SegUNetConstraints:
-    """SegmentationUNet model constraints on input and output tensors.
+class SegUNetConstraints(UNetConstraints):
+    """Segmentation UNet model constraints on input and output tensors.
 
     Parameters
     ----------
@@ -48,39 +48,3 @@ class SegUNetConstraints:
                 f"targets are one-hot encoded, adjust your data to have a single "
                 f"channel with integer class labels."
             )
-
-    def validate_spatial_shape(self, input_shape: Sequence[int]) -> None:
-        """Whether the given spatial shape is compatible with the model constraints.
-
-        Shape must be of length 2 (YX) or 3 (ZYX). To validate channel dimension, use
-        `validate_input_channels` or `validate_target_channels` instead.
-
-        Parameters
-        ----------
-        input_shape : Sequence[int]
-            The spatial shape of the input tensor to validate (length 2 or 3).
-
-        Raises
-        ------
-        ValueError
-            If the spatial shape is not compatible with the model constraints.
-        """
-        if len(input_shape) not in (2, 3):
-            raise ValueError(
-                f"Spatial input shape to model constraints should have length 2 (YX) or"
-                f" 3 (ZYX), but got shape {input_shape}."
-            )
-
-        dim_label = "ZYX" if len(input_shape) == 3 else "YX"
-
-        # check spatial dims against model depth constraints
-        depth = self.model_config.depth
-        for i, dim in enumerate(input_shape):
-            if dim % (2**depth) != 0 or dim == 0:
-                raise ValueError(
-                    f"Input data dimension {dim_label[i]} (size {dim}) is not a "
-                    f"multiple of {2**depth} (2 to the power of the model depth). If "
-                    f"you are training, adjust `patch_size`. If you are predicting,"
-                    f" your input data shape is not compatible, use tiling by passing "
-                    f"`tile_size`. If you are already using tiling, adjust `tile_size`."
-                )

--- a/src/careamics/models/constraints/seg_unet_constraints.py
+++ b/src/careamics/models/constraints/seg_unet_constraints.py
@@ -26,29 +26,6 @@ class SegUNetConstraints:
         """
         self.model_config = model_config
 
-    def validate_input_channels(self, n_channels: int) -> None:
-        """Whether the given channel size is compatible with the model constraints.
-
-        Parameters
-        ----------
-        n_channels : int
-            The number of channels in the input tensor to validate.
-
-        Raises
-        ------
-        ValueError
-            If the number of channels is not compatible with the model constraints.
-        """
-        # validate input channels
-        if n_channels != self.model_config.get_num_input_channels():
-            raise ValueError(
-                f"Number of channels in input image ({n_channels}) does not match the "
-                f"number of input channels expected by the model configuration "
-                f"({self.model_config.get_num_input_channels()}). Use the `channels` "
-                f"parameter to specify a subset of channels, or adjust the number of "
-                f"input channels in the configuration to match your data."
-            )
-
     def validate_target_channels(self, n_channels: int) -> None:
         """Whether the given channel size is compatible with the model constraints.
 


### PR DESCRIPTION
Semantic segmentation requires different model constraints from restoration algorithms because the model output has different shape than the target arrays. Indeed, model output are logits/probability per class while the target are class labels (no "C" dimension).

This PR changes the parameter passed to `get_model_constraints` from the model configuration to the algorithm configuration.
```python
# before
def get_model_constraints(model_config: UNetConfig) -> ModelConstraints:

# now
def get_model_constraints(algorithm_config: AlgorithmConfig) -> ModelConstraints:
```

It also adds the segmentation constraints class.

## Changes

### Added

- Segmentation constraints
    - Inherit from Unet constraints to reuse validation
    - Here, `validate_target_channels` needs to ensure that targets are class labels by checking it is a singleton channel

### Modified

- Update `get_model_constraints` to take in the algorithm configuration and accommodate segmentation constraints.
- Update `SupportedAlgorithms` to accommodate segmentation, reorganizes order.
- Update `Configuration` and `CAREamist` to pass the correct configuration (algorithm, not model) to `get_model_constraints`