### PR TITLE
Feat(Segmentation): add losses

### DIFF
--- a/src/careamics/losses/__init__.py
+++ b/src/careamics/losses/__init__.py
@@ -3,6 +3,7 @@
 __all__ = [
     "denoisplit_loss",
     "denoisplit_musplit_loss",
+    "get_seg_loss",
     "hdn_loss",
     "lvae_loss_factory",
     "musplit_loss",
@@ -18,3 +19,4 @@ from .lvae import (
     musplit_loss,
 )
 from .n2v_losses import n2v_loss, pn2v_loss
+from .segmentation_losses import get_seg_loss

--- a/src/careamics/losses/segmentation_losses.py
+++ b/src/careamics/losses/segmentation_losses.py
@@ -1,0 +1,283 @@
+"""Segmentation losses."""
+
+from collections.abc import Callable
+
+import torch
+import torch.nn.functional as F
+from torch.nn import Module
+
+
+def _targets_to_class_indices(targets: torch.Tensor, num_classes: int) -> torch.Tensor:
+    """Convert segmentation targets to class indices.
+
+    This method removes the C dimension, casts the labels to long for the loss
+    calculation, and performs validation.
+
+    Parameters
+    ----------
+    targets : torch.Tensor
+        Target representing class labels with a singleton C dimension.
+    num_classes : int
+        Number of classes.
+
+    Returns
+    -------
+    torch.Tensor
+        Target as class indices tensor.
+    """
+    if targets.shape[1] == 1:
+        class_indices = targets[:, 0].long()
+    else:
+        raise ValueError(
+            f"Target channel dimension must be of size 1 (class labels), got size "
+            f"{targets.shape[1]}."
+        )
+
+    if class_indices.min() < 0 or class_indices.max() >= num_classes:
+        raise ValueError(
+            f"Target class values must be in [0, {num_classes - 1}], got values in "
+            f"[{class_indices.min().item()}, {class_indices.max().item()}]."
+        )
+
+    return class_indices
+
+
+def _targets_to_one_hot(targets: torch.Tensor, num_classes: int) -> torch.Tensor:
+    """Convert singleton-channel class labels to one-hot encoding.
+
+    Parameters
+    ----------
+    targets : torch.Tensor
+        Target representing class labels with a singleton C dimension.
+    num_classes : int
+        Number of classes.
+
+    Returns
+    -------
+    torch.Tensor
+        Target as one-hot encoded tensor.
+    """
+    class_indices = _targets_to_class_indices(targets, num_classes)
+    one_hot = F.one_hot(class_indices, num_classes=num_classes).movedim(-1, 1)
+
+    return one_hot.float()
+
+
+class DiceLoss(Module):
+    """Dice loss for binary and multi-class segmentation.
+
+    Applies softmax activation to the model logits and computes Dice coefficient per
+    class, then averages across classes.
+
+    Parameters
+    ----------
+    weight : Tensor, optional
+        A manual rescaling weight given to each class.
+    include_background : bool, default=True
+        Whether to include the background class (class 0) in the loss calculation.
+    """
+
+    def __init__(self, weight=None, include_background=True) -> None:
+        """Constructor.
+
+        Parameters
+        ----------
+        weight : Tensor, optional
+            A manual rescaling weight given to each class.
+        include_background : bool, default=True
+            Whether to include the background class (class 0) in the loss calculation.
+        """
+        super().__init__()
+        self.weight = weight
+        self.include_background = include_background
+
+    def forward(self, inputs, targets, smooth=1) -> torch.Tensor:
+        """Compute Dice loss.
+
+        Parameters
+        ----------
+        inputs : Tensor
+            Predicted logits of shape (B, C, [Z], Y, X) where C is the number of
+            classes, including background (C=2 for binary).
+        targets : Tensor
+            Ground truth of shape (B, 1, [Z], Y, X) with class indices.
+        smooth : float, default=1
+            Smoothing constant to avoid division by zero.
+
+        Returns
+        -------
+        Tensor
+            Dice loss value (1 - Dice coefficient).
+        """
+        num_classes = inputs.shape[1]
+
+        probabilities = F.softmax(inputs, dim=1)
+        targets = _targets_to_one_hot(targets, num_classes).to(inputs.device)
+
+        if not self.include_background:
+            probabilities = probabilities[:, 1:]
+            targets = targets[:, 1:]
+
+        probabilities = probabilities.flatten(2)
+        targets = targets.flatten(2)
+
+        intersection = (probabilities * targets).sum(dim=2)
+        union = probabilities.sum(dim=2) + targets.sum(dim=2)
+        dice_per_class = (2.0 * intersection + smooth) / (union + smooth)
+
+        if self.weight is not None:
+            weight = self.weight
+            if weight.shape[0] != num_classes:
+                raise ValueError(
+                    f"Class weights must have length {num_classes}, got "
+                    f"{weight.shape[0]}."
+                )
+
+            if not self.include_background:
+                weight = weight[1:]
+
+            dice_per_class = dice_per_class * weight.to(dice_per_class.device)
+
+        return 1 - dice_per_class.mean()
+
+
+class DiceCELoss(Module):
+    """Combined Dice and Cross-Entropy loss for binary and multi-class segmentation.
+
+    Parameters
+    ----------
+    weight : Tensor, default=None
+        A manual rescaling weight given to each class for both losses.
+    include_background : bool, default=True
+        Whether to include the background class in the Dice loss calculation.
+    ce_weight : float, default=1.0
+        Weight for the cross-entropy component.
+    dice_weight : float, default=1.0
+        Weight for the Dice loss component.
+    """
+
+    def __init__(
+        self, weight=None, include_background=True, ce_weight=1.0, dice_weight=1.0
+    ) -> None:
+        """Constructor.
+
+        Parameters
+        ----------
+        weight : Tensor, default=None
+            A manual rescaling weight given to each class for both losses.
+        include_background : bool, default=True
+            Whether to include the background class in the Dice loss calculation.
+        ce_weight : float, default=1.0
+            Weight for the cross-entropy component.
+        dice_weight : float, default=1.0
+            Weight for the Dice loss component.
+        """
+        super().__init__()
+        self.dice_loss = DiceLoss(weight=weight, include_background=include_background)
+        self.weight = weight
+        self.ce_weight = ce_weight
+        self.dice_weight = dice_weight
+
+    def forward(self, inputs, targets, smooth=1) -> torch.Tensor:
+        """Compute combined Dice and Cross-Entropy loss.
+
+        Parameters
+        ----------
+        inputs : Tensor
+            Predicted logits of shape (B, C, [Z], Y, X) where C is the number of
+            classes, including background (C=2 for binary).
+        targets : Tensor
+            Ground truth of shape (B, 1, [Z], Y, X) with class indices.
+        smooth : float, default=1
+            Smoothing constant for Dice loss.
+
+        Returns
+        -------
+        Tensor
+            Combined loss value.
+        """
+        num_classes = inputs.shape[1]
+
+        target_indices = _targets_to_class_indices(targets, num_classes).to(
+            inputs.device
+        )
+
+        # compute Dice loss
+        dice_loss = self.dice_loss(inputs, targets, smooth=smooth)
+
+        # compute cross entropy
+        ce_loss = F.cross_entropy(
+            inputs,
+            target_indices,
+            weight=self.weight,
+            reduction="mean",
+        )
+
+        return self.ce_weight * ce_loss + self.dice_weight * dice_loss
+
+
+class CrossEntropyLoss(Module):
+    """Cross-entropy loss for segmentation targets with singleton label channels.
+
+    Parameters
+    ----------
+    weight : Tensor, default=None
+        A manual rescaling weight given to each class for both losses.
+    """
+
+    def __init__(self, weight=None) -> None:
+        """Constructor.
+
+        Parameters
+        ----------
+        weight : Tensor, optional
+            A manual rescaling weight given to each class.
+        """
+        super().__init__()
+        self.weight = weight
+
+    def forward(self, inputs, targets) -> torch.Tensor:
+        """Compute cross-entropy loss from segmentation logits and targets.
+
+        Parameters
+        ----------
+        inputs : Tensor
+            Predicted logits of shape (B, C, [Z], Y, X) where C is the number of
+            classes, including background (C=2 for binary).
+        targets : Tensor
+            Ground truth of shape (B, 1, [Z], Y, X) with class indices.
+
+        Returns
+        -------
+        Tensor
+            Loss value.
+        """
+        target_indices = _targets_to_class_indices(targets, inputs.shape[1]).to(
+            inputs.device
+        )
+        return F.cross_entropy(
+            inputs, target_indices, weight=self.weight, reduction="mean"
+        )
+
+
+def get_seg_loss(loss: str) -> Callable:
+    """Get loss function by name.
+
+    Parameters
+    ----------
+    loss : str
+        Name of the loss function. Supported: "dice", "ce", "dice_ce".
+
+    Returns
+    -------
+    Callable
+        Corresponding loss function.
+    """
+    if loss == "dice":
+        return DiceLoss()
+    elif loss == "ce":
+        return CrossEntropyLoss()
+    elif loss == "dice_ce":
+        return DiceCELoss()
+    else:
+        raise ValueError(f"Unsupported loss function: {loss}")

--- a/tests/unit/losses/test_segmentation_losses.py
+++ b/tests/unit/losses/test_segmentation_losses.py
@@ -1,0 +1,167 @@
+"""Tests for segmentation losses."""
+
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+import torch
+
+from careamics.losses.segmentation_losses import (
+    CrossEntropyLoss,
+    DiceCELoss,
+    DiceLoss,
+    get_seg_loss,
+)
+
+# --- Test utilities
+
+LOSSES = [DiceCELoss, DiceLoss, CrossEntropyLoss]
+
+BIN_CLASS_LABELS = torch.tensor([[0, 1], [0, 1]])
+
+BIN_ONE_HOT = torch.tensor(
+    [
+        [[1, 0], [1, 0]],
+        [[0, 1], [0, 1]],
+    ]
+)
+
+MUL_CLASS_LABELS = torch.tensor([[0, 1], [0, 2]])
+
+MUL_ONE_HOT = torch.tensor(
+    [
+        [[1, 0], [1, 0]],
+        [[0, 1], [0, 0]],
+        [[0, 0], [0, 1]],
+    ]
+)
+
+
+def to_3D(tensor: torch.Tensor) -> torch.Tensor:
+    """Turn a 2D label map or one-hot map into a small 3D volume."""
+    if tensor.ndim == 2:
+        return torch.stack([tensor, torch.rot90(tensor, k=1)], dim=0)
+    return torch.stack([tensor, torch.rot90(tensor, k=1, dims=(1, 2))], dim=1)
+
+
+def to_batch(tensor: torch.Tensor, batch_size: int = 1) -> torch.tensor:
+    """Add batch dimension by repeating the same sample."""
+    return tensor.unsqueeze(0).repeat(batch_size, *([1] * tensor.ndim))
+
+
+def make_targets(class_labels: torch.Tensor, batch_size: int = 1) -> torch.Tensor:
+    """Create batched targets of shape (B, 1, ...)."""
+    return to_batch(class_labels.unsqueeze(0), batch_size=batch_size)
+
+
+def low_loss_logits(one_hot, logit=10.0):
+    """Logits corresponding to a near-perfect prediction."""
+    return one_hot * logit + (1 - one_hot) * -logit
+
+
+def high_loss_logits(one_hot, logit=10.0):
+    """Logits corresponding to a confidently wrong prediction."""
+    return one_hot * -logit + (1 - one_hot) * logit
+
+
+# --- Unit tests
+
+
+@pytest.mark.parametrize(
+    "loss_func,class_labels,one_hot_labels,low_threshold",
+    [
+        (DiceLoss, BIN_CLASS_LABELS, BIN_ONE_HOT, 1e-3),
+        (DiceLoss, MUL_CLASS_LABELS, MUL_ONE_HOT, 1e-3),
+        (DiceCELoss, BIN_CLASS_LABELS, BIN_ONE_HOT, 1e-2),
+        (DiceCELoss, MUL_CLASS_LABELS, MUL_ONE_HOT, 1e-2),
+        (CrossEntropyLoss, BIN_CLASS_LABELS, BIN_ONE_HOT, 1e-3),
+        (CrossEntropyLoss, MUL_CLASS_LABELS, MUL_ONE_HOT, 1e-3),
+    ],
+)
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("is_3D", [False, True])
+def test_loss_perfect_prediction_is_low(
+    loss_func, class_labels, one_hot_labels, low_threshold, batch_size, is_3D
+):
+    """Perfect logits should produce a very small loss."""
+    loss = loss_func()
+
+    inputs = one_hot_labels if not is_3D else to_3D(one_hot_labels)
+    targets = class_labels if not is_3D else to_3D(class_labels)
+
+    logits = to_batch(low_loss_logits(inputs), batch_size=batch_size)
+    targets = make_targets(targets, batch_size=batch_size)
+
+    loss_value = loss(logits, targets)
+
+    assert loss_value < low_threshold
+
+
+@pytest.mark.parametrize(
+    "loss_func,class_labels,one_hot_labels",
+    [
+        (DiceLoss, BIN_CLASS_LABELS, BIN_ONE_HOT),
+        (DiceLoss, MUL_CLASS_LABELS, MUL_ONE_HOT),
+        (DiceCELoss, BIN_CLASS_LABELS, BIN_ONE_HOT),
+        (DiceCELoss, MUL_CLASS_LABELS, MUL_ONE_HOT),
+        (CrossEntropyLoss, BIN_CLASS_LABELS, BIN_ONE_HOT),
+        (CrossEntropyLoss, MUL_CLASS_LABELS, MUL_ONE_HOT),
+    ],
+)
+def test_loss_wrong_prediction_is_higher(loss_func, class_labels, one_hot_labels):
+    """Wrong logits should produce a larger loss than perfect logits."""
+    loss = loss_func()
+    low_logits = to_batch(low_loss_logits(one_hot_labels))
+    high_logits = to_batch(high_loss_logits(one_hot_labels))
+    targets = make_targets(class_labels)
+
+    low_loss = loss(low_logits, targets)
+    high_loss = loss(high_logits, targets)
+
+    assert low_loss < high_loss
+    assert high_loss - low_loss > 0.1
+
+
+@pytest.mark.parametrize(
+    "class_labels,one_hot_labels",
+    [
+        (BIN_CLASS_LABELS, BIN_ONE_HOT),
+        (MUL_CLASS_LABELS, MUL_ONE_HOT),
+        (BIN_CLASS_LABELS, BIN_ONE_HOT),
+        (MUL_CLASS_LABELS, MUL_ONE_HOT),
+        (BIN_CLASS_LABELS, BIN_ONE_HOT),
+        (MUL_CLASS_LABELS, MUL_ONE_HOT),
+    ],
+)
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("is_3D", [False, True])
+def test_dice_ce_sum(class_labels, one_hot_labels, batch_size, is_3D):
+    """Test that DiceCE is the sum of Dice and CE."""
+    dice_ce = DiceCELoss()
+    ce = CrossEntropyLoss()
+    dice = DiceLoss()
+
+    inputs = one_hot_labels if not is_3D else to_3D(one_hot_labels)
+    targets = class_labels if not is_3D else to_3D(class_labels)
+
+    inp = to_batch(low_loss_logits(inputs), batch_size=batch_size)
+    tar = make_targets(targets, batch_size=batch_size)
+
+    assert dice_ce.forward(inp, tar) == ce.forward(inp, tar) + dice.forward(inp, tar)
+
+
+@pytest.mark.parametrize(
+    "loss_name, exp_class, exp_error",
+    [
+        # no error
+        ("dice", DiceLoss, does_not_raise()),
+        ("ce", CrossEntropyLoss, does_not_raise()),
+        ("dice_ce", DiceCELoss, does_not_raise()),
+        # error
+        ("not_a_loss", None, pytest.raises(ValueError, match="Unsupported")),
+    ],
+)
+def test_get_loss(loss_name, exp_class, exp_error):
+    """Test loss factory."""
+    with exp_error:
+        loss = get_seg_loss(loss_name)
+        assert isinstance(loss, exp_class)


### PR DESCRIPTION
Add semantic segmentation losses.

This PR adds `DiceLoss`, `CrossEntropyLoss` and `DiceCELoss` (Dice+CrossEntropy) losses. All losses assume that the input to the `forward` method are:
- `inputs`: raw model output as logits of dims (B, C, [Z], Y, X) where `C` has dimension `num_classes` (including background)
- `targets`: class labels with singleton channel of dims (B, 1, [Z], Y, X).

Dice loss converts the input to probabilities (softmax) and the targets to one-hot encoding, while cross-entropy simply removes from the target the singleton `C` dimension and converts to `long` (necessary for `torch.nn.functional.cross_entropy`).

## Changes

### Added

- Segmentation losses to `segmentation_losses`
- Corresponding tests

## Notes

Typing added in https://github.com/CAREamics/careamics/pull/1081.

Part of splitting https://github.com/CAREamics/careamics/pull/986 into smaller PRs.