### PR TITLE
Feat(API): add `target_axes` to prediction

### DIFF
--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -796,6 +796,7 @@ class CAREamist:
         tile_size: tuple[int, ...] | None = None,
         tile_overlap: tuple[int, ...] | None = (48, 48),
         axes: str | None = None,
+        target_axes: str | None = None,
         data_type: Literal["array", "tiff", "zarr", "czi", "custom"] | None = None,
         # ADVANCED PARAMS
         num_workers: int | None = None,
@@ -815,6 +816,7 @@ class CAREamist:
         tile_size: tuple[int, ...] | None = None,
         tile_overlap: tuple[int, ...] | None = (48, 48),
         axes: str | None = None,
+        target_axes: str | None = None,
         data_type: Literal["array", "tiff", "zarr", "czi", "custom"] | None = None,
         # ADVANCED PARAMS
         num_workers: int | None = None,
@@ -833,6 +835,7 @@ class CAREamist:
         tile_size: tuple[int, ...] | None = None,
         tile_overlap: tuple[int, ...] | None = (48, 48),
         axes: str | None = None,
+        target_axes: str | None = None,
         data_type: Literal["array", "tiff", "zarr", "czi", "custom"] | None = None,
         # ADVANCED PARAMS
         num_workers: int | None = None,
@@ -871,6 +874,9 @@ class CAREamist:
             Overlap between tiles, can be None.
         axes : str, optional
             Axes of the input data, by default None.
+        target_axes : str | None, default=None
+            Axes for prediction target data. If None, uses target axes from the training
+            configuration.
         data_type : {"array", "tiff", "czi", "zarr", "custom"}, optional
             Type of the input data.
         num_workers : int, optional
@@ -908,6 +914,7 @@ class CAREamist:
             tile_size=tile_size,
             tile_overlap=tile_overlap,
             axes=axes,
+            target_axes=target_axes,
             data_type=data_type,
             num_workers=num_workers,
             channels=channels,
@@ -972,6 +979,7 @@ class CAREamist:
         tile_size: tuple[int, ...] | None = None,
         tile_overlap: tuple[int, ...] | None = (48, 48),
         axes: str | None = None,
+        target_axes: str | None = None,
         data_type: Literal["array", "tiff", "zarr", "czi", "custom"] | None = None,
         # ADVANCED PARAMS
         num_workers: int | None = None,
@@ -998,6 +1006,7 @@ class CAREamist:
         tile_size: tuple[int, ...] | None = None,
         tile_overlap: tuple[int, ...] | None = (48, 48),
         axes: str | None = None,
+        target_axes: str | None = None,
         data_type: Literal["array", "tiff", "zarr", "czi", "custom"] | None = None,
         # ADVANCED PARAMS
         num_workers: int | None = None,
@@ -1023,6 +1032,7 @@ class CAREamist:
         tile_size: tuple[int, ...] | None = None,
         tile_overlap: tuple[int, ...] | None = (48, 48),
         axes: str | None = None,
+        target_axes: str | None = None,
         data_type: Literal["array", "tiff", "zarr", "czi", "custom"] | None = None,
         # ADVANCED PARAMS
         num_workers: int | None = None,
@@ -1078,6 +1088,9 @@ class CAREamist:
             Overlap between tiles.
         axes : str, optional
             Axes of the input data, by default None.
+        target_axes : str | None, default=None
+            Axes for prediction target data. If None, uses target axes from the training
+            configuration.
         data_type : {"array", "tiff", "czi", "zarr", "custom"}, optional
             Type of the input data.
         num_workers : int, optional
@@ -1166,6 +1179,7 @@ class CAREamist:
             tile_size=tile_size,
             tile_overlap=tile_overlap,
             axes=axes,
+            target_axes=target_axes,
             data_type=data_type,
             num_workers=num_workers,
             channels=channels,

--- a/src/careamics/careamist.py
+++ b/src/careamics/careamist.py
@@ -706,7 +706,7 @@ class CAREamist:
         tile_size: tuple[int, ...] | None = None,
         tile_overlap: tuple[int, ...] | None = (48, 48),
         axes: str | None = None,
-        target_axes: str | None = None,
+        output_axes: str | None = None,
         data_type: Literal["array", "tiff", "zarr", "czi", "custom"] | None = None,
         num_workers: int | None = None,
         channels: Sequence[int] | Literal["all"] | None = None,
@@ -731,9 +731,9 @@ class CAREamist:
             Tile overlap for prediction. If None, defaults to (48, 48).
         axes : str | None, default=None
             Axes for prediction. If None, uses training configuration axes.
-        target_axes : str | None, default=None
-            Axes for prediction target data. If None, uses target axes from the training
-            configuration.
+        output_axes : str | None, default=None
+            Output axes used for reshaping prediction. If None, uses `target_axes` from
+            the training configuration.
         data_type : {"array", "tiff", "zarr", "czi", "custom"} | None, default=None
             Data type for prediction. If None, uses training configuration data type.
         num_workers : int | None, default=None
@@ -768,7 +768,7 @@ class CAREamist:
             new_data_type=data_type,
             new_dataloader_params=dataloader_params,
             new_axes=axes,
-            new_target_axes=target_axes,
+            new_target_axes=output_axes,
             new_channels=channels,
             new_in_memory=in_memory,
         )
@@ -796,7 +796,7 @@ class CAREamist:
         tile_size: tuple[int, ...] | None = None,
         tile_overlap: tuple[int, ...] | None = (48, 48),
         axes: str | None = None,
-        target_axes: str | None = None,
+        output_axes: str | None = None,
         data_type: Literal["array", "tiff", "zarr", "czi", "custom"] | None = None,
         # ADVANCED PARAMS
         num_workers: int | None = None,
@@ -816,7 +816,7 @@ class CAREamist:
         tile_size: tuple[int, ...] | None = None,
         tile_overlap: tuple[int, ...] | None = (48, 48),
         axes: str | None = None,
-        target_axes: str | None = None,
+        output_axes: str | None = None,
         data_type: Literal["array", "tiff", "zarr", "czi", "custom"] | None = None,
         # ADVANCED PARAMS
         num_workers: int | None = None,
@@ -835,7 +835,7 @@ class CAREamist:
         tile_size: tuple[int, ...] | None = None,
         tile_overlap: tuple[int, ...] | None = (48, 48),
         axes: str | None = None,
-        target_axes: str | None = None,
+        output_axes: str | None = None,
         data_type: Literal["array", "tiff", "zarr", "czi", "custom"] | None = None,
         # ADVANCED PARAMS
         num_workers: int | None = None,
@@ -874,9 +874,9 @@ class CAREamist:
             Overlap between tiles, can be None.
         axes : str, optional
             Axes of the input data, by default None.
-        target_axes : str | None, default=None
-            Axes for prediction target data. If None, uses target axes from the training
-            configuration.
+        output_axes : str | None, default=None
+            Output axes used for reshaping prediction. If None, uses `target_axes` from
+            the training configuration.
         data_type : {"array", "tiff", "czi", "zarr", "custom"}, optional
             Type of the input data.
         num_workers : int, optional
@@ -914,7 +914,7 @@ class CAREamist:
             tile_size=tile_size,
             tile_overlap=tile_overlap,
             axes=axes,
-            target_axes=target_axes,
+            output_axes=output_axes,
             data_type=data_type,
             num_workers=num_workers,
             channels=channels,
@@ -979,7 +979,7 @@ class CAREamist:
         tile_size: tuple[int, ...] | None = None,
         tile_overlap: tuple[int, ...] | None = (48, 48),
         axes: str | None = None,
-        target_axes: str | None = None,
+        output_axes: str | None = None,
         data_type: Literal["array", "tiff", "zarr", "czi", "custom"] | None = None,
         # ADVANCED PARAMS
         num_workers: int | None = None,
@@ -1006,7 +1006,7 @@ class CAREamist:
         tile_size: tuple[int, ...] | None = None,
         tile_overlap: tuple[int, ...] | None = (48, 48),
         axes: str | None = None,
-        target_axes: str | None = None,
+        output_axes: str | None = None,
         data_type: Literal["array", "tiff", "zarr", "czi", "custom"] | None = None,
         # ADVANCED PARAMS
         num_workers: int | None = None,
@@ -1032,7 +1032,7 @@ class CAREamist:
         tile_size: tuple[int, ...] | None = None,
         tile_overlap: tuple[int, ...] | None = (48, 48),
         axes: str | None = None,
-        target_axes: str | None = None,
+        output_axes: str | None = None,
         data_type: Literal["array", "tiff", "zarr", "czi", "custom"] | None = None,
         # ADVANCED PARAMS
         num_workers: int | None = None,
@@ -1088,9 +1088,9 @@ class CAREamist:
             Overlap between tiles.
         axes : str, optional
             Axes of the input data, by default None.
-        target_axes : str | None, default=None
-            Axes for prediction target data. If None, uses target axes from the training
-            configuration.
+        output_axes : str | None, default=None
+            Output axes used for reshaping prediction. If None, uses `target_axes` from
+            the training configuration.
         data_type : {"array", "tiff", "czi", "zarr", "custom"}, optional
             Type of the input data.
         num_workers : int, optional
@@ -1179,7 +1179,7 @@ class CAREamist:
             tile_size=tile_size,
             tile_overlap=tile_overlap,
             axes=axes,
-            target_axes=target_axes,
+            output_axes=output_axes,
             data_type=data_type,
             num_workers=num_workers,
             channels=channels,


### PR DESCRIPTION
`target_axes` is missing from `CAREamist` prediction functions, so when changing `axes` at prediction time users may not be able to predict since `axes` and `target_axes` can disagree. 

This was missed during the PRs that introduced `target_axes`.

Part of splitting https://github.com/CAREamics/careamics/pull/986 into smaller PRs.