### PR TITLE
Feat(CI): add e2e CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: 🧪 Run tests
-        run: uv run pytest --color=yes -m "not lvae and not compat"
+        run: uv run pytest --color=yes -m "not lvae and not e2e"
 
 
   deploy:

--- a/.github/workflows/ci_e2e.yml
+++ b/.github/workflows/ci_e2e.yml
@@ -1,0 +1,48 @@
+name: CI-e2e
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # run every week (for --pre release tests)
+    - cron: "0 0 * * 0"
+
+jobs:
+  test:
+    name: e2e py3.12 (ubuntu-latest)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+            
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          # Install a specific version of uv.
+          version: "0.9.0"
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: 🧪 Run e2e tests
+        # does not run doctests
+        run: uv run pytest tests/e2e --color=yes

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -41,7 +41,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: 🧪 Run Tests
-        run: uv run pytest --color=yes --cov --cov-config=pyproject.toml --cov-report=xml --cov-report=term-missing 
+        run: uv run pytest --color=yes --cov --cov-config=pyproject.toml --cov-report=xml --cov-report=term-missing  -m "not e2e"
 
       - name: Coverage
         uses: codecov/codecov-action@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,9 +176,8 @@ filterwarnings = [
 addopts = "-p no:doctest"
 
 markers = [
-    # "gpu: marks tests as requiring gpu",
     "lvae: marks tests as testing lvae",
-    "compat: marks tests as testing v0.1 compat modules",
+    "e2e: marks longer running end-to-end tests",
     "mps_gh_fail: marks tests as failing on Github macos-latest runner",
     "czi: marks tests using czi files",
 ]

--- a/src/careamics/lightning/callbacks/prediction/image_write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction/image_write_strategy.py
@@ -173,7 +173,7 @@ class ImageWriteStrategy(WriteStrategy):
         for data_idx in complete_images:
             cached_preds = self.image_cache.pop(data_idx)
 
-            image_lst, sources = combine_samples(cached_preds)
+            image_lst, sources = combine_samples(cached_preds, restore_shape=True)
 
             for i, image in enumerate(image_lst):
                 source_path = Path(sources[i])

--- a/src/careamics/lightning/callbacks/prediction/tile_write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction/tile_write_strategy.py
@@ -158,7 +158,7 @@ class TileWriteStrategy(WriteStrategy):
             Tiles to stitch and write.
         """
         # stitch prediction
-        prediction_image = stitch_single_prediction(tiles)
+        prediction_image = stitch_single_prediction(tiles, restore_shape=True)
         source: Path = Path(tiles[0].source)
 
         # Handle array sources with postfix

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,10 @@
+import pathlib
+
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    """Mark all tests in this subtree as end-to-end tests."""
+    for item in items:
+        if pathlib.Path(item.fspath).parent.name == "e2e":
+            item.add_marker(pytest.mark.e2e)

--- a/tests/e2e/test_lightning_api.py
+++ b/tests/e2e/test_lightning_api.py
@@ -144,6 +144,7 @@ def test_smoke_n2v_tiff(tmp_path, shape, axes, channels, tiled):
     predicted_images, _ = convert_prediction(
         predicted,
         tiled=tiled,
+        restore_shape=True,
     )
 
     # assert predicted file exists

--- a/tests/lightning/callbacks/prediction/test_image_write_strategy.py
+++ b/tests/lightning/callbacks/prediction/test_image_write_strategy.py
@@ -59,7 +59,7 @@ def test_cache_tiles_init(write_func, write_image_strategy):
 
 def test_write_image_batch(write_image_strategy, ordered_array, mocker):
     """Test writing a batch."""
-    array = ordered_array((5, 8, 8))
+    array = ordered_array((5, 1, 8, 8))
 
     prediction = [
         ImageRegionData(
@@ -69,7 +69,7 @@ def test_write_image_batch(write_image_strategy, ordered_array, mocker):
             dtype=np.float32,
             axes="SYX",  # axes describes the full dataset, not individual sample
             target_axes="SYX",
-            original_data_shape=array.shape,
+            original_data_shape=array.squeeze(1).shape,
             region_spec={
                 "data_idx": 0,
                 "sample_idx": i,
@@ -102,4 +102,4 @@ def test_write_image_batch(write_image_strategy, ordered_array, mocker):
         postfix="_0",
     )
     assert call_args["file_path"] == expected_file_path
-    np.testing.assert_array_equal(call_args["img"], array)
+    np.testing.assert_array_equal(call_args["img"], array.squeeze(1))

--- a/tests/lightning/callbacks/prediction/test_tile_write_strategy.py
+++ b/tests/lightning/callbacks/prediction/test_tile_write_strategy.py
@@ -75,7 +75,7 @@ def tiles(n_data, shape, axes) -> list[ImageRegionData]:
                 data_shape=shape_with_sc,
                 axes=axes,
                 target_axes=axes,
-                original_data_shape=shape_with_sc,
+                original_data_shape=shape,
                 region_spec=tile_spec,
                 additional_metadata={},
             )

--- a/uv.lock
+++ b/uv.lock
@@ -440,7 +440,7 @@ requires-dist = [
     { name = "scikit-image", specifier = "<=0.26.0" },
     { name = "tensorboard", marker = "extra == 'tensorboard'" },
     { name = "tifffile", specifier = "<=2026.3.3" },
-    { name = "torch", specifier = ">=2.1.0,<2.10.0" },
+    { name = "torch", specifier = ">=2.1.0,<2.13.0" },
     { name = "torchmetrics", specifier = ">0.7.0,<1.9.0" },
     { name = "torchvision", specifier = "<=0.25.0" },
     { name = "wandb", marker = "extra == 'wandb'" },
@@ -1484,12 +1484,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/e8/042eeac7c78565f1b4c14ba3dc6a96aad9b958e008a1e291a1cbf72123e9/imagecodecs-2026.6.26-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c48767bbc6ed0b40df3607cafdf59dac6f4467b91c26e835744d7ee4085cfdf7", size = 13164944, upload-time = "2026-06-28T18:26:29.33Z" },
     { url = "https://files.pythonhosted.org/packages/1d/dd/0e0c86df9a55a0a90ced8cf5214abb459015cda5f2e713e0495ccd9bf23f/imagecodecs-2026.6.26-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:9c130cf207efcb35acf74d6040317d217294640e478aa733fb51be758bcaddbc", size = 32436234, upload-time = "2026-06-28T18:26:33.35Z" },
     { url = "https://files.pythonhosted.org/packages/b9/9a/2d63eb2ffa46863bf0ea05884ce1ea2a73a5153b428937b8cbe4faa81536/imagecodecs-2026.6.26-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:014f5f809418eb3dfe29badd4af29ddeeaba8b5eabda4bd502e2292727e4094f", size = 33446845, upload-time = "2026-06-28T18:26:38.238Z" },
-    { url = "https://files.pythonhosted.org/packages/14/68/ece973cd5b1d8305b95ad827b3c6033aed166c5ce93780b6092dbfd5deec/imagecodecs-2026.6.26-cp314-cp314t-win32.whl", hash = "sha256:daa276e5645750404a28a911dcbfb94c7d32b2d8903b5f05167474ea02bd5b40", size = 17330378, upload-time = "2026-06-28T18:26:42.172Z" },
     { url = "https://files.pythonhosted.org/packages/ad/e6/ab2e9ee84e44768ceb73bb9301988ea4ab9022f02ef9d824d6ebb641a0fb/imagecodecs-2026.6.26-cp314-cp314t-win_amd64.whl", hash = "sha256:0718d75672768871aa6adac2129c8f74c167fb4a3da25f660f3afc94b420304f", size = 22122461, upload-time = "2026-06-28T18:26:45.622Z" },
-    { url = "https://files.pythonhosted.org/packages/58/53/7943321eb84c6d39e71ca47e689557a976c6ebafec48b759b3be0bd7c601/imagecodecs-2026.6.26-cp314-cp314t-win_arm64.whl", hash = "sha256:69b90b7b729d33cd9417d3d572d3092d2d49f7974638ee00e2cdc3ed1fba11d6", size = 17657147, upload-time = "2026-06-28T18:26:48.924Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/de/130820754c21c00dfdc6852661de2bb30161b5a439a8643a446dae97a02f/imagecodecs-2026.6.26-cp315-cp315t-win32.whl", hash = "sha256:a10c347225f5fb1b9d1a36cfadccad9b173609c30e0dd3f68706675d6f4f9b58", size = 17330338, upload-time = "2026-06-28T18:26:52.04Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/df/b4f6f2a9e9102ca674673cb1b432bbebfe2d99acb6364390768024d56ae6/imagecodecs-2026.6.26-cp315-cp315t-win_amd64.whl", hash = "sha256:85ab027a8bc900f13b1cdaac05bb602ea58749731ae18743a7956642a7da7a2c", size = 22116857, upload-time = "2026-06-28T18:26:55.65Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/c4/d87b33e8df5c6ec19f5cd1d5ab39195b2077ac21536ff5146c20d3fb8694/imagecodecs-2026.6.26-cp315-cp315t-win_arm64.whl", hash = "sha256:41e18fcd2124c083b00f988eeb9c5cf89274e5c2f473ee03d54761b71048085c", size = 17651071, upload-time = "2026-06-28T18:26:59.305Z" },
 ]
 
 [[package]]
@@ -2701,7 +2696,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2712,7 +2707,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2739,9 +2734,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2752,7 +2747,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },


### PR DESCRIPTION
This PR adds e2e CI and normalizes behaviour of writing arrays to disk.

## Main features

> [!WARNING]  
> Changes from #986 touched on these particular tests and were included here.

- New e2e CI that only runs `tests/e2e` in a single CI, these tests being excluded from other CIs.
- Tile and image writing strategies now restore the shape of the arrays/tiles before writing. 
    - Without these changes, the resulting arrays written to disk will have singleton channels. 
    - A consequence is that `predict` and `predict_to_disk` results will have different shape.
    - If channels were present in the original data (or target), then the singleton channels are kept as is the behaviour of `restore_shape`.

## Changes

### Added

- `.github/ci_e2e.yml` gh action
- `tests/e2e/conftest.py` to mark all e2e tests

### Modified

- `pyproject.toml` declares the `e2e` pytest mark
- `smoke_tests` renamed `lightning_api` e2e tests
- `image_write_strategy` and `tile_write_strategy` now do `restore_shape=True`
- Related tests are updated.

Part of splitting https://github.com/CAREamics/careamics/pull/986 into smaller PRs.