### PR TITLE
Fix: stitching back tiles when input and output have different number of channels

### DIFF
--- a/src/careamics/dataset/dataset.py
+++ b/src/careamics/dataset/dataset.py
@@ -15,6 +15,7 @@ from careamics.config.data.data_config import (
 )
 from careamics.dataset.augmentation.compose import Compose
 from careamics.models.constraints import ModelConstraints
+from careamics.utils.reshape_array import adjust_shape_for_channels
 
 from .image_region_data import ImageRegionData
 from .image_stack import GenericImageStack
@@ -81,10 +82,8 @@ def _adjust_original_shape_for_channels(
         Adjusted original data shape.
     """
     if channels is not None and "C" in axes:
-        c_idx = axes.index("C")
-        adjusted_original_shape = list(original_data_shape)
-        adjusted_original_shape[c_idx] = len(channels) if value == "channels" else value
-        original_data_shape = tuple(adjusted_original_shape)
+        n_channels = len(channels) if value == "channels" else value
+        return adjust_shape_for_channels(original_data_shape, axes, n_channels)
     return original_data_shape
 
 

--- a/src/careamics/dataset/dataset.py
+++ b/src/careamics/dataset/dataset.py
@@ -31,7 +31,7 @@ def _adjust_shape_for_channels(
     shape: Sequence[int],
     channels: Sequence[int] | None,
     value: int | Literal["channels"] = "channels",
-) -> tuple[int, ...]:
+) -> Sequence[int]:
     """Adjust shape to account for selecting a subset of channels.
 
     Parameters
@@ -50,10 +50,11 @@ def _adjust_shape_for_channels(
         The adjusted data shape in SC(Z)YX format.
     """
     if channels is not None:
-        adjusted_shape = list(shape)
-        adjusted_shape[1] = len(channels) if value == "channels" else value
-        return tuple(adjusted_shape)
-    return tuple(shape)
+        axes = "SCZYX" if len(shape) == 5 else "SCYX"
+        n_channels = len(channels) if value == "channels" else value
+        return adjust_shape_for_channels(shape, axes, n_channels)
+
+    return shape
 
 
 def _adjust_original_shape_for_channels(

--- a/src/careamics/lightning/prediction/stitch_prediction.py
+++ b/src/careamics/lightning/prediction/stitch_prediction.py
@@ -9,7 +9,7 @@ from numpy.typing import NDArray
 
 from careamics.dataset.image_region_data import ImageRegionData
 from careamics.dataset.patching import TileSpecs
-from careamics.utils.reshape_array import restore_array
+from careamics.utils.reshape_array import adjust_shape_for_channels, restore_array
 
 
 def group_tiles_by_key(
@@ -103,7 +103,11 @@ def stitch_single_prediction(
     numpy.ndarray
         Full image, with dimensions SC(Z)YX.
     """
-    data_shape = tiles[0].data_shape
+    data_shape = adjust_shape_for_channels(
+        tiles[0].data_shape,
+        "SCZYX" if "Z" in tiles[0].axes else "SCYX",  # canonical axes of the full array
+        tiles[0].data.shape[0],
+    )
     predicted_image = np.zeros(data_shape, dtype=np.float32)
 
     # stitch each sample separately
@@ -151,7 +155,11 @@ def stitch_single_sample(
     numpy.ndarray
         Full sample, with dimensions C(Z)YX.
     """
-    data_shape = tiles[0].data_shape  # SC(Z)YX
+    data_shape = adjust_shape_for_channels(
+        tiles[0].data_shape,
+        "SCZYX" if "Z" in tiles[0].axes else "SCYX",  # canonical axes of the full array
+        tiles[0].data.shape[0],
+    )
     predicted_sample = np.zeros(data_shape[1:], dtype=np.float32)
 
     for tile in tiles:

--- a/src/careamics/utils/reshape_array.py
+++ b/src/careamics/utils/reshape_array.py
@@ -16,6 +16,46 @@ _VALID_AXES = set(_REF_ORDER)
 # TODO to clarify the transformations call the transformed space "canonical".
 
 
+def adjust_shape_for_channels(
+    data_shape: Sequence[int],
+    axes: str,
+    n_channels: int,
+) -> Sequence[int]:
+    """Adjust a shape with a different number of channels.
+
+    This method is used in two contexts: subsetting channels during data loading and
+    creating prediction arrays from input shape with different number of output
+    channels.
+
+    Parameters
+    ----------
+    data_shape : Sequence[int]
+        Data shape.
+    axes : str
+        Axes string describing `data_shape`.
+    n_channels : int
+        Number of channels to update `data_shape` with.
+
+    Returns
+    -------
+    Sequence[int]
+        Adjusted data shape.
+
+    Raises
+    ------
+    ValueError
+        If "C" is not found in axes.
+    """
+    if "C" not in axes:
+        raise ValueError(f"Channel axis `C` not found in axes, got {axes}.")
+
+    c_idx = axes.index("C")
+    adjusted_shape = list(data_shape)
+    adjusted_shape[c_idx] = n_channels
+
+    return tuple(adjusted_shape)
+
+
 # TODO reuse the validators from configuration? or simply drop the validation from here
 def _validate_axes(axes: str) -> None:
     """Validate axes.

--- a/tests/e2e/test_care.py
+++ b/tests/e2e/test_care.py
@@ -43,3 +43,33 @@ def test_target_axes():
     predictions, _ = careamist.predict(pred_data=train_data)
 
     assert predictions[0].shape == out_shape
+
+
+def test_care_tiling_different_channels():
+    """Test CARE with tiled prediction and different input/output channels."""
+    input_channels = 2
+    output_channels = 3
+    spatial_shape = (512, 512)
+    axes = "YXC"
+
+    input_data = np.random.random((*spatial_shape, input_channels))
+    target_data = np.random.random((*spatial_shape, output_channels))
+
+    config = create_advanced_care_config(
+        experiment_name="input_output_channels",
+        data_type="array",
+        axes=axes,
+        patch_size=(64, 64),
+        batch_size=16,
+        num_epochs=3,
+        n_channels_in=input_channels,
+        n_channels_out=output_channels,
+    )
+
+    careamist = CAREamist(config=config)
+    careamist.train(train_data=input_data, train_data_target=target_data)
+
+    predictions, _ = careamist.predict(
+        pred_data=input_data, tile_size=(64, 64), tile_overlap=(48, 48)
+    )
+    assert predictions[0].shape == target_data.shape

--- a/tests/unit/utils/test_reshape_array.py
+++ b/tests/unit/utils/test_reshape_array.py
@@ -4,6 +4,7 @@ import pytest
 from careamics.utils.reshape_array import (
     AxesTransform,
     RestoredAxesTransform,
+    adjust_shape_for_channels,
     reshape_array,
     restore_array,
 )
@@ -408,6 +409,21 @@ _CHANNEL_MISMATCH_TILE_DISORDERED = [
 ]
 
 # --- Unit tests
+
+
+@pytest.mark.parametrize(
+    "shape, axes, n_channels",
+    [
+        ((3, 2, 8, 8), "SCYX", 3),
+        ((1, 2, 8, 8), "SCYX", 3),
+        ((3, 2, 8, 8, 8), "SCZYX", 3),
+        ((8, 3, 2, 8), "XSCY", 3),
+    ],
+)
+def test_adjust_shape_for_channels(shape, axes, n_channels):
+    """Test adjusting a data shape with a different channel number."""
+    adjusted_shape = adjust_shape_for_channels(shape, axes, n_channels)
+    assert adjusted_shape[axes.index("C")] == n_channels
 
 
 class TestAxesTransform:


### PR DESCRIPTION
#993 failed to close #948 because it did not address tile stitching (outside of Zarr) but only combining entire samples. This PR introduces a new function to adjust data shapes and use it in the stitching utilities to create arrays of the correct size.

## Changes

### Added

- `adjust_shape_for_channels` in `reshape_array.py`: a method to update a data shape with a new channel dimension size given the axes
- Relevant unit and e2e tests

### Modified

- `dataaset.py`: a similar step was performed in the dataset, it has been updated to use the new `adjust_shape_for_channels` function.
- `stitch_single_prediction` and `stitch_single_sample` were updated to adjust the channels of the receiving array shape.


## Resolves

Closes #948