### PR TITLE
Refac: rename `ImageRegionData` and `reshape_array` attributes for clarity

### DIFF
--- a/docs/tutorials/data_custom_image_stack.py
+++ b/docs/tutorials/data_custom_image_stack.py
@@ -56,9 +56,7 @@ class HDF5ImageStack:
         self._image_data = image_data
         self.original_axes = axes
         self.original_data_shape = image_data.shape
-        self.data_shape = AxesTransform(
-            axes, self.original_data_shape
-        ).transformed_shape
+        self.data_shape = AxesTransform(axes, self.original_data_shape).canonical_shape
 
     @property
     def data_dtype(self) -> DTypeLike:

--- a/docs/tutorials/implementing_an_image_stack.py
+++ b/docs/tutorials/implementing_an_image_stack.py
@@ -16,7 +16,7 @@ class HDF5ImageStack:
         self.original_data_shape = image_data.shape  # (2)!
         self.data_shape = AxesTransform(  # (3)!
             axes, self.original_data_shape
-        ).transformed_shape
+        ).canonical_shape
 
     @property
     def data_dtype(self) -> DTypeLike:
@@ -73,7 +73,7 @@ from careamics.utils.reshape_array import AxesTransform
 
 original_axes = "YXC"
 original_data_shape = (512, 620, 2)
-data_shape = AxesTransform(original_axes, original_data_shape).transformed_shape
+data_shape = AxesTransform(original_axes, original_data_shape).canonical_shape
 print(data_shape)
 # --8<-- [end:transform-data-shape]
 # %%

--- a/src/careamics/dataset/dataset.py
+++ b/src/careamics/dataset/dataset.py
@@ -315,17 +315,17 @@ class CareamicsDataset(Dataset, Generic[GenericImageStack]):
         target_metadata = self.patch_constructor.get_target_image_metadata(patch_spec)
         target_axes = self.config.target_axes or self.config.axes
 
-        input_metadata["data_shape"] = _adjust_shape_for_channels(
-            input_metadata["data_shape"], self.config.channels
+        input_metadata["canonical_shape"] = _adjust_shape_for_channels(
+            input_metadata["canonical_shape"], self.config.channels
         )
-        input_metadata["original_data_shape"] = _adjust_original_shape_for_channels(
-            input_metadata["original_data_shape"],
+        input_metadata["original_shape"] = _adjust_original_shape_for_channels(
+            input_metadata["original_shape"],
             self.config.channels,
             self.config.axes,
         )
         input_data = ImageRegionData(
             data=input_patch,
-            axes=self.config.axes,
+            original_axes=self.config.axes,
             target_axes=target_axes,
             region_spec=patch_spec,
             **input_metadata,
@@ -333,7 +333,7 @@ class CareamicsDataset(Dataset, Generic[GenericImageStack]):
         if target_patch is not None and target_metadata is not None:
             target_data = ImageRegionData(
                 data=target_patch,
-                axes=target_axes,
+                original_axes=target_axes,
                 target_axes=target_axes,
                 region_spec=patch_spec,
                 **target_metadata,

--- a/src/careamics/dataset/image_region_data.py
+++ b/src/careamics/dataset/image_region_data.py
@@ -54,8 +54,8 @@ class ImageRegionData(NamedTuple, Generic[RegionSpecs]):
     """
 
     original_shape: Sequence[int]
-    """Original shape of the source image before reshaping in canonical space and with
-    channel subsetting."""
+    """Original shape of the source image before reshaping in canonical space and may
+    include channel subsetting."""
 
     region_spec: RegionSpecs  # PatchSpecs or subclasses, e.g. TileSpecs
     """Specifications of the region within the source image from where `data` is

--- a/src/careamics/dataset/image_region_data.py
+++ b/src/careamics/dataset/image_region_data.py
@@ -17,58 +17,55 @@ class ImageRegionData(NamedTuple, Generic[RegionSpecs]):
     An ImageRegionData may be a patch during training/validation, a tile during
     prediction with tiling, or a whole image during prediction without tiling.
 
-    `data_shape` may not correspond to the shape of the original data if a subset
+    `canonical_shape` may not correspond to the shape of the original data if a subset
     of the channels has been requested, in which case the channel dimension may
     be smaller than that of the original data and only correspond to the requested
     number of channels.
 
-    ImageRegionData may be collated in batches during training by the DataLoader. In
-    that case:
-    - data: arrays are collated into NDArray of shape (B,C,Z,Y,X)
-    - source: list of str, length B
-    - data_shape: list of tuples of int, each tuple being of length B and representing
-        the shape of the original images in the corresponding dimension
-    - dtype: list of str, length B
-    - axes: list of str, length B
-    - region_spec: dict of {str: sequence}, each sequence being of length B
-    - additional_metadata: list of dict
-
+    ImageRegionData may be collated in batches during training by the DataLoader.
     Description of the fields is given for the uncollated case (non-batched).
+
+    Canonical space refers to the SC(Z)YX space, while original space is the original
+    axes order of the data.
     """
 
     data: NDArray
-    """Patch, tile or image in C(Z)YX format."""
+    """Patch, tile or image in canonical space."""
 
     source: Union[str, Literal["array"]]
     """Source of the data, e.g. file path, zarr URI, or "array" for in-memory arrays."""
 
-    data_shape: Sequence[int]
-    """Shape of the image in SC(Z)YX format and order. If channels are
-    subsetted, the channel dimension corresponds to the number of requested channels."""
+    canonical_shape: Sequence[int]
+    """Shape of the source image in canonical space. Axis order may differ from the
+    source due to reshaping to canonical space. Channel dimension may differ from
+    if channels were subsetted. `data` may be a patch or a tile from the source data,
+    and can therefore have a different shape from `canonical_shape`."""
 
     dtype: str  # dtype should be str for collate
-    """Data type of the original image as a string."""
+    """Data type of the source image as a string."""
 
-    axes: str
-    """Axes of the original data array. SCTZYX dimensions are allowed in any order."""
+    original_axes: str
+    """Axes of the source image in the original space."""
 
     target_axes: str
-    """Axes of the target data array. If no target was used during training, this should
-    be set to axes.
+    """Axes of the target array corresponding to the source image. If no target was
+    used during training, this should be set to `original_axes`. Target axes may differ
+    from `original_axes` depending on the task.
     """
 
-    original_data_shape: Sequence[int]
-    """Original shape of the data before any reshaping."""
+    original_shape: Sequence[int]
+    """Original shape of the source image before reshaping in canonical space and with
+    channel subsetting."""
 
     region_spec: RegionSpecs  # PatchSpecs or subclasses, e.g. TileSpecs
-    """Specifications of the region within the original image from where `data` is
+    """Specifications of the region within the source image from where `data` is
     extracted. Of type PatchSpecs during training/validation and prediction without
     tiling, and TileSpecs during prediction with tiling.
     """
 
     additional_metadata: dict[str, Any]
-    """Additional metadata to be stored with the image region. Currently used to store
-    chunk and shard information for zarr image stacks."""
+    """Additional metadata to be stored with the image region. Used to store chunk and
+    shard information for zarr image stacks."""
 
     @classmethod
     def from_model_output(
@@ -92,11 +89,11 @@ class ImageRegionData(NamedTuple, Generic[RegionSpecs]):
         return cls(
             data=output_data,
             source=input_region.source,
-            data_shape=input_region.data_shape,
+            canonical_shape=input_region.canonical_shape,
             dtype=input_region.dtype,
-            axes=input_region.axes,
+            original_axes=input_region.original_axes,
             target_axes=input_region.target_axes,
-            original_data_shape=input_region.original_data_shape,
+            original_shape=input_region.original_shape,
             region_spec=input_region.region_spec,
             additional_metadata=input_region.additional_metadata,
         )

--- a/src/careamics/dataset/image_stack/czi_image_stack.py
+++ b/src/careamics/dataset/image_stack/czi_image_stack.py
@@ -72,7 +72,7 @@ class CziImageStack:
         Path to the CZI file without scene index.
     scene : int or None
         Index of the scene to extract, or None if not specified.
-    data_shape : Sequence[int]
+    canonical_shape : Sequence[int]
         The shape of the data in the order `(SC(Z)YX)`.
     axes : str
         The axes in the CZI file corresponding to the dimensions in `data_shape`.
@@ -170,7 +170,7 @@ class CziImageStack:
         self._czi = CziReader(str(self.data_path))
 
         # Determine metadata
-        self.axes, self.data_shape, self._bounding_rectangle, self._sample_axes = (
+        self.axes, self.canonical_shape, self._bounding_rectangle, self._sample_axes = (
             self._get_shape()
         )
         self.data_dtype = np.float32
@@ -247,7 +247,7 @@ class CziImageStack:
         return original
 
     @property
-    def original_data_shape(self) -> tuple[int, ...]:
+    def original_shape(self) -> tuple[int, ...]:
         """Original shape of the data.
 
         Returns
@@ -257,10 +257,10 @@ class CziImageStack:
         """
         if not self._sample_axes:
             # No dimensions were merged into S, so shape is already original
-            return tuple(self.data_shape)
+            return tuple(self.canonical_shape)
 
         # Reconstruct original shape by replacing S dimension with sample axes
-        shape_list = list(self.data_shape)
+        shape_list = list(self.canonical_shape)
         s_idx = self.axes.index("S")
         # Replace S dimension with the sample axes dimensions
         sample_sizes = list(self._sample_axes.values())
@@ -294,14 +294,14 @@ class CziImageStack:
         """
         # check that channels are within bounds
         if channels is not None:
-            max_channel = self.data_shape[1] - 1  # channel is second dimension
+            max_channel = self.canonical_shape[1] - 1  # channel is second dimension
             for ch in channels:
                 if ch > max_channel:
                     raise ValueError(
                         f"Channel index {ch} is out of bounds for data with "
-                        f"{self.data_shape[1]} channels. Check the provided `channels` "
-                        f"parameter in the configuration for erroneous channel "
-                        f"indices."
+                        f"{self.canonical_shape[1]} channels. Check the provided "
+                        f"`channels` parameter in the configuration for erroneous "
+                        f"channel indices."
                     )
 
         # Determine 3rd dimension (T, Z or none)
@@ -329,7 +329,7 @@ class CziImageStack:
         )
 
         # Create output array of shape (C, Z, Y, X)
-        n_channels = self.data_shape[1] if channels is None else len(channels)
+        n_channels = self.canonical_shape[1] if channels is None else len(channels)
         patch = np.zeros(
             (n_channels, third_dim_size, *patch_size[-2:]), dtype=np.float32
         )
@@ -347,7 +347,9 @@ class CziImageStack:
         # Read XY planes sequentially
         channel_iter: Iterable
         if channels is None:
-            channel_iter = range(self.data_shape[1])  # iter over number of requested C
+            channel_iter = range(
+                self.canonical_shape[1]
+            )  # iter over number of requested C
         else:
             channel_iter = list(channels)
 
@@ -360,7 +362,10 @@ class CziImageStack:
                     plane[third_dim] = third_dim_offset + third_dim_index
 
                     # check if in bounds
-                    if 0 > plane[third_dim] or plane[third_dim] >= self.data_shape[-3]:
+                    if (
+                        0 > plane[third_dim]
+                        or plane[third_dim] >= self.canonical_shape[-3]
+                    ):
                         continue
 
                 # read plane

--- a/src/careamics/dataset/image_stack/file_image_stack.py
+++ b/src/careamics/dataset/image_stack/file_image_stack.py
@@ -224,7 +224,7 @@ class FileImageStack:
         # TODO: think this is correct but need more examples to test
         file = tifffile.TiffFile(path)
         original_data_shape = file.series[0].shape
-        data_shape = AxesTransform(axes, original_data_shape).transformed_shape
+        data_shape = AxesTransform(axes, original_data_shape).canonical_shape
         dtype = file.series[0].dtype
         return cls(
             source=path,

--- a/src/careamics/dataset/image_stack/file_image_stack.py
+++ b/src/careamics/dataset/image_stack/file_image_stack.py
@@ -35,7 +35,7 @@ class FileImageStack:
         Function to read the file into an array.
     read_kwargs : dict or Any, optional
         Extra keyword arguments for `read_func`.
-    original_data_shape : tuple of int or None, optional
+    original_shape : tuple of int or None, optional
         Shape in original axis order.
 
     Notes
@@ -52,7 +52,7 @@ class FileImageStack:
         data_dtype: DTypeLike,
         read_func: ReadFunc,
         read_kwargs: dict[str, Any] | Any = None,
-        original_data_shape: tuple[int, ...] | None = None,
+        original_shape: tuple[int, ...] | None = None,
     ):
         """Constructor.
 
@@ -75,18 +75,18 @@ class FileImageStack:
             Function to read the file into an array.
         read_kwargs : dict or Any, optional
             Extra keyword arguments passed to `read_func`.
-        original_data_shape : tuple of int or None, optional
+        original_shape : tuple of int or None, optional
             Shape in original axis order before transformation.
         """
         self.source = source
         self.axes = axes
-        self.data_shape = data_shape
+        self.canonical_shape = data_shape
         self.data_dtype = data_dtype
         self.read_func = read_func
         self.read_kwargs = read_kwargs
         self._data: NDArray | None = None
-        self._original_data_shape: tuple[int, ...] = (
-            original_data_shape if original_data_shape is not None else ()
+        self._original_shape: tuple[int, ...] = (
+            original_shape if original_shape is not None else ()
         )
 
     def extract_patch(
@@ -128,14 +128,14 @@ class FileImageStack:
 
         # check that channels are within bounds
         if channels is not None:
-            max_channel = self.data_shape[1] - 1  # channel is second dimension
+            max_channel = self.canonical_shape[1] - 1  # channel is second dimension
             for ch in channels:
                 if ch > max_channel:
                     raise ValueError(
                         f"Channel index {ch} is out of bounds for data with "
-                        f"{self.data_shape[1]} channels. Check the provided `channels` "
-                        f"parameter in the configuration for erroneous channel "
-                        f"indices."
+                        f"{self.canonical_shape[1]} channels. Check the provided "
+                        f"`channels` parameter in the configuration for erroneous "
+                        f"channel indices."
                     )
 
         patch_data = self._data[
@@ -145,14 +145,14 @@ class FileImageStack:
                 channel_slice(channels),  # type: ignore
                 *[
                     slice(
-                        np.clip(c, 0, self.data_shape[2 + i]),
-                        np.clip(c + ps, 0, self.data_shape[2 + i]),
+                        np.clip(c, 0, self.canonical_shape[2 + i]),
+                        np.clip(c + ps, 0, self.canonical_shape[2 + i]),
                     )
                     for i, (c, ps) in enumerate(zip(coords, patch_size, strict=False))
                 ],  # type: ignore
             )  # type: ignore
         ]
-        patch = pad_patch(coords, patch_size, self.data_shape, patch_data)
+        patch = pad_patch(coords, patch_size, self.canonical_shape, patch_data)
 
         return patch
 
@@ -179,19 +179,19 @@ class FileImageStack:
         return self._data is not None
 
     @property
-    def original_data_shape(self) -> tuple[int, ...]:
-        """Original shape of the data.
+    def original_shape(self) -> tuple[int, ...]:
+        """Original shape of the source image.
 
         Returns
         -------
         tuple of int
             Shape in original axis order.
         """
-        return self._original_data_shape
+        return self._original_shape
 
     @property
     def original_axes(self) -> str:
-        """Original axes of the data.
+        """Original axes of the source image.
 
         Returns
         -------
@@ -223,8 +223,8 @@ class FileImageStack:
         """
         # TODO: think this is correct but need more examples to test
         file = tifffile.TiffFile(path)
-        original_data_shape = file.series[0].shape
-        data_shape = AxesTransform(axes, original_data_shape).canonical_shape
+        original_shape = file.series[0].shape
+        data_shape = AxesTransform(axes, original_shape).canonical_shape
         dtype = file.series[0].dtype
         return cls(
             source=path,
@@ -232,5 +232,5 @@ class FileImageStack:
             data_shape=data_shape,
             data_dtype=dtype,
             read_func=read_tiff,
-            original_data_shape=original_data_shape,
+            original_shape=original_shape,
         )

--- a/src/careamics/dataset/image_stack/image_stack_protocol.py
+++ b/src/careamics/dataset/image_stack/image_stack_protocol.py
@@ -32,18 +32,18 @@ class ImageStack(Protocol):
         ...
 
     @property
-    def data_shape(self) -> Sequence[int]:
-        """Shape of the image data (SC(Z)YX)."""
+    def canonical_shape(self) -> Sequence[int]:
+        """Shape of the image in canonical space (SC(Z)YX)."""
         ...
 
     @property
     def data_dtype(self) -> DTypeLike:
-        """Data type of the image data."""
+        """Data type of the source image."""
         ...
 
     @property
-    def original_data_shape(self) -> Sequence[int]:
-        """Original shape of the data."""
+    def original_shape(self) -> Sequence[int]:
+        """Original shape of the source image."""
         ...
 
     @property

--- a/src/careamics/dataset/image_stack/in_memory_image_stack.py
+++ b/src/careamics/dataset/image_stack/in_memory_image_stack.py
@@ -26,7 +26,7 @@ class InMemoryImageStack:
         Array with axes SC(Z)YX.
     original_axes : str or None, optional
         Axis in original order.
-    original_data_shape : tuple of int or None, optional
+    original_shape : tuple of int or None, optional
         Shape in original axis order.
     """
 
@@ -35,7 +35,7 @@ class InMemoryImageStack:
         source: Union[Path, Literal["array"]],
         data: NDArray,
         original_axes: str | None = None,
-        original_data_shape: tuple[int, ...] | None = None,
+        original_shape: tuple[int, ...] | None = None,
     ):
         """Constructor.
 
@@ -48,17 +48,17 @@ class InMemoryImageStack:
             Array with axes SC(Z)YX.
         original_axes : str or None, optional
             Axis in original order.
-        original_data_shape : tuple of int or None, optional
+        original_shape : tuple of int or None, optional
             Shape in original axis order.
         """
         self.source: Union[str, Path, Literal["array"]] = source
         # data expected to be in SC(Z)YX shape, reason to use from_array constructor
         self.data_dtype: DTypeLike = data.dtype
         self._data: NDArray = data.astype(np.float32, copy=False)
-        self.data_shape: Sequence[int] = self._data.shape
+        self.canonical_shape: Sequence[int] = self._data.shape
         self._original_axes: str = original_axes if original_axes is not None else ""
-        self._original_data_shape: tuple[int, ...] = (
-            original_data_shape if original_data_shape is not None else ()
+        self._original_shape: tuple[int, ...] = (
+            original_shape if original_shape is not None else ()
         )
 
     def extract_patch(
@@ -94,14 +94,14 @@ class InMemoryImageStack:
 
         # check that channels are within bounds
         if channels is not None:
-            max_channel = self.data_shape[1] - 1  # channel is second dimension
+            max_channel = self.canonical_shape[1] - 1  # channel is second dimension
             for ch in channels:
                 if ch > max_channel:
                     raise ValueError(
                         f"Channel index {ch} is out of bounds for data with "
-                        f"{self.data_shape[1]} channels. Check the provided `channels` "
-                        f"parameter in the configuration for erroneous channel "
-                        f"indices."
+                        f"{self.canonical_shape[1]} channels. Check the provided "
+                        f"`channels` parameter in the configuration for erroneous "
+                        f"channel indices."
                     )
 
         # TODO: test for 2D or 3D?
@@ -113,19 +113,19 @@ class InMemoryImageStack:
                 channel_slice(channels),  # type: ignore
                 *[
                     slice(
-                        np.clip(c, 0, self.data_shape[2 + i]),
-                        np.clip(c + ps, 0, self.data_shape[2 + i]),
+                        np.clip(c, 0, self.canonical_shape[2 + i]),
+                        np.clip(c + ps, 0, self.canonical_shape[2 + i]),
                     )
                     for i, (c, ps) in enumerate(zip(coords, patch_size, strict=False))
                 ],  # type: ignore
             )  # type: ignore
         ]
-        patch = pad_patch(coords, patch_size, self.data_shape, patch_data)
+        patch = pad_patch(coords, patch_size, self.canonical_shape, patch_data)
 
         return patch
 
     @property
-    def original_data_shape(self) -> tuple[int, ...]:
+    def original_shape(self) -> tuple[int, ...]:
         """Original shape of the data.
 
         Returns
@@ -133,7 +133,7 @@ class InMemoryImageStack:
         tuple of int
             Shape in original axis order.
         """
-        return self._original_data_shape
+        return self._original_shape
 
     @property
     def original_axes(self) -> str:
@@ -166,7 +166,7 @@ class InMemoryImageStack:
             source="array",
             data=reshape_array(data, axes),
             original_axes=axes,
-            original_data_shape=data.shape,
+            original_shape=data.shape,
         )
 
     @classmethod
@@ -190,7 +190,7 @@ class InMemoryImageStack:
             source=path,
             data=reshape_array(data, axes),
             original_axes=axes,
-            original_data_shape=data.shape,
+            original_shape=data.shape,
         )
 
     @classmethod
@@ -220,5 +220,5 @@ class InMemoryImageStack:
             source=path,
             data=reshape_array(data, axes),
             original_axes=axes,
-            original_data_shape=data.shape,
+            original_shape=data.shape,
         )

--- a/src/careamics/dataset/image_stack/zarr_image_stack.py
+++ b/src/careamics/dataset/image_stack/zarr_image_stack.py
@@ -61,8 +61,8 @@ class ZarrImageStack:
         #   - must contain XY
         #   - must be subset of STCZYX
         self._original_axes = axes
-        self._original_data_shape: tuple[int, ...] = self._array.shape
-        self.data_shape = AxesTransform(axes, self._original_data_shape).canonical_shape
+        self._original_shape: tuple[int, ...] = self._array.shape
+        self.canonical_shape = AxesTransform(axes, self._original_shape).canonical_shape
 
         self._data_dtype = self._array.dtype
         self._chunk_size = self._array.chunks
@@ -117,19 +117,19 @@ class ZarrImageStack:
         return self._data_dtype
 
     @property
-    def original_data_shape(self) -> tuple[int, ...]:
-        """Original shape of the data.
+    def original_shape(self) -> tuple[int, ...]:
+        """Original shape of the source image.
 
         Returns
         -------
         tuple of int
             Shape in original axis order.
         """
-        return self._original_data_shape
+        return self._original_shape
 
     @property
     def original_axes(self) -> str:
-        """Original axes of the data.
+        """Original axes of the source image.
 
         Returns
         -------
@@ -165,7 +165,7 @@ class ZarrImageStack:
         """
         patch_slice = get_patch_slices(
             self._original_axes,
-            self._original_data_shape,
+            self._original_shape,
             sample_idx,
             channels,
             coords,
@@ -174,5 +174,5 @@ class ZarrImageStack:
 
         patch_data: NDArray = self._array[patch_slice]  # type: ignore
         patch_data = reshape_patch(patch_data, self._original_axes)
-        patch = pad_patch(coords, patch_size, self.data_shape, patch_data)
+        patch = pad_patch(coords, patch_size, self.canonical_shape, patch_data)
         return patch

--- a/src/careamics/dataset/image_stack/zarr_image_stack.py
+++ b/src/careamics/dataset/image_stack/zarr_image_stack.py
@@ -62,9 +62,7 @@ class ZarrImageStack:
         #   - must be subset of STCZYX
         self._original_axes = axes
         self._original_data_shape: tuple[int, ...] = self._array.shape
-        self.data_shape = AxesTransform(
-            axes, self._original_data_shape
-        ).transformed_shape
+        self.data_shape = AxesTransform(axes, self._original_data_shape).canonical_shape
 
         self._data_dtype = self._array.dtype
         self._chunk_size = self._array.chunks

--- a/src/careamics/dataset/patch_constructor/metadata_utils.py
+++ b/src/careamics/dataset/patch_constructor/metadata_utils.py
@@ -15,10 +15,10 @@ class ImageMetadata(TypedDict):
         Source path or identifier for the image stack.
     dtype : str
         Data type of the image stack.
-    data_shape : Sequence[int]
-        Loaded data shape.
-    original_data_shape : Sequence[int]
-        Original source data shape.
+    canonical_shape : Sequence[int]
+        Image shape once loaded in canonical space (SC(Z)YX).
+    original_shape : Sequence[int]
+        Original source image shape.
     additional_metadata : dict[str, Any]
         Format-specific metadata, such as chunking for zarr data.
     """

--- a/src/careamics/dataset/patch_constructor/metadata_utils.py
+++ b/src/careamics/dataset/patch_constructor/metadata_utils.py
@@ -25,8 +25,8 @@ class ImageMetadata(TypedDict):
 
     source: str
     dtype: str
-    data_shape: Sequence[int]
-    original_data_shape: Sequence[int]
+    canonical_shape: Sequence[int]
+    original_shape: Sequence[int]
     additional_metadata: dict[str, Any]
 
 
@@ -58,7 +58,7 @@ def get_image_metadata(image_stack: ImageStack) -> ImageMetadata:
     return {
         "source": str(image_stack.source),
         "dtype": str(image_stack.data_dtype),
-        "data_shape": image_stack.data_shape,
-        "original_data_shape": image_stack.original_data_shape,
+        "canonical_shape": image_stack.data_shape,
+        "original_shape": image_stack.original_data_shape,
         "additional_metadata": additional_metadata,
     }

--- a/src/careamics/dataset/patch_constructor/metadata_utils.py
+++ b/src/careamics/dataset/patch_constructor/metadata_utils.py
@@ -58,7 +58,7 @@ def get_image_metadata(image_stack: ImageStack) -> ImageMetadata:
     return {
         "source": str(image_stack.source),
         "dtype": str(image_stack.data_dtype),
-        "canonical_shape": image_stack.data_shape,
-        "original_shape": image_stack.original_data_shape,
+        "canonical_shape": image_stack.canonical_shape,
+        "original_shape": image_stack.original_shape,
         "additional_metadata": additional_metadata,
     }

--- a/src/careamics/dataset/patch_constructor/microsplit_patch_constructors.py
+++ b/src/careamics/dataset/patch_constructor/microsplit_patch_constructors.py
@@ -1037,7 +1037,7 @@ def _extract_lc_patch(
         Lateral context patch with axes CL(Z)YX, where L is the lateral context input
         axis ordered from the native patch scale to larger context scales.
     """
-    shape = extractor.image_stacks[data_idx].data_shape
+    shape = extractor.image_stacks[data_idx].canonical_shape
     spatial_shape = shape[2:]
     n_channels = shape[1] if channels is None else len(channels)
 
@@ -1120,9 +1120,9 @@ def _get_uncorrelated_metadata(
         ]
     principal_image_stack = image_stacks[patch_spec["principal_channel"]]
     all_sources = [str(image_stack.source) for image_stack in image_stacks]
-    all_data_shapes = [image_stack.data_shape for image_stack in image_stacks]
+    all_data_shapes = [image_stack.canonical_shape for image_stack in image_stacks]
     all_original_data_shapes = [
-        image_stack.original_data_shape for image_stack in image_stacks
+        image_stack.original_shape for image_stack in image_stacks
     ]
 
     metadata = get_image_metadata(principal_image_stack)

--- a/src/careamics/dataset/patch_extractor/patch_extractor.py
+++ b/src/careamics/dataset/patch_extractor/patch_extractor.py
@@ -33,16 +33,16 @@ class PatchExtractor(Generic[GenericImageStack]):
 
         # check all image stacks have the same number of dimensions
         # check all image stacks have the same number of channels
-        self.n_spatial_dims = len(self.image_stacks[0].data_shape) - 2  # SC(Z)YX
+        self.n_spatial_dims = len(self.image_stacks[0].canonical_shape) - 2  # SC(Z)YX
         for i, image_stack in enumerate(image_stacks):
-            if (ndims := len(image_stack.data_shape) - 2) != self.n_spatial_dims:
+            if (ndims := len(image_stack.canonical_shape) - 2) != self.n_spatial_dims:
                 raise ValueError(
                     "All `ImageStack` objects in a `PatchExtractor` must have the same "
                     "number of spatial dimensions. The first image stack is "
                     f"{self.n_spatial_dims}D but found a {ndims}D image stack at index "
                     f"{i}."
                 )
-            if (n_channels := image_stack.data_shape[1]) != self.n_channels:
+            if (n_channels := image_stack.canonical_shape[1]) != self.n_channels:
                 raise ValueError(
                     "All `ImageStack` objects in a `PatchExtractor` must have the same "
                     f"number of channels. The first image stack has {self.n_channels} "
@@ -130,7 +130,7 @@ class PatchExtractor(Generic[GenericImageStack]):
         list of Sequence[int]
             Shape of each stack.
         """
-        return [stack.data_shape for stack in self.image_stacks]
+        return [stack.canonical_shape for stack in self.image_stacks]
 
     @property
     def n_channels(self) -> int:
@@ -141,4 +141,4 @@ class PatchExtractor(Generic[GenericImageStack]):
         int
             Number of channels.
         """
-        return self.image_stacks[0].data_shape[1]
+        return self.image_stacks[0].canonical_shape[1]

--- a/src/careamics/lightning/callbacks/prediction/image_write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction/image_write_strategy.py
@@ -130,9 +130,9 @@ class ImageWriteStrategy(WriteStrategy):
         int
             Total number of samples in the S dimension, or 1 if no S dimension.
         """
-        if "S" in prediction.axes:
-            s_idx = prediction.axes.index("S")
-            return prediction.data_shape[s_idx]
+        if "S" in prediction.original_axes:
+            s_idx = prediction.original_axes.index("S")
+            return prediction.canonical_shape[s_idx]
         return 1
 
     def _get_complete_images(self) -> list[int]:

--- a/src/careamics/lightning/callbacks/prediction/zarr_tile_write_strategy.py
+++ b/src/careamics/lightning/callbacks/prediction/zarr_tile_write_strategy.py
@@ -67,8 +67,8 @@ class ZarrTileHandler:
         """
         self.tile = region.data
         tile_shape = region.data.shape
-        original_shape = region.original_data_shape
-        original_axes = region.axes
+        original_shape = region.original_shape
+        original_axes = region.original_axes
         target_axes = region.target_axes
         self.original_chunks = region.additional_metadata.get("chunks", None)
         self.original_shards = region.additional_metadata.get("shards", None)

--- a/src/careamics/lightning/prediction/convert_prediction.py
+++ b/src/careamics/lightning/prediction/convert_prediction.py
@@ -89,23 +89,23 @@ def decollate_image_region_data(
         additional_metadata = _decollate_batch_dict(batch.additional_metadata, i)
 
         # data shape
-        assert isinstance(batch.data_shape, list)
-        data_shape = tuple(int(dim[i]) for dim in batch.data_shape)
+        assert isinstance(batch.canonical_shape, list)
+        data_shape = tuple(int(dim[i]) for dim in batch.canonical_shape)
 
         # original data shape
-        assert isinstance(batch.original_data_shape, list)
-        original_data_shape = tuple(int(dim[i]) for dim in batch.original_data_shape)
+        assert isinstance(batch.original_shape, list)
+        original_data_shape = tuple(int(dim[i]) for dim in batch.original_shape)
 
         image_region = ImageRegionData(
             data=batch.data[i],  # discard batch dimension
             source=batch.source[i],
             dtype=batch.dtype[i],
-            data_shape=data_shape,
-            axes=batch.axes[i],
+            canonical_shape=data_shape,
+            original_axes=batch.original_axes[i],
             target_axes=batch.target_axes[i],
             region_spec=region_spec,  # type: ignore
             additional_metadata=additional_metadata,
-            original_data_shape=original_data_shape,
+            original_shape=original_data_shape,
         )
         decollated.append(image_region)
 
@@ -157,9 +157,9 @@ def combine_samples(
 
         if restore_shape:
             # get original shape info from the first image region
-            original_axes = image_regions[0].axes
+            original_axes = image_regions[0].original_axes
             target_axes = image_regions[0].target_axes
-            original_data_shape = image_regions[0].original_data_shape
+            original_data_shape = image_regions[0].original_shape
             combined_data = restore_array(
                 combined_data, original_axes, original_data_shape, target_axes
             )

--- a/src/careamics/lightning/prediction/stitch_prediction.py
+++ b/src/careamics/lightning/prediction/stitch_prediction.py
@@ -103,7 +103,7 @@ def stitch_single_prediction(
     numpy.ndarray
         Full image, with dimensions SC(Z)YX.
     """
-    data_shape = tiles[0].data_shape
+    data_shape = tiles[0].canonical_shape
     predicted_image = np.zeros(data_shape, dtype=np.float32)
 
     # stitch each sample separately
@@ -124,8 +124,8 @@ def stitch_single_prediction(
     if restore_shape:
         predicted_image = restore_array(
             predicted_image,
-            tiles[0].axes,
-            tiles[0].original_data_shape,
+            tiles[0].original_axes,
+            tiles[0].original_shape,
             tiles[0].target_axes,
         )
 
@@ -151,7 +151,7 @@ def stitch_single_sample(
     numpy.ndarray
         Full sample, with dimensions C(Z)YX.
     """
-    data_shape = tiles[0].data_shape  # SC(Z)YX
+    data_shape = tiles[0].canonical_shape  # SC(Z)YX
     predicted_sample = np.zeros(data_shape[1:], dtype=np.float32)
 
     for tile in tiles:

--- a/src/careamics/utils/reshape_array.py
+++ b/src/careamics/utils/reshape_array.py
@@ -68,20 +68,20 @@ def _validate_axes_and_target(original_axes: str, target_axes: str) -> None:
         )
 
 
-# TODO can these classes be simplified for clarity?
 @dataclass(frozen=True)
 class AxesTransform:
-    """Transformation between original and transformed space axes.
+    """Transformation between original and canonical space axes.
 
-    All transformation decisions are derived from the original axes string,
-    shape.
+    All transformation decisions are derived from the original axes and shape. Canonical
+    space refers to SC(Z)YX order.
 
     Attributes
     ----------
     original_axes : str
-        User defined attribute. Axes string of the input data (e.g. "YXC", "STCZYX").
+        Axes string of the source image (e.g. "YXC", "STCZYX").
     original_shape : tuple[int, ...]
-        User defined attribute. Shape corresponding to `original_axes`.
+        Shape of the source image corresponding to `original_axes`, channels may be
+        subsetted compared to the source image.
     sample_dims : list[str]
         Computed property. Original dimensions merged into S. Spatial (Y, X and Z), as
         well as channels, are never considered sample dimensions.
@@ -89,20 +89,22 @@ class AxesTransform:
         Computed property. Whether original data contains a Z axis.
     original_dim_sizes : dict[str, int]
         Computed property. Map from axis name to original size.
-    transformed_axes : str
-        Computed property. Transformed axes string: "SC(Z)YX".
-    transformed_shape : tuple[int, ...]
-        Computed property. Expected shape after forward transformation.
+    canonical_axes : str
+        Computed property. Axes of the data in canonical space.
+    canonical_shape : tuple[int, ...]
+        Computed property. Expected shape after forward transformation to the canonical
+        space.
     order_permutation : list[int]
         Computed property. Permutation to reorder original axes to STCZYX reference
         order in SC(Z)YX space.
     """
 
     original_axes: str
-    """Original axes string of the input data (e.g. "YXC", "STCZYX")."""
+    """Axes string of the source image (e.g. "YXC", "STCZYX")."""
 
     original_shape: Sequence[int]
-    """Shape corresponding to `original_axes`."""
+    """Shape of the source image corresponding to `original_axes`, channels may be
+    subsetted compared to the source image."""
 
     def __post_init__(self) -> None:
         """Validate original axes and shape."""
@@ -159,7 +161,7 @@ class AxesTransform:
         return dict(zip(self.original_axes, self.original_shape, strict=True))
 
     @property
-    def transformed_axes(self) -> str:
+    def canonical_axes(self) -> str:
         """Transformed axes string, `SC(Z)YX` or `SCYX`.
 
         Returns
@@ -171,7 +173,7 @@ class AxesTransform:
         return "SCZYX" if self.original_has_z else "SCYX"
 
     @property
-    def transformed_shape(self) -> tuple[int, ...]:
+    def canonical_shape(self) -> tuple[int, ...]:
         """Expected shape in transformed space.
 
         Returns
@@ -263,8 +265,9 @@ class RestoredAxesTransform:
     (C(Z)YX) or a full array shape (SC(Z)YX).
 
     This class is used in the following cases:
-    - Restoring a full array from SC(Z)YX to original axes order, after prediction.
-    - Restoring a tile from C(Z)YX to original axes order, before writing it in a Zarr.
+    - Restoring a full array from canonical to original axes order, after prediction.
+    - Restoring a tile from canonical to original axes order, before writing it in a
+    Zarr.
     - Generate slices in a fully restored array to index a restored tile (Zarr).
     - Adjust shape based on channel difference between original and current shape, used
     to ensure that Zarr shard and chunk sizes are compatible with the restored array
@@ -829,7 +832,7 @@ def get_patch_slices(
         Slices to index into the original array to extract the patch.
     """
     transform = AxesTransform(original_axes, tuple(original_shape))
-    transformed_shape = transform.transformed_shape
+    transformed_shape = transform.canonical_shape
     # original axes assumed to be any subset of STCZYX (containing YX), in any order
     # arguments must be transformed to index data in original axes order
     # to do this: loop through original axes and append correct index/slice

--- a/src/careamics/utils/reshape_array.py
+++ b/src/careamics/utils/reshape_array.py
@@ -10,35 +10,6 @@ import numpy as np
 from numpy.typing import NDArray
 
 _REF_ORDER = "STCZYX"
-_VALID_AXES = set(_REF_ORDER)
-
-
-# TODO to clarify the transformations call the transformed space "canonical".
-
-
-# TODO reuse the validators from configuration? or simply drop the validation from here
-def _validate_axes(axes: str) -> None:
-    """Validate axes.
-
-    Parameters
-    ----------
-    axes : str
-        Axes string of the input data (e.g. "YXC", "STCZYX").
-
-    Raises
-    ------
-    ValueError
-        If axes are not valid.
-    """
-    invalid = set(axes) - _VALID_AXES
-    if invalid:
-        raise ValueError(f"Invalid axis names: {invalid}. Must be from {_VALID_AXES}.")
-
-    if len(set(axes)) != len(axes):
-        raise ValueError(f"Duplicate axes in '{axes}'.")
-
-    if "Y" not in axes or "X" not in axes:
-        raise ValueError("Axes must contain Y and X.")
 
 
 def _validate_axes_and_shape(axes: str, shape: Sequence[int]) -> None:
@@ -56,8 +27,6 @@ def _validate_axes_and_shape(axes: str, shape: Sequence[int]) -> None:
     ValueError
         If axes and shape are not compatible.
     """
-    _validate_axes(axes)
-
     if len(axes) != len(shape):
         raise ValueError(
             f"Axes '{axes}' length ({len(axes)}) does not match shape {shape} length "
@@ -319,10 +288,8 @@ class RestoredAxesTransform:
     """Whether current_shape is a tile shape (C(Z)YX). This is used to identify the axes
     order in `current_shape`."""
 
-    # TODO axes validation could be skipped here since it is ensured by the config
     def __post_init__(self) -> None:
         """Validate current shape and axes."""
-        _validate_axes(self.target_axes)
         _validate_axes_and_target(self.original_axes, self.target_axes)
         _validate_axes_and_shape(self.original_axes, self.original_shape)
 

--- a/tests/dataset/dataset/test_dataset.py
+++ b/tests/dataset/dataset/test_dataset.py
@@ -83,11 +83,11 @@ def test_from_array_with_target_axes():
     )
 
     sample, target = train_dataset[0]
-    assert sample.axes == "YX"
-    assert target.axes == "CYX"
+    assert sample.original_axes == "YX"
+    assert target.original_axes == "CYX"
     assert sample.data.shape == (1, *patch_size)
     assert target.data.shape == (2, *patch_size)
-    assert target.original_data_shape == example_target.shape
+    assert target.original_shape == example_target.shape
 
 
 # TODO revisit these tests
@@ -145,7 +145,7 @@ def test_from_array_with_channels(data_shape, patch_size, channels):
                 assert np.all((ch + 1) * 1000 >= sample.data[i])
 
             # test that channels are properly adjusted in data_shape
-            assert sample.data_shape[1] == len(channels)
+            assert sample.canonical_shape[1] == len(channels)
 
 
 @pytest.mark.parametrize(

--- a/tests/dataset/image_stack/czi/test_czi_image_stack.py
+++ b/tests/dataset/image_stack/czi/test_czi_image_stack.py
@@ -127,7 +127,7 @@ class TestCziImageStack:
 
         # check axes and shape
         assert image_stack.axes == expected_axes
-        assert image_stack.data_shape == expected_shape
+        assert image_stack.canonical_shape == expected_shape
 
         # test extracted patch matches patch from reference data
         if len(expected_axes) < 5:
@@ -205,7 +205,7 @@ class TestCziImageStack:
             image_stack = CziImageStack(
                 data_path=file_path, scene=scene_idx, depth_axis="Z"
             )
-            assert image_stack.data_shape == expected_shape
+            assert image_stack.canonical_shape == expected_shape
 
             t = expected_shape[0] - scene_idx - 1
             coords = (2, 9, 4)

--- a/tests/dataset/image_stack/test_in_memory_image_stack.py
+++ b/tests/dataset/image_stack/test_in_memory_image_stack.py
@@ -25,7 +25,7 @@ def array_stack(shape, axes) -> tuple[NDArray, InMemoryImageStack]:
 def test_from_array(array_stack):
     data, image_stack = array_stack
     np.testing.assert_array_equal(image_stack._data, data)
-    assert image_stack.data_shape == data.shape
+    assert image_stack.canonical_shape == data.shape
     assert image_stack.data_dtype == data.dtype
 
 

--- a/tests/dataset/patch_extractor/test_limit_files_extractor.py
+++ b/tests/dataset/patch_extractor/test_limit_files_extractor.py
@@ -28,7 +28,7 @@ def test_files_limited(tmp_path: Path):
 
     # using random patching
     patching = RandomPatching(
-        [image_stack.data_shape for image_stack in image_stacks],
+        [image_stack.canonical_shape for image_stack in image_stacks],
         patch_size=(16, 16),
         seed=42,
     )

--- a/tests/lightning/callbacks/prediction/test_image_write_strategy.py
+++ b/tests/lightning/callbacks/prediction/test_image_write_strategy.py
@@ -65,11 +65,11 @@ def test_write_image_batch(write_image_strategy, ordered_array, mocker):
         ImageRegionData(
             source="array.tiff",
             data=array[i],  # individual sample without S dimension
-            data_shape=array.shape,
+            canonical_shape=array.shape,
             dtype=np.float32,
-            axes="SYX",  # axes describes the full dataset, not individual sample
+            original_axes="SYX",  # describes the full dataset, not individual sample
             target_axes="SYX",
-            original_data_shape=array.shape,
+            original_shape=array.shape,
             region_spec={
                 "data_idx": 0,
                 "sample_idx": i,

--- a/tests/lightning/callbacks/prediction/test_tile_write_strategy.py
+++ b/tests/lightning/callbacks/prediction/test_tile_write_strategy.py
@@ -72,10 +72,10 @@ def tiles(n_data, shape, axes) -> list[ImageRegionData]:
                 data=tile,
                 source=f"array_{i}.tif",
                 dtype=str(tile.dtype),
-                data_shape=shape_with_sc,
-                axes=axes,
+                canonical_shape=shape_with_sc,
+                original_axes=axes,
                 target_axes=axes,
-                original_data_shape=shape_with_sc,
+                original_shape=shape_with_sc,
                 region_spec=tile_spec,
                 additional_metadata={},
             )

--- a/tests/lightning/callbacks/prediction/test_zarr_tile_write_strategy.py
+++ b/tests/lightning/callbacks/prediction/test_zarr_tile_write_strategy.py
@@ -261,7 +261,7 @@ def test_write_from_array(tmp_path):
     patch_extractor = PatchExtractor(image_stacks)
 
     strategy = TiledPatching(
-        data_shapes=[image_stacks[0].data_shape] * 2,
+        data_shapes=[image_stacks[0].canonical_shape] * 2,
         patch_size=(8, 8),
         overlaps=(4, 4),
     )
@@ -296,7 +296,7 @@ def test_write_from_tiff(tmp_path):
     patch_extractor = PatchExtractor(image_stacks)
 
     strategy = TiledPatching(
-        data_shapes=[image_stacks[0].data_shape] * 2,
+        data_shapes=[image_stacks[0].canonical_shape] * 2,
         patch_size=(8, 8),
         overlaps=(4, 4),
     )

--- a/tests/lightning/callbacks/prediction/test_zarr_tile_write_strategy.py
+++ b/tests/lightning/callbacks/prediction/test_zarr_tile_write_strategy.py
@@ -161,7 +161,7 @@ def tiles(
         )
         sources.append(arr.store_path)
 
-    shape_with_sc = AxesTransform(data_config.axes, shape).transformed_shape
+    shape_with_sc = AxesTransform(data_config.axes, shape).canonical_shape
 
     tiling_strategy = TiledPatching(
         data_shapes=[shape_with_sc] * n_data,

--- a/tests/lightning/callbacks/prediction/test_zarr_tile_write_strategy.py
+++ b/tests/lightning/callbacks/prediction/test_zarr_tile_write_strategy.py
@@ -46,10 +46,10 @@ def create_image_region(
         data=patch,
         source=str(source),
         dtype=str(extractor.image_stacks[data_idx].data_dtype),
-        canonical_shape=extractor.image_stacks[data_idx].data_shape,
+        canonical_shape=extractor.image_stacks[data_idx].canonical_shape,
         original_axes=axes,
         target_axes=axes,
-        original_shape=extractor.image_stacks[data_idx].original_data_shape,
+        original_shape=extractor.image_stacks[data_idx].original_shape,
         region_spec=patch_spec,
         additional_metadata={
             "shards": shards,

--- a/tests/lightning/callbacks/prediction/test_zarr_tile_write_strategy.py
+++ b/tests/lightning/callbacks/prediction/test_zarr_tile_write_strategy.py
@@ -46,10 +46,10 @@ def create_image_region(
         data=patch,
         source=str(source),
         dtype=str(extractor.image_stacks[data_idx].data_dtype),
-        data_shape=extractor.image_stacks[data_idx].data_shape,
-        axes=axes,
+        canonical_shape=extractor.image_stacks[data_idx].data_shape,
+        original_axes=axes,
         target_axes=axes,
-        original_data_shape=extractor.image_stacks[data_idx].original_data_shape,
+        original_shape=extractor.image_stacks[data_idx].original_data_shape,
         region_spec=patch_spec,
         additional_metadata={
             "shards": shards,

--- a/tests/lightning/prediction/test_convert_prediction.py
+++ b/tests/lightning/prediction/test_convert_prediction.py
@@ -36,10 +36,10 @@ def batches(source_name: str) -> list[ImageRegionData]:
                     data=(
                         data_idx * np.ones((32, 32)).astype(np.float32)
                     ),  # individual sample, B dim added by collate
-                    data_shape=(10, 32, 32),
+                    canonical_shape=(10, 32, 32),
                     dtype="float32",
                     # axes describes the full dataset shape
-                    axes="SYX",
+                    original_axes="SYX",
                     target_axes="SYX",
                     # non-sense to check that they are properly decollated
                     region_spec={
@@ -52,7 +52,7 @@ def batches(source_name: str) -> list[ImageRegionData]:
                         "chunks": (1, 1, 16, 16),
                         "shards": (1, 1, 32, 32),
                     },
-                    original_data_shape=(10, 32, 32),
+                    original_shape=(10, 32, 32),
                 )
             )
 
@@ -116,8 +116,8 @@ class TestCombineSamples:
                         data=np.ones((3, 32, 32)).astype(np.float32) * data_idx,
                         source=f"{data_idx}.tiff",
                         dtype="float32",
-                        data_shape=(32, 32),
-                        axes="TYXC",
+                        canonical_shape=(32, 32),
+                        original_axes="TYXC",
                         target_axes="TYXC",
                         region_spec={
                             "data_idx": data_idx,
@@ -126,7 +126,7 @@ class TestCombineSamples:
                             "patch_size": (32, 32),
                         },
                         additional_metadata={},
-                        original_data_shape=(10, 32, 32, 3),
+                        original_shape=(10, 32, 32, 3),
                     )
                 )
 
@@ -156,9 +156,9 @@ def test_decollate_image_region_data(n_batch) -> None:
                 source="array.tiff",
                 # individual sample, B dim is added by collate
                 data=np.ones((4, 4)).astype(np.float32),
-                data_shape=(32, 32),
+                canonical_shape=(32, 32),
                 dtype=str(np.float32),
-                axes="YX",
+                original_axes="YX",
                 target_axes="YX",
                 region_spec={
                     "data_idx": i,
@@ -170,7 +170,7 @@ def test_decollate_image_region_data(n_batch) -> None:
                     "chunks": (1, 1, 16, i),
                     "shards": (1, 1, 32, i * 2),
                 },
-                original_data_shape=(32, 32),
+                original_shape=(32, 32),
             )
         )
 
@@ -181,9 +181,9 @@ def test_decollate_image_region_data(n_batch) -> None:
     for i in range(len(batch)):
         np.testing.assert_array_equal(decollated[i].data, batch[i].data, verbose=True)
         assert decollated[i].source == batch[i].source
-        assert decollated[i].data_shape == batch[i].data_shape
+        assert decollated[i].canonical_shape == batch[i].canonical_shape
         assert decollated[i].dtype == batch[i].dtype
-        assert decollated[i].axes == batch[i].axes
+        assert decollated[i].original_axes == batch[i].original_axes
         assert decollated[i].region_spec == batch[i].region_spec
         assert (
             decollated[i].additional_metadata["chunks"]

--- a/tests/unit/dataset/patch_constructor/test_microsplit_patch_constructors.py
+++ b/tests/unit/dataset/patch_constructor/test_microsplit_patch_constructors.py
@@ -56,7 +56,7 @@ def _image_stack_from_array(
         source=Path(source),
         data=array,
         original_axes=axes,
-        original_data_shape=array.shape,
+        original_shape=array.shape,
     )
 
 

--- a/tests/unit/lightning/callbacks/prediction/test_zarr_tile_writer.py
+++ b/tests/unit/lightning/callbacks/prediction/test_zarr_tile_writer.py
@@ -39,11 +39,11 @@ def tile(
     return ImageRegionData(
         data=np.random.rand(*tile_shape).astype(np.float32),
         source="test_source",
-        data_shape=tile_shape,
+        canonical_shape=tile_shape,
         dtype="float32",
-        axes=original_axes,
+        original_axes=original_axes,
         target_axes=target_axes,
-        original_data_shape=original_shape,
+        original_shape=original_shape,
         region_spec=TileSpecs(
             data_idx=2,
             sample_idx=0 if has_samples else None,

--- a/tests/unit/utils/test_reshape_array.py
+++ b/tests/unit/utils/test_reshape_array.py
@@ -464,18 +464,6 @@ class TestAxesTransform:
         transform = AxesTransform("TYX", (T_S, XY_S, XY_S))
         assert transform.canonical_shape == (T_S, 1, XY_S, XY_S)
 
-    def test_invalid_axis_name(self):
-        with pytest.raises(ValueError):
-            AxesTransform("ABX", (1, 2, 3))
-
-    def test_duplicate_axes(self):
-        with pytest.raises(ValueError):
-            AxesTransform("YYX", (32, 32, 32))
-
-    def test_missing_y_or_x(self):
-        with pytest.raises(ValueError):
-            AxesTransform("SC", (5, 3))
-
     def test_shape_axes_length_mismatch(self):
         with pytest.raises(ValueError):
             AxesTransform("YX", (32, 32, 32))

--- a/tests/unit/utils/test_reshape_array.py
+++ b/tests/unit/utils/test_reshape_array.py
@@ -24,7 +24,7 @@ def _array_to_tile(input_shape, axes, target_shape, target_axes, output_shape):
 def _transformed_shape(input_shape, axes, target_axes, output_shape):
     """Get the transformed shape from the restore_array test inputs."""
     transform = AxesTransform(axes, input_shape)
-    return input_shape, axes, transform.transformed_shape, target_axes, output_shape
+    return input_shape, axes, transform.canonical_shape, target_axes, output_shape
 
 
 # default axes shapes
@@ -440,16 +440,16 @@ class TestAxesTransform:
         assert AxesTransform("YX", (XY_S, XY_S)).original_has_z is False
 
     def test_dl_axes_2d(self):
-        assert AxesTransform("YX", (XY_S, XY_S)).transformed_axes == "SCYX"
+        assert AxesTransform("YX", (XY_S, XY_S)).canonical_axes == "SCYX"
 
     def test_dl_axes_3d(self):
-        assert AxesTransform("ZYX", (Z_S, XY_S, XY_S)).transformed_axes == "SCZYX"
+        assert AxesTransform("ZYX", (Z_S, XY_S, XY_S)).canonical_axes == "SCZYX"
 
     def test_dl_shape_yx(self):
-        assert AxesTransform("YX", (XY_S, XY_S)).transformed_shape == (1, 1, XY_S, XY_S)
+        assert AxesTransform("YX", (XY_S, XY_S)).canonical_shape == (1, 1, XY_S, XY_S)
 
     def test_dl_shape_with_c(self):
-        assert AxesTransform("YXC", (XY_S, XY_S, C_S)).transformed_shape == (
+        assert AxesTransform("YXC", (XY_S, XY_S, C_S)).canonical_shape == (
             1,
             C_S,
             XY_S,
@@ -458,11 +458,11 @@ class TestAxesTransform:
 
     def test_dl_shape_with_st(self):
         transform = AxesTransform("STCYX", (S_S, T_S, C_S, XY_S, XY_S))
-        assert transform.transformed_shape == (S_S * T_S, C_S, XY_S, XY_S)
+        assert transform.canonical_shape == (S_S * T_S, C_S, XY_S, XY_S)
 
     def test_dl_shape_t_as_s(self):
         transform = AxesTransform("TYX", (T_S, XY_S, XY_S))
-        assert transform.transformed_shape == (T_S, 1, XY_S, XY_S)
+        assert transform.canonical_shape == (T_S, 1, XY_S, XY_S)
 
     def test_invalid_axis_name(self):
         with pytest.raises(ValueError):
@@ -485,7 +485,7 @@ class TestAxesTransform:
         """Result should always have S, C, and optionally Z, then Y, X."""
         transform = AxesTransform(axes, shape)
         expected_axes = "SCZYX" if "Z" in axes else "SCYX"
-        assert transform.transformed_axes == expected_axes
+        assert transform.canonical_axes == expected_axes
 
 
 class TestReshape:
@@ -496,7 +496,7 @@ class TestReshape:
         result = reshape_array(array, axes)
         transform = AxesTransform(axes, shape)
 
-        assert result.shape == transform.transformed_shape
+        assert result.shape == transform.canonical_shape
         assert result.ndim in (4, 5)
 
     @pytest.mark.parametrize(
@@ -815,7 +815,7 @@ class TestRestoredAxesTransform:
             axes,
             in_shape,
             target_axes,
-            AxesTransform(axes, in_shape).transformed_shape,
+            AxesTransform(axes, in_shape).canonical_shape,
             False,
         )
         assert transform.adjust_shape(shape) == expected_shape

--- a/uv.lock
+++ b/uv.lock
@@ -440,7 +440,7 @@ requires-dist = [
     { name = "scikit-image", specifier = "<=0.26.0" },
     { name = "tensorboard", marker = "extra == 'tensorboard'" },
     { name = "tifffile", specifier = "<=2026.3.3" },
-    { name = "torch", specifier = ">=2.1.0,<2.10.0" },
+    { name = "torch", specifier = ">=2.1.0,<2.13.0" },
     { name = "torchmetrics", specifier = ">0.7.0,<1.9.0" },
     { name = "torchvision", specifier = "<=0.25.0" },
     { name = "wandb", marker = "extra == 'wandb'" },
@@ -1484,12 +1484,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/e8/042eeac7c78565f1b4c14ba3dc6a96aad9b958e008a1e291a1cbf72123e9/imagecodecs-2026.6.26-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c48767bbc6ed0b40df3607cafdf59dac6f4467b91c26e835744d7ee4085cfdf7", size = 13164944, upload-time = "2026-06-28T18:26:29.33Z" },
     { url = "https://files.pythonhosted.org/packages/1d/dd/0e0c86df9a55a0a90ced8cf5214abb459015cda5f2e713e0495ccd9bf23f/imagecodecs-2026.6.26-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:9c130cf207efcb35acf74d6040317d217294640e478aa733fb51be758bcaddbc", size = 32436234, upload-time = "2026-06-28T18:26:33.35Z" },
     { url = "https://files.pythonhosted.org/packages/b9/9a/2d63eb2ffa46863bf0ea05884ce1ea2a73a5153b428937b8cbe4faa81536/imagecodecs-2026.6.26-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:014f5f809418eb3dfe29badd4af29ddeeaba8b5eabda4bd502e2292727e4094f", size = 33446845, upload-time = "2026-06-28T18:26:38.238Z" },
-    { url = "https://files.pythonhosted.org/packages/14/68/ece973cd5b1d8305b95ad827b3c6033aed166c5ce93780b6092dbfd5deec/imagecodecs-2026.6.26-cp314-cp314t-win32.whl", hash = "sha256:daa276e5645750404a28a911dcbfb94c7d32b2d8903b5f05167474ea02bd5b40", size = 17330378, upload-time = "2026-06-28T18:26:42.172Z" },
     { url = "https://files.pythonhosted.org/packages/ad/e6/ab2e9ee84e44768ceb73bb9301988ea4ab9022f02ef9d824d6ebb641a0fb/imagecodecs-2026.6.26-cp314-cp314t-win_amd64.whl", hash = "sha256:0718d75672768871aa6adac2129c8f74c167fb4a3da25f660f3afc94b420304f", size = 22122461, upload-time = "2026-06-28T18:26:45.622Z" },
-    { url = "https://files.pythonhosted.org/packages/58/53/7943321eb84c6d39e71ca47e689557a976c6ebafec48b759b3be0bd7c601/imagecodecs-2026.6.26-cp314-cp314t-win_arm64.whl", hash = "sha256:69b90b7b729d33cd9417d3d572d3092d2d49f7974638ee00e2cdc3ed1fba11d6", size = 17657147, upload-time = "2026-06-28T18:26:48.924Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/de/130820754c21c00dfdc6852661de2bb30161b5a439a8643a446dae97a02f/imagecodecs-2026.6.26-cp315-cp315t-win32.whl", hash = "sha256:a10c347225f5fb1b9d1a36cfadccad9b173609c30e0dd3f68706675d6f4f9b58", size = 17330338, upload-time = "2026-06-28T18:26:52.04Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/df/b4f6f2a9e9102ca674673cb1b432bbebfe2d99acb6364390768024d56ae6/imagecodecs-2026.6.26-cp315-cp315t-win_amd64.whl", hash = "sha256:85ab027a8bc900f13b1cdaac05bb602ea58749731ae18743a7956642a7da7a2c", size = 22116857, upload-time = "2026-06-28T18:26:55.65Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/c4/d87b33e8df5c6ec19f5cd1d5ab39195b2077ac21536ff5146c20d3fb8694/imagecodecs-2026.6.26-cp315-cp315t-win_arm64.whl", hash = "sha256:41e18fcd2124c083b00f988eeb9c5cf89274e5c2f473ee03d54761b71048085c", size = 17651071, upload-time = "2026-06-28T18:26:59.305Z" },
 ]
 
 [[package]]
@@ -2701,7 +2696,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2712,7 +2707,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2739,9 +2734,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2752,7 +2747,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },


### PR DESCRIPTION
This PR attempts at clarifying the attributes from `ImageRegionData` and `AxesTransform`. Often it is unclear whether a `data_shape` is from the original space, or the transformed SC(Z)YX space.

Here, we introduce `canonical` to refer to the transformed SC(Z)YX space and `original` for the source image space, and updated the attribute descriptions.

## Changes

### Modified
- `ImageRegionData`:
    - `data_shape` becomes `canonical_shape`
    - `axes` become `original_axes`
    - `original_data_shape` becomes `original_shape`
-  `AxesTransform`
    - `transformed_shape` becomes `canonical_shape`
    - `transformed_axes` becomes `canonical_axes`
- Image stacks
    - `data_shape` becomes `canonical_shape`
    - `original_data_shape` becomes `original_shape`
- Similar changes to ImageMetadata in `metadata_utils.py`
- Changes propagated thoughout the code 

# TODO

- [ ] Check tutorial docs for text mentioning the wrong parameter