### PR TITLE
Chore(Test): remove unused pytest mark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,6 @@ addopts = "-p no:doctest"
 markers = [
     "lvae: marks tests as testing lvae",
     "e2e: marks longer running end-to-end tests",
-    "mps_gh_fail: marks tests as failing on Github macos-latest runner",
     "czi: marks tests using czi files",
 ]
 

--- a/tests/GUIDELINES.md
+++ b/tests/GUIDELINES.md
@@ -35,4 +35,3 @@ test data, etc.)
 
 - `lvae`: lvae-specific tests
 - `slow`: tests that are slow to run, e.g. training for several epochs
-- `mps_gh_fail`: tests that are expected to fail on MPS on Github (e.g. due to unsupported features)

--- a/tests/model_io/test_bmz_io.py
+++ b/tests/model_io/test_bmz_io.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 import torch
 from bioimageio.spec import InvalidDescr, load_description
 from torch import Tensor
@@ -8,8 +7,6 @@ from careamics import CAREamist
 from careamics.model_io import export_to_bmz, load_pretrained
 from careamics.model_io.bmz_io import _export_state_dict, _load_state_dict
 from careamics.utils.version import get_careamics_version
-
-pytestmark = pytest.mark.mps_gh_fail
 
 
 def test_state_dict_io(tmp_path, ordered_array, pre_trained):

--- a/tests/test_careamist_predict.py
+++ b/tests/test_careamist_predict.py
@@ -15,7 +15,6 @@ def random_array(shape: tuple[int, ...], seed: int = 42) -> NDArray:
     return (rng.integers(0, 255, shape)).astype(np.float32)
 
 
-@pytest.mark.mps_gh_fail
 @pytest.mark.parametrize("samples", [1, 2, 4])
 @pytest.mark.parametrize("batch_size", [1, 2])
 def test_predict_arrays_no_tiling(tmp_path: Path, batch_size: int, samples: int):
@@ -42,7 +41,6 @@ def test_predict_arrays_no_tiling(tmp_path: Path, batch_size: int, samples: int)
     assert predicted[0].shape == (samples, 32, 32)
 
 
-@pytest.mark.mps_gh_fail
 @pytest.mark.parametrize("samples", [1, 2, 4])
 @pytest.mark.parametrize("batch_size", [1, 2])
 def test_predict_on_array_tiled(tmp_path: Path, batch_size: int, samples: int):
@@ -71,7 +69,6 @@ def test_predict_on_array_tiled(tmp_path: Path, batch_size: int, samples: int):
     assert predicted[0].shape == (samples, 32, 32)
 
 
-@pytest.mark.mps_gh_fail
 @pytest.mark.parametrize("tiled", [True, False])
 def test_predict_path(tmp_path: Path, tiled: bool):
     """Test that CAREamist can predict with tiff files."""
@@ -115,7 +112,6 @@ def test_predict_path(tmp_path: Path, tiled: bool):
         assert p.squeeze().shape == train_array.shape
 
 
-@pytest.mark.mps_gh_fail
 @pytest.mark.parametrize("independent_channels", [False, True])
 @pytest.mark.parametrize("batch_size", [1, 2])
 def test_predict_tiled_channel(
@@ -152,7 +148,6 @@ def test_predict_tiled_channel(
 
 
 @pytest.mark.skip(reason="TODO revisit after fixing stats in convert mode")
-@pytest.mark.mps_gh_fail
 def test_predict_channel_subset(tmp_path: Path):
     """Test that CAREamist can predict on a subset of channels."""
     train_array = random_array((3, 32, 32), seed=42)
@@ -181,7 +176,6 @@ def test_predict_channel_subset(tmp_path: Path):
     assert predicted[0].squeeze().shape == (2, 32, 32)
 
 
-@pytest.mark.mps_gh_fail
 def test_predict_to_disk_path_tiff(tmp_path: Path):
     """Test predict_to_disk with path source and tiff write type."""
     train_array = random_array((32, 32), seed=42)
@@ -216,7 +210,6 @@ def test_predict_to_disk_path_tiff(tmp_path: Path):
         assert (tmp_path / "predictions" / f"image_{i}.tiff").is_file()
 
 
-@pytest.mark.mps_gh_fail
 def test_predict_to_disk_custom(tmp_path: Path):
     """Test predict_to_disk with custom write type."""
 

--- a/tests/test_careamist_train.py
+++ b/tests/test_careamist_train.py
@@ -61,7 +61,6 @@ def test_train_error_no_target_data(tmp_path: Path):
         )
 
 
-@pytest.mark.mps_gh_fail
 def test_v2_train_array(tmp_path: Path):
     """Test that CAREamist can be trained on arrays."""
     train_array = random_array((32, 32), seed=42)
@@ -108,7 +107,6 @@ def test_v2_train_array_auto_val_split_small_data(tmp_path: Path):
         careamist.train(train_data=train_array)
 
 
-@pytest.mark.mps_gh_fail
 @pytest.mark.parametrize("independent_channels", [False, True])
 def test_v2_train_array_channel(tmp_path: Path, independent_channels: bool):
     """Test that CAREamist can be trained on arrays with channels."""
@@ -136,7 +134,6 @@ def test_v2_train_array_channel(tmp_path: Path, independent_channels: bool):
     assert len(careamist.get_checkpoints()) > 0
 
 
-@pytest.mark.mps_gh_fail
 def test_v2_train_array_3d(tmp_path: Path):
     """Test that CAREamist can be trained on 3D arrays."""
     train_array = random_array((8, 32, 32), seed=42)
@@ -159,7 +156,6 @@ def test_v2_train_array_3d(tmp_path: Path):
     assert len(careamist.get_checkpoints()) > 0
 
 
-@pytest.mark.mps_gh_fail
 def test_v2_train_tiff_in_memory(tmp_path: Path):
     """Test that CAREamist can be trained with tiff files in memory."""
     train_array = random_array((32, 32), seed=42)
@@ -188,7 +184,6 @@ def test_v2_train_tiff_in_memory(tmp_path: Path):
     assert len(careamist.get_checkpoints()) > 0
 
 
-@pytest.mark.mps_gh_fail
 def test_v2_train_tiff_not_in_memory(tmp_path: Path):
     """Test N2V training from tiff files with in_memory=False (on-disk reading)."""
     train_array = random_array((32, 32), seed=42)


### PR DESCRIPTION
## Description

`mps_gh_fail` used to be used in our CI to avoid failed tests on macOS runner. It is no longer used in our CI. This PR simply removes it.