### PR TITLE
Fix: enforce non-interactive matplotlib backend for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
   test:
     name: ${{ matrix.platform }} (${{ matrix.python-version }})
     runs-on: ${{ matrix.platform }}
+    env:
+      MPLBACKEND: Agg # non-interactive matplotlib back-end
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_guides.yml
+++ b/.github/workflows/ci_guides.yml
@@ -8,8 +8,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  test-guides:
     runs-on: ubuntu-latest
+    env:
+      MPLBACKEND: Agg # non-interactive matplotlib back-end
     steps:
       - name: ✅ Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,6 +12,8 @@ jobs:
   codecov:
     name: codecov update
     runs-on: ubuntu-latest
+    env:
+      MPLBACKEND: Agg # non-interactive matplotlib back-end
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

Attempt at fixing https://github.com/CAREamics/careamics/issues/1093, which is currently forcing us to restart manually many CI runs.